### PR TITLE
React spin

### DIFF
--- a/scipio/src/parking.rs
+++ b/scipio/src/parking.rs
@@ -415,7 +415,12 @@ impl ReactorLock<'_> {
         let next_timer = self.reactor.process_timers(&mut wakers);
 
         // Block on I/O events.
-        let res = match self.reactor.sys.wait(&mut wakers, timeout, next_timer) {
+        let ores = match timeout {
+            Some(preempt) => self.reactor.sys.step(&mut wakers, preempt),
+            None => self.reactor.sys.wait(&mut wakers, next_timer),
+        };
+
+        let res = match ores {
             // We slept, so don't wait for the next loop to process timers
             Ok(true) => {
                 self.reactor.process_timers(&mut wakers);


### PR DESCRIPTION
Closes #76 by replacing `park()` with `park(spin: Duration)`.

This patch separates `ReactorLock::react` code paths into 2 flows: stepping through the `uring` queue and sleeping:

- it adds support for spinning directly to the `Reactor::wait`.
- it separates `Reactor::wait` into `wait` and `step`
- it stores wakers vec in Parker::Inner.

Spinning occurs right before sleeping (parking) with canceled or rearmed timer for the next timer occurrence. 