### PR TITLE
shared channels: spsc connection between executors

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -20,3 +20,4 @@ lazy-static,https://crates.io/crates/lazy_static,MIT/Apache-2.0,Marvin Löbel
 scopeguard,https://crates.io/crates/scopeguard,MIT/Apache-2.0,bluss
 pin-project-lite:https://crates.io/crates/pin-project-lite,MIT/Apache-2.0,Taiki Endo
 log,https://crates.io/crates/log,MIT/Apache-2.0/The Rust Project Developers
+bounded-spsc-queue:https://github.com/polyfractal/bounded-spsc-queue.git,Apache-2.0,Zachary Tong

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -46,3 +46,7 @@ harness = false
 [[bench]]
 name = "local_channel"
 harness = false
+
+[[bench]]
+name = "shared_channel"
+harness = false

--- a/glommio/benches/shared_channel.rs
+++ b/glommio/benches/shared_channel.rs
@@ -1,0 +1,93 @@
+use glommio::channels::shared_channel;
+use glommio::prelude::*;
+use std::sync::mpsc::sync_channel;
+use std::time::{Duration, Instant};
+
+fn test_spsc(capacity: usize) {
+    let runs: u32 = 10_000_000;
+    let (sender, receiver) = shared_channel::new_bounded(capacity);
+
+    let sender = LocalExecutorBuilder::new()
+        .pin_to_cpu(0)
+        .spin_before_park(Duration::from_millis(10))
+        .spawn(move || async move {
+            let sender = sender.connect();
+            let t = Instant::now();
+            for _ in 0..runs {
+                sender.send(1).await.unwrap();
+            }
+            println!(
+                "cost of sending shared channel {:#?}, capacity: {}",
+                t.elapsed() / runs,
+                capacity
+            );
+            drop(sender);
+        })
+        .unwrap();
+
+    let receiver = LocalExecutorBuilder::new()
+        .spin_before_park(Duration::from_millis(10))
+        .pin_to_cpu(1)
+        .spawn(move || async move {
+            let receiver = receiver.connect();
+            let t = Instant::now();
+            for _ in 0..runs {
+                receiver.recv().await.unwrap();
+            }
+            println!(
+                "cost of receiving shared channel: {:#?}, capacity {}",
+                t.elapsed() / runs,
+                capacity
+            );
+        })
+        .unwrap();
+
+    sender.join().unwrap();
+    receiver.join().unwrap();
+}
+
+fn test_rust_std(capacity: usize) {
+    let runs: u32 = 10_000_000;
+    let (sender, receiver) = sync_channel::<u8>(capacity);
+
+    let sender = LocalExecutorBuilder::new()
+        .pin_to_cpu(0)
+        .spin_before_park(Duration::from_millis(10))
+        .spawn(move || async move {
+            let t = Instant::now();
+            for _ in 0..runs {
+                sender.send(1).unwrap();
+            }
+            println!(
+                "cost of sending rust standard channel {:#?}, capacity: {}",
+                t.elapsed() / runs,
+                capacity
+            );
+            drop(sender);
+        })
+        .unwrap();
+
+    let receiver = LocalExecutorBuilder::new()
+        .spin_before_park(Duration::from_millis(10))
+        .pin_to_cpu(1)
+        .spawn(move || async move {
+            let t = Instant::now();
+            for _ in 0..runs {
+                receiver.recv().unwrap();
+            }
+            println!(
+                "cost of receiving rust standard channel: {:#?}, capacity {}",
+                t.elapsed() / runs,
+                capacity
+            );
+        })
+        .unwrap();
+
+    sender.join().unwrap();
+    receiver.join().unwrap();
+}
+
+fn main() {
+    test_rust_std(1024);
+    test_spsc(1024);
+}

--- a/glommio/src/channels/mod.rs
+++ b/glommio/src/channels/mod.rs
@@ -5,6 +5,7 @@
 //
 //! glommio::channels is a module that provides glommio channel-like abstractions.
 //!
+mod spsc_queue;
 
 /// Allow data to be transmitted across two tasks in the same shard.
 ///
@@ -58,6 +59,92 @@
 /// [`StreamExt`]: https://docs.rs/futures-lite/1.11.1/futures_lite/stream/trait.StreamExt.html
 pub mod local_channel;
 
+/// Allow data to be transmitted across two tasks in the different executors.
+///
+/// Most useful thread-per-core applications will heavily process data locally
+/// to their executor, but at times inter-executor communication is unavoidable
+/// (if you never communicate inter-executors, you may consider just using independent
+/// processes!)
+///
+/// Whenever you need to send data across two executors you can use the `shared_channel`.
+/// This channel is a fully lockless single-producer-single-consumer channel, unlike the standard
+/// library [`channel`], which is multi-producer and need locks for synchronization. That means
+/// that to wire N executors to each other you will have to create O(N^2) channels.
+///
+/// The channels are also not bidirectional, so for full bidirectional communication you
+/// will need pairs of channels.
+///
+/// True to the spirit of our library the `shared_channel` is not created or wired
+/// automatically among executors. You can have executors that work as sinks and never
+/// respond back, other executors that are not really connected to anybody, cliques of
+/// executors, you name it.
+///
+/// Data that goes into the channels need to be [`Send`], as well as the channels themselves
+/// (otherwise you would not be able to really pass them along to the actual executors). But to
+/// prevent accidental use from multiple producers, the channel endpoints have to be `connected` before
+/// using: Connecting consumes the endpoint, transforming a [`SharedSender`] into a [`ConnectedSender`] and
+/// a [`SharedReceiver`] into a [`ConnectedReceiver`] so although you can pass one of the ends of the channel
+/// to multiple executors, you can only connect in one of them. The connected channel itself is not
+/// [`Send`] nor [`Sync`] so once connected they are stuck in an executor.
+///
+/// The communication between sender and receiver is broken when one of them goes
+/// out of scope. They however behave differently:
+///
+/// * The [`ConnectedReceiver`] never sees an error, as it is implemented as a stream
+///   interface compatible with [`StreamExt`]. When the sender is no longer available the receiver's call to [`next`] will return [`None`].
+/// * The [`ConnectedSender`] will return a [`ChannelError`] encapsulating a [`BrokenPipe`] error if it tries to [`send`] into
+///   a channel that no longer has a receiver.
+///
+/// # Examples
+///
+/// ```
+/// use glommio::{LocalExecutorBuilder, Local};
+/// use glommio::channels::shared_channel;
+///
+/// // creates both ends of the channel. This is done outside the executors
+/// // and we will not pass the sender to ex1 and the receiver to ex2
+/// let (sender, receiver) = shared_channel::new_bounded(1);
+///
+/// let ex1 = LocalExecutorBuilder::new()
+///     .spawn(move || async move {
+///         // Before using we have to connect. Connecting this endpoint
+///         // binds it this executor as the connected endpoint is not Send.
+///         let sender = sender.connect();
+///         // Channel has room for 1 element so this will always succeed
+///         sender.try_send(100).unwrap();
+///     })
+///     .unwrap();
+///
+/// let ex2 = LocalExecutorBuilder::new()
+///     .spawn(move || async move {
+///         // much like the sender, the receiver also needs to be connected
+///         let receiver = receiver.connect();
+///         let x = receiver.recv().await.unwrap();
+///         assert_eq!(x, 100);
+///     })
+///     .unwrap();
+///
+/// ex1.join().unwrap();
+/// ex2.join().unwrap();
+/// ```
+/// [`ChannelError`]: struct.ChannelError.html
+/// [`ConnectedSender`]: struct.ConnectedSender.html
+/// [`ConnectedReceiver`]: struct.ConnectedReceiver.html
+/// [`SharedSender`]: struct.SharedSender.html
+/// [`SharedReceiver`]: struct.SharedReceiver.html
+/// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
+/// [`Sync`]: https://doc.rust-lang.org/std/marker/trait.Sync.html
+/// [`send`]: struct.ConnectedSender.html#method.send
+/// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+/// [`BrokenPipe`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.BrokenPipe
+/// [`channel`]: https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html
+/// [`next`]: https://docs.rs/futures-lite/1.11.1/futures_lite/stream/trait.StreamExt.html#method.next
+/// [`StreamExt`]: https://docs.rs/futures-lite/1.11.1/futures_lite/stream/trait.StreamExt.html
+pub mod shared_channel;
+
+use std::fmt;
+use std::io;
+
 #[derive(Debug)]
 /// Establishes the capacity of this channel.
 ///
@@ -65,4 +152,39 @@ pub mod local_channel;
 enum ChannelCapacity {
     Unbounded,
     Bounded(usize),
+}
+
+#[derive(Debug)]
+/// This is the error that is returned from channel operations if something goes wrong.
+///
+/// It encapsulates an [`ErrorKind`], which will be different for each kind of error and
+/// also makes the item sent through the channel available through the public attribute `item`.
+///
+/// You can convert between this and [`io::Error`] (losing information on `item`) so the
+/// ? constructs around [`io::Error`] should all work. Another possible way of doing this
+/// is returning an [`io::Error`] and encapsulating `item` on its inner field. However that
+/// adds [`Send`] and [`Sync`] requirements plus an allocation to the inner field (or to a
+/// helper struct around the inner field) that we'd like to avoid.
+///
+/// [`ErrorKind`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html
+/// [`io::Error`]: https://doc.rust-lang.org/std/io/struct.Error.html
+/// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
+/// [`Sync`]: https://doc.rust-lang.org/std/marker/trait.Sync.html
+pub struct ChannelError<T> {
+    kind: io::ErrorKind,
+    /// The `ChannelError` encapsulates the item we originally tried to send into the channel
+    /// in case you need to do something with it upon failure.
+    pub item: T,
+}
+
+impl<T> ChannelError<T> {
+    fn new(kind: io::ErrorKind, item: T) -> ChannelError<T> {
+        ChannelError { kind, item }
+    }
+}
+
+impl<T: fmt::Debug> From<ChannelError<T>> for io::Error {
+    fn from(error: ChannelError<T>) -> Self {
+        io::Error::new(error.kind, format!("item: {:?}", error.item))
+    }
 }

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -1,0 +1,554 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the
+// MIT/Apache-2.0 License, at your convenience
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//
+//
+use crate::channels::spsc_queue::{make, Consumer, Producer};
+use crate::channels::ChannelError;
+use crate::{enclose, Reactor};
+use futures_lite::stream::Stream;
+use futures_lite::FutureExt;
+use futures_lite::{future, ready};
+use std::io;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll};
+
+#[derive(Debug)]
+/// The `SharedReceiver` is the receiving end of the Shared Channel.
+/// It implements [`Send`] so it can be passed to any thread. However
+/// it doesn't implement any method: before it is used it must be changed
+/// into a [`ConnectedReceiver`], which then makes sure it will be used by
+/// at most one thread.
+///
+/// It is technically possible to share this among multiple threads inside
+/// a lock, although such design is discouraged and beats the purpose of a
+/// spsc channel.
+///
+/// [`ConnectedReceiver`]: struct.ConnectedReceiver.html
+/// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
+pub struct SharedReceiver<T: Send + Sized + Copy> {
+    state: Option<Rc<ReceiverState<T>>>,
+}
+
+#[derive(Debug)]
+/// The `SharedSender` is the sending end of the Shared Channel.
+/// It implements [`Send`] so it can be passed to any thread. However
+/// it doesn't implement any method: before it is used it must be changed
+/// into a [`ConnectedSender`], which then makes sure it will be used by
+/// at most one thread.
+///
+/// It is technically possible to share this among multiple threads inside
+/// a lock, although such design is discouraged and beats the purpose of a
+/// spsc channel.
+///
+/// [`ConnectedSender`]: struct.ConnectedSender.html
+/// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
+pub struct SharedSender<T: Send + Sized + Copy> {
+    state: Option<Rc<SenderState<T>>>,
+}
+
+unsafe impl<T: Send + Sized + Copy> Send for SharedReceiver<T> {}
+unsafe impl<T: Send + Sized + Copy> Send for SharedSender<T> {}
+
+#[derive(Debug)]
+/// The `ConnectedReceiver` is the receiving end of the Shared Channel.
+pub struct ConnectedReceiver<T: Send + Sized + Copy> {
+    id: u64,
+    state: Rc<ReceiverState<T>>,
+}
+
+#[derive(Debug)]
+/// The `ConnectedReceiver` is the sending end of the Shared Channel.
+pub struct ConnectedSender<T: Send + Sized + Copy> {
+    id: u64,
+    state: Rc<SenderState<T>>,
+}
+
+#[derive(Debug)]
+struct SenderState<T: Send + Sized + Copy> {
+    buffer: Producer<T>,
+}
+
+#[derive(Debug)]
+struct ReceiverState<T: Send + Sized + Copy> {
+    buffer: Consumer<T>,
+}
+
+/// Creates a a new `shared_channel` returning its sender and receiver endpoints.
+///
+/// All shared channels must be bounded.
+pub fn new_bounded<T: Send + Sized + Copy>(size: usize) -> (SharedSender<T>, SharedReceiver<T>) {
+    let (producer, consumer) = make(size);
+    (
+        SharedSender {
+            state: Some(Rc::new(SenderState { buffer: producer })),
+        },
+        SharedReceiver {
+            state: Some(Rc::new(ReceiverState { buffer: consumer })),
+        },
+    )
+}
+
+impl<T: 'static + Send + Sized + Copy> SharedSender<T> {
+    /// Connects this sender, returning a [`ConnectedSender`] that can be used
+    /// to send data into this channel
+    ///
+    /// [`ConnectedSender`]: struct.ConnectedSender.html
+    pub fn connect(mut self) -> ConnectedSender<T> {
+        let state = self.state.take().unwrap();
+        state.buffer.connect(Reactor::get().eventfd());
+        let id = Reactor::get().register_shared_channel(Box::new(enclose! {(state) move || {
+            if state.buffer.consumer_disconnected() {
+                state.buffer.capacity()
+            } else {
+                state.buffer.free_space()
+            }
+        }}));
+
+        ConnectedSender { state, id }
+    }
+}
+
+impl<T: Send + Sized + Copy> ConnectedSender<T> {
+    /// Sends data into this channel.
+    ///
+    /// It returns a [`ChannelError`] encapsulating a [`BrokenPipe`] if the receiver is destroyed.
+    /// It returns a [`ChannelError`] encapsulating a [`WouldBlock`] if this is a bounded channel that has no more capacity
+    ///
+    /// # Examples
+    /// ```
+    /// use glommio::prelude::*;
+    /// use glommio::channels::shared_channel;
+    /// use futures_lite::StreamExt;
+    ///
+    /// let ex = LocalExecutor::make_default();
+    /// ex.run(async move {
+    ///     let (sender, receiver) = shared_channel::new_bounded(1);
+    ///     let sender = sender.connect();
+    ///     let mut receiver = receiver.connect();
+    ///     sender.try_send(0);
+    ///     sender.try_send(0).unwrap_err(); // no more capacity
+    ///     receiver.next().await.unwrap(); // now we have capacity again
+    ///     drop(receiver); // but because the receiver is destroyed send will err
+    ///     sender.try_send(0).unwrap_err();
+    /// });
+    /// ```
+    ///
+    /// [`BrokenPipe`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.BrokenPipe
+    /// [`WouldBlock`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.WouldBlock
+    /// [`Other`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.Other
+    /// [`ChannelError`]: struct.ChannelError.html
+    pub fn try_send(&self, item: T) -> Result<(), ChannelError<T>> {
+        // This is a shared channel so state can change under our noses.
+        // We test if the buffer is disconnected before sending to avoid
+        // sending a value that will not be received (otherwise we would only
+        // receive WouldBlock when the buffer capacity fills).
+        //
+        // However after we try_push(), we can still fail because the buffer
+        // disconnected between now and then. That's okay as all we're trying to
+        // do here is prevent unnecessary sends.
+        if self.state.buffer.consumer_disconnected() {
+            return Err(ChannelError::new(io::ErrorKind::BrokenPipe, item));
+        }
+        match self.state.buffer.try_push(item) {
+            None => {
+                if let Some(fd) = self.state.buffer.must_notify() {
+                    Reactor::get().notify(fd);
+                }
+                Ok(())
+            }
+            Some(item) => {
+                if self.state.buffer.consumer_disconnected() {
+                    Err(ChannelError::new(io::ErrorKind::BrokenPipe, item))
+                } else {
+                    Err(ChannelError::new(io::ErrorKind::WouldBlock, item))
+                }
+            }
+        }
+    }
+
+    /// Sends data into this channel when it is ready to receive it
+    ///
+    /// # Examples
+    /// ```
+    /// use glommio::prelude::*;
+    /// use glommio::channels::shared_channel;
+    ///
+    /// let ex = LocalExecutor::make_default();
+    /// ex.run(async move {
+    ///     let (sender, receiver) = shared_channel::new_bounded(1);
+    ///     let sender = sender.connect();
+    ///     let receiver = receiver.connect();
+    ///     sender.send(0).await.unwrap();
+    /// });
+    /// ```
+    pub async fn send(&self, item: T) -> Result<(), ChannelError<T>> {
+        let waiter = future::poll_fn(|cx| self.wait_for_room(cx));
+        waiter.await;
+        let res = self.try_send(item);
+        if let Err(x) = &res {
+            assert_ne!(x.kind, io::ErrorKind::WouldBlock);
+        }
+        res
+    }
+
+    fn wait_for_room(&self, cx: &mut Context<'_>) -> Poll<()> {
+        match self.state.buffer.free_space() > 0 {
+            true => Poll::Ready(()),
+            false => {
+                Reactor::get().add_shared_channel_waker(self.id, cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+}
+
+impl<T: 'static + Send + Sized + Copy> SharedReceiver<T> {
+    /// Connects this receiver, returning a [`ConnectedReceiver`] that can be used
+    /// to send data into this channel
+    ///
+    /// [`ConnectedReceiver`]: struct.ConnectedReceiver.html
+    pub fn connect(mut self) -> ConnectedReceiver<T> {
+        let state = self.state.take().unwrap();
+        state.buffer.connect(Reactor::get().eventfd());
+        let id = Reactor::get().register_shared_channel(Box::new(enclose! { (state) move || {
+            if state.buffer.producer_disconnected() {
+                state.buffer.capacity()
+            } else {
+                state.buffer.size()
+            }
+        }}));
+        ConnectedReceiver { state, id }
+    }
+}
+
+impl<T: Send + Sized + Copy> ConnectedReceiver<T> {
+    /// Receives data from this channel
+    ///
+    /// If the sender is no longer available it returns [`None`]. Otherwise block until
+    /// an item is available and returns it wrapped in [`Some`]
+    ///
+    /// Notice that this is also available as a Stream. Whether to consume from a stream
+    /// or `recv` is up to the application. The biggest difference is that [`StreamExt`]'s
+    /// [`next`] method takes a mutable reference to self. If the LocalReceiver is, say,
+    /// behind an [`Rc`] it may be more ergonomic to recv.
+    ///
+    /// # Examples
+    /// ```
+    /// use glommio::prelude::*;
+    /// use glommio::channels::shared_channel;
+    ///
+    /// let ex = LocalExecutor::make_default();
+    /// ex.run(async move {
+    ///     let (sender, receiver) = shared_channel::new_bounded(1);
+    ///     let sender = sender.connect();
+    ///     let receiver = receiver.connect();
+    ///     sender.send(0).await.unwrap();
+    ///     let x = receiver.recv().await.unwrap();
+    ///     assert_eq!(x, 0);
+    /// });
+    /// ```
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
+    /// [`StreamExt`]: https://docs.rs/futures-lite/1.11.2/futures_lite/stream/index.html
+    /// [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
+    pub async fn recv(&self) -> Option<T> {
+        let waiter = future::poll_fn(|cx| self.recv_one(cx));
+        waiter.await
+    }
+
+    fn recv_one(&self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        let res = ready!(match self.state.buffer.try_pop() {
+            Some(item) => {
+                Poll::Ready(Some(item))
+            }
+            None => {
+                if self.state.buffer.producer_disconnected() {
+                    Poll::Ready(None)
+                } else {
+                    Reactor::get().add_shared_channel_waker(self.id, cx.waker().clone());
+                    Poll::Pending
+                }
+            }
+        });
+        if let Some(fd) = self.state.buffer.must_notify() {
+            Reactor::get().notify(fd);
+        }
+        Poll::Ready(res)
+    }
+}
+
+impl<T: Send + Sized + Copy> Stream for ConnectedReceiver<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut waiter = future::poll_fn(|cx| self.recv_one(cx));
+        waiter.poll(cx)
+    }
+}
+
+impl<T: Send + Sized + Copy> Drop for SharedSender<T> {
+    fn drop(&mut self) {
+        if let Some(state) = self.state.take() {
+            // Never connected, we must connect ourselves.
+            state.buffer.disconnect();
+            if let Some(fd) = state.buffer.must_notify() {
+                Reactor::get().notify(fd);
+            }
+        }
+    }
+}
+
+impl<T: Send + Sized + Copy> Drop for SharedReceiver<T> {
+    fn drop(&mut self) {
+        if let Some(state) = self.state.take() {
+            // Never connected, we must connect ourselves.
+            state.buffer.disconnect();
+            if let Some(fd) = state.buffer.must_notify() {
+                Reactor::get().notify(fd);
+            }
+        }
+    }
+}
+
+impl<T: Send + Sized + Copy> Drop for ConnectedReceiver<T> {
+    fn drop(&mut self) {
+        self.state.buffer.disconnect();
+        if let Some(fd) = self.state.buffer.must_notify() {
+            Reactor::get().notify(fd);
+        }
+    }
+}
+
+impl<T: Send + Sized + Copy> Drop for ConnectedSender<T> {
+    fn drop(&mut self) {
+        self.state.buffer.disconnect();
+        if let Some(fd) = self.state.buffer.must_notify() {
+            Reactor::get().notify(fd);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::timer::Timer;
+    use crate::LocalExecutorBuilder;
+    use futures_lite::StreamExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[test]
+    fn producer_consumer() {
+        let (sender, receiver) = new_bounded(10);
+
+        let ex1 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                let sender = sender.connect();
+                Timer::new(Duration::from_millis(10)).await;
+                sender.try_send(100).unwrap();
+            })
+            .unwrap();
+
+        let ex2 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                let receiver = receiver.connect();
+                let x = receiver.recv().await;
+                assert_eq!(x.unwrap(), 100);
+            })
+            .unwrap();
+
+        ex1.join().unwrap();
+        ex2.join().unwrap();
+    }
+
+    #[test]
+    fn producer_stream_consumer() {
+        let (sender, receiver) = new_bounded(1);
+
+        let ex1 = LocalExecutorBuilder::new()
+            .pin_to_cpu(0)
+            .spin_before_park(Duration::from_millis(1000000))
+            .spawn(move || async move {
+                let sender = sender.connect();
+                for _ in 0..10 {
+                    sender.send(1).await.unwrap();
+                    Timer::new(Duration::from_millis(1)).await;
+                }
+            })
+            .unwrap();
+
+        let ex2 = LocalExecutorBuilder::new()
+            .pin_to_cpu(1)
+            .spin_before_park(Duration::from_millis(1000000))
+            .spawn(move || async move {
+                let receiver = receiver.connect();
+                let sum = receiver.fold(0, |acc, x| acc + x).await;
+                assert_eq!(sum, 10);
+            })
+            .unwrap();
+
+        ex1.join().unwrap();
+        ex2.join().unwrap();
+    }
+
+    #[test]
+    fn consumer_sleeps_before_producer_produces() {
+        let (sender, receiver) = new_bounded(1);
+
+        let ex1 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                Timer::new(Duration::from_millis(100)).await;
+                let sender = sender.connect();
+                sender.send(1).await.unwrap();
+            })
+            .unwrap();
+
+        let ex2 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                let receiver = receiver.connect();
+                let recv = receiver.recv().await.unwrap();
+                assert_eq!(recv, 1);
+                let sum = receiver.fold(0, |acc, x| acc + x).await;
+                assert_eq!(sum, 0);
+            })
+            .unwrap();
+
+        ex1.join().unwrap();
+        ex2.join().unwrap();
+    }
+
+    #[test]
+    fn producer_sleeps_before_consumer_consumes() {
+        let (sender, receiver) = new_bounded(1);
+
+        let ex1 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                let sender = sender.connect();
+                // This will go right away because the channel fits 1 element
+                sender.try_send(1).unwrap();
+                // This will sleep. The consumer should unblock us
+                sender.send(1).await.unwrap();
+            })
+            .unwrap();
+
+        let ex2 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                Timer::new(Duration::from_millis(100)).await;
+                let receiver = receiver.connect();
+                let sum = receiver.fold(0, |acc, x| acc + x).await;
+                assert_eq!(sum, 2);
+            })
+            .unwrap();
+
+        ex1.join().unwrap();
+        ex2.join().unwrap();
+    }
+
+    #[test]
+    fn producer_never_connects() {
+        let (sender, receiver) = new_bounded(1);
+
+        let ex1 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                drop(sender);
+            })
+            .unwrap();
+
+        let ex2 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                let receiver: ConnectedReceiver<usize> = receiver.connect();
+                assert_eq!(receiver.recv().await.is_none(), true);
+            })
+            .unwrap();
+
+        ex1.join().unwrap();
+        ex2.join().unwrap();
+    }
+
+    #[test]
+    fn consumer_never_connects() {
+        let (sender, receiver) = new_bounded(1);
+
+        let ex1 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                drop(receiver);
+            })
+            .unwrap();
+
+        let ex2 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                Timer::new(Duration::from_millis(100)).await;
+                let sender: ConnectedSender<usize> = sender.connect();
+                match sender.send(0).await {
+                    Ok(_) => panic!("Should not have sent"),
+                    Err(x) => assert_eq!(x.kind, io::ErrorKind::BrokenPipe),
+                }
+            })
+            .unwrap();
+
+        ex1.join().unwrap();
+        ex2.join().unwrap();
+    }
+
+    #[test]
+    fn pass_function() {
+        let (sender, receiver) = new_bounded(10);
+
+        let ex1 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                let sender = sender.connect();
+                Timer::new(Duration::from_millis(10)).await;
+                if sender.send(|| 32).await.is_err() {
+                    panic!("send failed");
+                }
+            })
+            .unwrap();
+
+        let ex2 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                let receiver = receiver.connect();
+                let x = receiver.recv().await.unwrap();
+                assert_eq!(32, x());
+            })
+            .unwrap();
+
+        ex1.join().unwrap();
+        ex2.join().unwrap();
+    }
+
+    #[test]
+    fn send_to_full_channel() {
+        let (sender, receiver) = new_bounded(1);
+
+        let status = Arc::new(AtomicUsize::new(0));
+        let s1 = status.clone();
+
+        let ex1 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                let sender = sender.connect();
+                sender.send(0).await.unwrap();
+                let x = sender.try_send(1);
+                assert_eq!(x.is_err(), true);
+                s1.store(1, Ordering::Relaxed);
+            })
+            .unwrap();
+
+        let ex2 = LocalExecutorBuilder::new()
+            .spawn(move || async move {
+                let receiver = receiver.connect();
+
+                while status.load(Ordering::Relaxed) == 0 {}
+                let x = receiver.recv().await.unwrap();
+                assert_eq!(0, x);
+            })
+            .unwrap();
+
+        ex1.join().unwrap();
+        ex2.join().unwrap();
+    }
+}

--- a/glommio/src/channels/spsc_queue.rs
+++ b/glommio/src/channels/spsc_queue.rs
@@ -1,0 +1,405 @@
+use std::cell::Cell;
+use std::fmt;
+use std::os::unix::io::RawFd;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+const CACHELINE_LEN: usize = 64;
+
+const fn cacheline_pad(used: usize) -> usize {
+    CACHELINE_LEN / std::mem::size_of::<usize>() - used
+}
+
+/// The internal memory buffer used by the queue.
+///
+/// Buffer holds a pointer to allocated memory which represents the bounded
+/// ring buffer, as well as a head and tail atomicUsize which the producer and consumer
+/// use to track location in the ring.
+#[repr(C)]
+struct Buffer<T: Copy> {
+    buffer_storage: Arc<Vec<Cell<T>>>,
+
+    /// The bounded size as specified by the user.  If the queue reaches capacity, it will block
+    /// until values are poppped off.
+    capacity: usize,
+
+    /// The allocated size of the ring buffer, in terms of number of values (not physical memory).
+    /// This will be the next power of two larger than `capacity`
+    allocated_size: usize,
+    _padding1: [usize; cacheline_pad(3)],
+
+    /// Consumer cacheline:
+
+    /// Index position of the current head
+    head: AtomicUsize,
+    shadow_tail: Cell<usize>,
+    producer_disconnected: AtomicUsize,
+    producer_eventfd: Cell<Option<Arc<AtomicUsize>>>,
+    _padding2: [usize; cacheline_pad(4)],
+
+    /// Producer cacheline:
+
+    /// Index position of current tail
+    tail: AtomicUsize,
+    shadow_head: Cell<usize>,
+    consumer_disconnected: AtomicUsize,
+    consumer_eventfd: Cell<Option<Arc<AtomicUsize>>>,
+    _padding3: [usize; cacheline_pad(4)],
+}
+
+impl<T: Copy> fmt::Debug for Buffer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let head = self.head.load(Ordering::Relaxed);
+        let tail = self.tail.load(Ordering::Relaxed);
+        let shead = self.shadow_head.get();
+        let consumer_disconnected = self.consumer_disconnected.load(Ordering::Relaxed) != 0;
+        let producer_disconnected = self.producer_disconnected.load(Ordering::Relaxed) != 0;
+
+        f.debug_struct("SPSC Buffer")
+            .field("capacity:", &self.capacity)
+            .field("allocated_size:", &self.allocated_size)
+            .field("consumer_head:", &head)
+            .field("producer_tail:", &tail)
+            .field("shadow_head:", &shead)
+            .field("consumer_disconnected:", &consumer_disconnected)
+            .field("producer_disconnected:", &producer_disconnected)
+            .finish()
+    }
+}
+
+unsafe impl<T: Sync + Copy> Sync for Buffer<T> {}
+
+/// A handle to the queue which allows consuming values from the buffer
+#[derive(Debug)]
+pub(crate) struct Consumer<T: Copy> {
+    buffer: Arc<Buffer<T>>,
+}
+
+/// A handle to the queue which allows adding values onto the buffer
+#[derive(Debug)]
+pub(crate) struct Producer<T: Copy> {
+    buffer: Arc<Buffer<T>>,
+}
+
+unsafe impl<T: Send + Copy> Send for Consumer<T> {}
+unsafe impl<T: Send + Copy> Send for Producer<T> {}
+
+impl<T: Copy> Buffer<T> {
+    /// Attempt to pop a value off the buffer.
+    ///
+    /// If the buffer is empty, this method will not block.  Instead, it will return `None`
+    /// signifying the buffer was empty.  The caller may then decide what to do next (e.g. spin-wait,
+    /// sleep, process something else, etc)
+    fn try_pop(&self) -> Option<T> {
+        let current_head = self.head.load(Ordering::Relaxed);
+
+        if current_head == self.shadow_tail.get() {
+            self.shadow_tail.set(self.tail.load(Ordering::Acquire));
+            if current_head == self.shadow_tail.get() {
+                return None;
+            }
+        }
+
+        let index = current_head & (self.allocated_size - 1);
+        let v = self.buffer_storage[index].get();
+        self.head
+            .store(current_head.wrapping_add(1), Ordering::Release);
+        Some(v)
+    }
+
+    /// Attempt to push a value onto the buffer.
+    ///
+    /// If the buffer is full, this method will not block.  Instead, it will return `Some(v)`, where
+    /// `v` was the value attempting to be pushed onto the buffer.  If the value was successfully
+    /// pushed onto the buffer, `None` will be returned signifying success.
+    fn try_push(&self, v: T) -> Option<T> {
+        if self.consumer_disconnected.load(Ordering::Acquire) > 0 {
+            return Some(v);
+        }
+        let current_tail = self.tail.load(Ordering::Relaxed);
+
+        if self.shadow_head.get() + self.capacity <= current_tail {
+            self.shadow_head.set(self.head.load(Ordering::Relaxed));
+            if self.shadow_head.get() + self.capacity <= current_tail {
+                return Some(v);
+            }
+        }
+
+        let index = current_tail & (self.allocated_size - 1);
+        self.buffer_storage[index].set(v);
+        self.tail
+            .store(current_tail.wrapping_add(1), Ordering::Release);
+        None
+    }
+
+    /// Disconnects the consumer, and returns whether or not it was already disconnected
+    pub(crate) fn disconnect_consumer(&self) -> bool {
+        self.consumer_disconnected.swap(1, Ordering::Release) != 0
+    }
+
+    /// Disconnects the consumer, and returns whether or not it was already disconnected
+    pub(crate) fn disconnect_producer(&self) -> bool {
+        self.producer_disconnected.swap(1, Ordering::Release) != 0
+    }
+
+    /// Disconnects the consumer, and returns whether or not it was already disconnected
+    pub(crate) fn producer_disconnected(&self) -> bool {
+        self.producer_disconnected.load(Ordering::Acquire) != 0
+    }
+
+    /// Disconnects the consumer, and returns whether or not it was already disconnected
+    pub(crate) fn consumer_disconnected(&self) -> bool {
+        self.consumer_disconnected.load(Ordering::Acquire) != 0
+    }
+}
+
+/// Handles deallocation of heap memory when the buffer is dropped
+impl<T: Copy> Drop for Buffer<T> {
+    fn drop(&mut self) {
+        // Pop the rest of the values off the queue.  By moving them into this scope,
+        // we implicitly call their destructor
+        while self.try_pop().is_some() {}
+        // We don't want to run any destructors here, because we didn't run
+        // any of the constructors through the vector. And whatever object was
+        // in fact still alive we popped above.
+        unsafe {
+            match Arc::get_mut(&mut self.buffer_storage) {
+                Some(storage) => storage.set_len(0),
+                None => unreachable!(),
+            }
+        }
+    }
+}
+
+pub(crate) fn make<T: Copy>(capacity: usize) -> (Producer<T>, Consumer<T>) {
+    let buffer_storage = allocate_buffer(capacity);
+
+    let arc = Arc::new(Buffer {
+        buffer_storage,
+        capacity,
+        allocated_size: capacity.next_power_of_two(),
+        _padding1: [0; cacheline_pad(3)],
+        _padding2: [0; cacheline_pad(4)],
+        _padding3: [0; cacheline_pad(4)],
+
+        head: AtomicUsize::new(0),
+        shadow_tail: Cell::new(0),
+        producer_disconnected: AtomicUsize::new(0),
+        producer_eventfd: Cell::new(None),
+
+        tail: AtomicUsize::new(0),
+        shadow_head: Cell::new(0),
+        consumer_disconnected: AtomicUsize::new(0),
+        consumer_eventfd: Cell::new(None),
+    });
+
+    (
+        Producer {
+            buffer: arc.clone(),
+        },
+        Consumer { buffer: arc },
+    )
+}
+
+fn allocate_buffer<T>(capacity: usize) -> Arc<Vec<T>> {
+    let size = capacity.next_power_of_two();
+    let mut vec = Vec::with_capacity(size);
+    unsafe {
+        vec.set_len(size);
+    }
+    Arc::new(vec)
+}
+
+impl<T: Copy> Producer<T> {
+    /// Attempt to push a value onto the buffer.
+    ///
+    /// This method does not block.  If the queue is not full, the value will be added to the
+    /// queue and the method will return `None`, signifying success.  If the queue is full,
+    /// this method will return `Some(v)``, where `v` is your original value.
+    pub(crate) fn try_push(&self, v: T) -> Option<T> {
+        (*self.buffer).try_push(v)
+    }
+
+    pub(crate) fn must_notify(&self) -> Option<RawFd> {
+        let mem = (*self.buffer).consumer_eventfd.take();
+        let ret = mem.as_ref().map(|x| x.load(Ordering::Acquire) as _);
+        (*self.buffer).consumer_eventfd.set(mem);
+        match ret {
+            None => None,
+            Some(0) => None,
+            Some(x) => Some(x),
+        }
+    }
+
+    pub(crate) fn connect(&self, eventfd: Arc<AtomicUsize>) {
+        let old = (*self.buffer).producer_eventfd.replace(Some(eventfd));
+        assert_eq!(old.is_none(), true);
+    }
+
+    /// Disconnects the producer, signaling to the consumer that no new values are going to be
+    /// produced.
+    ///
+    /// Returns the buffer status before the disconnect
+    pub(crate) fn disconnect(&self) -> bool {
+        (*self.buffer).producer_eventfd.set(None);
+        (*self.buffer).disconnect_producer()
+    }
+
+    pub(crate) fn consumer_disconnected(&self) -> bool {
+        (*self.buffer).consumer_disconnected()
+    }
+    /// Returns the total capacity of this queue
+    ///
+    /// This value represents the total capacity of the queue when it is full.  It does not
+    /// represent the current usage.  For that, call `size()`.
+    pub(crate) fn capacity(&self) -> usize {
+        (*self.buffer).capacity
+    }
+
+    /// Returns the current size of the queue
+    ///
+    /// This value represents the current size of the queue.  This value can be from 0-`capacity`
+    /// inclusive.
+    pub(crate) fn size(&self) -> usize {
+        (*self.buffer).tail.load(Ordering::Acquire) - (*self.buffer).head.load(Ordering::Acquire)
+    }
+
+    /// Returns the available space in the queue
+    ///
+    /// This value represents the number of items that can be pushed onto the queue before it
+    /// becomes full.
+    pub(crate) fn free_space(&self) -> usize {
+        self.capacity() - self.size()
+    }
+}
+
+impl<T: Copy> Consumer<T> {
+    pub(crate) fn connect(&self, eventfd: Arc<AtomicUsize>) {
+        let old = (*self.buffer).consumer_eventfd.replace(Some(eventfd));
+        assert_eq!(old.is_none(), true);
+    }
+
+    pub(crate) fn must_notify(&self) -> Option<RawFd> {
+        let mem = (*self.buffer).producer_eventfd.take();
+        let ret = mem.as_ref().map(|x| x.load(Ordering::Acquire) as _);
+        (*self.buffer).producer_eventfd.set(mem);
+        match ret {
+            None => None,
+            Some(0) => None,
+            Some(x) => Some(x),
+        }
+    }
+
+    /// Disconnects the consumer, signaling to the producer that no new values are going to be
+    /// consumed. After this is done, any attempt on the producer to try_push should fail
+    ///
+    /// Returns the buffer status before the disconnect
+    pub(crate) fn disconnect(&self) -> bool {
+        (*self.buffer).consumer_eventfd.set(None);
+        (*self.buffer).disconnect_consumer()
+    }
+
+    pub(crate) fn producer_disconnected(&self) -> bool {
+        (*self.buffer).producer_disconnected()
+    }
+
+    /// Attempt to pop a value off the queue.
+    ///
+    /// This method does not block.  If the queue is empty, the method will return `None`.  If
+    /// there is a value available, the method will return `Some(v)`, where `v` is the value
+    /// being popped off the queue.
+    pub(crate) fn try_pop(&self) -> Option<T> {
+        (*self.buffer).try_pop()
+    }
+
+    /// Returns the total capacity of this queue
+    ///
+    /// This value represents the total capacity of the queue when it is full.  It does not
+    /// represent the current usage.  For that, call `size()`.
+    pub(crate) fn capacity(&self) -> usize {
+        (*self.buffer).capacity
+    }
+
+    /// Returns the current size of the queue
+    ///
+    /// This value represents the current size of the queue.  This value can be from 0-`capacity`
+    /// inclusive.
+    pub(crate) fn size(&self) -> usize {
+        (*self.buffer).tail.load(Ordering::Acquire) - (*self.buffer).head.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn test_buffer_size() {
+        assert_eq!(::std::mem::size_of::<Buffer<()>>(), 3 * CACHELINE_LEN);
+    }
+
+    #[test]
+    fn test_try_push() {
+        let (p, _) = super::make(10);
+
+        for i in 0..10 {
+            p.try_push(i);
+            assert!(p.capacity() == 10);
+            assert!(p.size() == i + 1);
+        }
+
+        match p.try_push(10) {
+            Some(v) => {
+                assert!(v == 10);
+            }
+            None => assert!(false, "Queue should not have accepted another write!"),
+        }
+    }
+
+    #[test]
+    fn test_try_poll() {
+        let (p, c) = super::make(10);
+
+        match c.try_pop() {
+            Some(_) => assert!(false, "Queue was empty but a value was read!"),
+            None => {}
+        }
+
+        p.try_push(123);
+
+        match c.try_pop() {
+            Some(v) => assert!(v == 123),
+            None => assert!(false, "Queue was not empty but poll() returned nothing!"),
+        }
+
+        match c.try_pop() {
+            Some(_) => assert!(false, "Queue was empty but a value was read!"),
+            None => {}
+        }
+    }
+
+    #[test]
+    fn test_threaded() {
+        let (p, c) = super::make(500);
+
+        thread::spawn(move || {
+            for i in 0..100000 {
+                loop {
+                    if let None = p.try_push(i) {
+                        break;
+                    }
+                }
+            }
+        });
+
+        for i in 0..100000 {
+            loop {
+                if let Some(t) = c.try_pop() {
+                    assert!(t == i);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -486,6 +486,7 @@ impl LocalExecutorBuilder {
             let mut le = LocalExecutor::new(id);
             if let Some(cpu) = self.binding {
                 le.bind_to_cpu(cpu).unwrap();
+                le.queues.borrow_mut().spin_before_park = self.spin_before_park;
             }
             le.init().unwrap();
             le.run(async move {

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -363,22 +363,6 @@ pub(crate) mod test {
         };
     }
 
-    dma_file_test!(fallback_drop_closes_the_file, path, _k, {
-        let fd;
-        {
-            let file = DmaFile::create(path.join("testfile"))
-                .await
-                .expect("failed to create file");
-            fd = file.as_raw_fd();
-            std::fs::remove_file(path.join("testfile")).unwrap();
-        }
-        assert!(fd != -1);
-        let ret = unsafe { libc::close(fd) };
-        assert_eq!(ret, -1);
-        let err = std::io::Error::last_os_error().raw_os_error().unwrap();
-        assert_eq!(err, libc::EBADF);
-    });
-
     dma_file_test!(file_create_close, path, _k, {
         let new_file = DmaFile::create(path.join("testfile"))
             .await

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -88,6 +88,16 @@ pub(crate) fn sync_open(path: &Path, flags: libc::c_int, mode: libc::c_int) -> i
     syscall!(open(path.as_ptr(), flags, mode))
 }
 
+pub(crate) fn create_eventfd() -> io::Result<RawFd> {
+    syscall!(eventfd(0, libc::O_CLOEXEC))
+}
+
+pub(crate) fn write_eventfd(eventfd: RawFd) {
+    let buf = [1u64; 1];
+    let ret = syscall!(write(eventfd, &buf as *const u64 as _, 8)).unwrap();
+    assert_eq!(ret, 8);
+}
+
 fn cstr(path: &Path) -> io::Result<CString> {
     Ok(CString::new(path.as_os_str().as_bytes())?)
 }

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -17,8 +17,11 @@ use std::time::Duration;
 
 use crate::free_list::{FreeList, Idx};
 use crate::sys::posix_buffers::PosixDmaBuffer;
-use crate::sys::{IOBuffer, InnerSource, LinkStatus, PollableStatus, Source, SourceType};
+use crate::sys::{self, IOBuffer, InnerSource, LinkStatus, PollableStatus, Source, SourceType};
 use crate::{IoRequirements, Latency};
+use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use uring_sys::IoRingOp;
 
@@ -578,7 +581,23 @@ impl SleepableRing {
         source
     }
 
-    fn sleep(&mut self, link: &mut Source) -> io::Result<usize> {
+    fn install_eventfd(&mut self, eventfd_src: &Source) -> bool {
+        if let Some(mut sqe) = self.ring.next_sqe() {
+            // Now must wait on the eventfd in case someone wants to wake us up.
+            // If we can't then we can't sleep and will just bail immediately
+            let op = UringDescriptor {
+                fd: eventfd_src.raw(),
+                user_data: to_user_data(add_source(eventfd_src, self.submission_queue.clone())),
+                args: UringOpDescriptor::Read(0, 8),
+            };
+            fill_sqe(&mut sqe, &op, |_| panic!("not in the poll ring"));
+            true
+        } else {
+            false
+        }
+    }
+
+    fn sleep(&mut self, link: &mut Source, eventfd_src: &Source) -> io::Result<usize> {
         let is_freestanding = match &*link.source_type() {
             SourceType::LinkRings(LinkStatus::Linked) => false, // nothing to do
             SourceType::LinkRings(LinkStatus::Freestanding) => true,
@@ -603,7 +622,25 @@ impl SleepableRing {
             }
         }
 
-        self.ring.submit_sqes_and_wait(1)
+        let res = eventfd_src.take_result();
+        match res {
+            None => {
+                // We already have the eventfd registered and nobody woke us up so far.
+                // Just proceed to sleep
+                self.ring.submit_sqes_and_wait(1)
+            }
+            Some(res) => {
+                if self.install_eventfd(eventfd_src) {
+                    // Do not expect any failures reading from eventfd. This will panic if we failed.
+                    res.unwrap();
+                    // Now must wait on the eventfd in case someone wants to wake us up.
+                    // If we can't then we can't sleep and will just bail immediately
+                    self.ring.submit_sqes_and_wait(1)
+                } else {
+                    self.ring.submit_sqes()
+                }
+            }
+        }
     }
 }
 
@@ -665,6 +702,14 @@ pub struct Reactor {
     link_rings_src: RefCell<Source>,
 
     timeout_src: Cell<Option<Source>>,
+
+    // This keeps the eventfd alive. Drop will close it when we're done
+    _eventfd: std::fs::File,
+    // This tells the other reactors whether we are sleeping or not, and if we
+    // are what is our eventfd
+    eventfd_memory: Arc<AtomicUsize>,
+    // This is the source used to handle the notifications into the ring
+    eventfd_src: Source,
 }
 
 fn common_flags() -> PollFlags {
@@ -721,7 +766,7 @@ impl Reactor {
                 ),
             ));
         }
-        let main_ring = SleepableRing::new(128, "main")?;
+        let mut main_ring = SleepableRing::new(128, "main")?;
         let latency_ring = SleepableRing::new(128, "latency")?;
         let link_fd = latency_ring.ring_fd();
         let link_rings_src = Source::new(
@@ -730,13 +775,28 @@ impl Reactor {
             SourceType::LinkRings(LinkStatus::Freestanding),
         );
 
+        let eventfd = unsafe { std::fs::File::from_raw_fd(sys::create_eventfd()?) };
+        let eventfd_src = Source::new(
+            IoRequirements::default(),
+            eventfd.as_raw_fd(),
+            SourceType::Read(PollableStatus::NonPollable, None),
+        );
+        assert_eq!(main_ring.install_eventfd(&eventfd_src), true);
+
         Ok(Reactor {
             main_ring: RefCell::new(main_ring),
             latency_ring: RefCell::new(latency_ring),
             poll_ring: RefCell::new(PollRing::new(128)?),
             link_rings_src: RefCell::new(link_rings_src),
             timeout_src: Cell::new(None),
+            _eventfd: eventfd,
+            eventfd_memory: Arc::new(AtomicUsize::new(0)),
+            eventfd_src,
         })
+    }
+
+    pub(crate) fn eventfd(&self) -> Arc<AtomicUsize> {
+        self.eventfd_memory.clone()
     }
 
     pub(crate) fn alloc_dma_buffer(&self, size: usize) -> DmaBuffer {
@@ -832,9 +892,13 @@ impl Reactor {
     //
     // We may not be able to register an SQE at this point, so we return an Error and
     // will just not sleep.
-    fn link_rings_and_sleep(&self, ring: &mut SleepableRing) -> io::Result<()> {
+    fn link_rings_and_sleep(
+        &self,
+        ring: &mut SleepableRing,
+        eventfd_src: &Source,
+    ) -> io::Result<()> {
         let mut link_rings = self.link_rings_src.borrow_mut();
-        ring.sleep(&mut link_rings)?;
+        ring.sleep(&mut link_rings, eventfd_src)?;
         Ok(())
     }
 
@@ -871,12 +935,16 @@ impl Reactor {
     //   close as possible to the point where we *leave* this method. For instance: if we spin here
     //   for 3ms and the preempt timer is 10ms that would leave the next task queue just 7ms to
     //   run.
-    pub(crate) fn wait(
+    pub(crate) fn wait<F>(
         &self,
         wakers: &mut Vec<Waker>,
         preempt_timer: Option<Duration>,
         user_timer: Option<Duration>,
-    ) -> io::Result<bool> {
+        process_remote_channels: F,
+    ) -> io::Result<bool>
+    where
+        F: Fn(&mut Vec<Waker>) -> usize,
+    {
         let mut poll_ring = self.poll_ring.borrow_mut();
         let mut main_ring = self.main_ring.borrow_mut();
         let mut lat_ring = self.latency_ring.borrow_mut();
@@ -903,6 +971,7 @@ impl Reactor {
         if should_sleep {
             consume_rings!(into wakers; lat_ring, poll_ring, main_ring);
         }
+
         // If we generated any event so far, we can't sleep. Need to handle them.
         should_sleep &= wakers.is_empty();
 
@@ -923,11 +992,22 @@ impl Reactor {
                 }
             }
             if should_sleep {
-                self.link_rings_and_sleep(&mut main_ring)?;
+                // From this moment on the remote executors are aware that we are sleeping
+                // We have to sweep the remote channels function once more because since
+                // last time until now it could be that something happened in a remote executor
+                // that opened up room. If if did we bail on sleep and go process it.
+                self.eventfd_memory
+                    .store(self.eventfd_src.raw() as _, Ordering::Release);
+                if process_remote_channels(wakers) == 0 {
+                    self.link_rings_and_sleep(&mut main_ring, &self.eventfd_src)?;
+                    // woke up, so no need to notify us anymore.
+                    self.eventfd_memory.store(0, Ordering::Release);
+                }
             }
         }
 
         consume_rings!(into wakers; lat_ring, poll_ring, main_ring);
+
         // A Note about need_preempt:
         //
         // If in the last call to consume_rings! some events completed, the tail and
@@ -1018,14 +1098,14 @@ mod tests {
 
         let start = Instant::now();
         let mut wakers = Vec::new();
-        reactor.wait(&mut wakers, None, None).unwrap();
+        reactor.wait(&mut wakers, None, None, |_| 0).unwrap();
         let elapsed_ms = start.elapsed().as_millis();
         assert!(50 <= elapsed_ms && elapsed_ms < 100);
 
         drop(slow); // Cancel this one.
 
         let mut wakers = Vec::new();
-        reactor.wait(&mut wakers, None, None).unwrap();
+        reactor.wait(&mut wakers, None, None, |_| 0).unwrap();
         let elapsed_ms = start.elapsed().as_millis();
         assert!(300 <= elapsed_ms && elapsed_ms < 350);
     }

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -595,6 +595,11 @@ impl SleepableRing {
                     args: UringOpDescriptor::PollAdd(common_flags() | read_flags()),
                 };
                 fill_sqe(&mut sqe, &op, PosixDmaBuffer::new);
+            } else {
+                // Can't link rings because we ran out of CQEs. Just can't sleep.
+                // Submit what we have, once we're out of here we'll consume them
+                // and at some point will be able to sleep again.
+                return self.ring.submit_sqes();
             }
         }
 


### PR DESCRIPTION
Sometimes we need to pass data between executors. The shared channel
will be used for that.

To implement the Shared Channel I am using the spsc queue crate
from https://github.com/polyfractal/bounded-spsc-queue. I like the implementation
and it is plenty fast. There are some things that we need to change there
(like the fact that it depends on the unstable compiler) and I sent patches.

We'll see how responsive they are but worst case the crate is simple
enough that I can copy.

The idea behind it is that the types going through the channel need to
be Send. But in order to probe for whether or not there is space in
the channel and activate the wakers we need to drill down the reactor
and check on every poll. Because of that, we require a sender or
receiver to be connected with a connect() function.

The connect() function consumes self, the inner state is not accessible
to the public, and before a connection is made there are no methods
available in either the sender or receiver: this makes it safe to force
the Send trait onto the Shared Receiver/Producer even though their
state is implemented through an Rc.

The Rc is important for two reasons: first it allow us to pass the state
deep down to the reactor so we can check if the wakers can be woken up.

But secondly, it allows for many asynchronous, detached tasks to push
data into this channel inside a single executor.

Like the local channel, I am implementing a stream interface for the
receiver. However currently there is no good way to signal a disconnect
to the remote end so it is not very useful. Performance-wise, the best
way to implement this is in the actual spsc buffer so I am waiting to see
what will happen with that code before I add more into these interfaces.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[x] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
