### PR TITLE
glommio: Correct Scipio/Glommio typo in src/lib.rs

### DIFF
--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ## Attention
 //!
-//! This crate was previously named Glommio but was renamed after a trademark dispute.
+//! This crate was previously named Scipio but was renamed after a trademark dispute.
 //! We are removing this message soon but it is now here to avoid confusion.
 //!
 //! ## What is Glommio


### PR DESCRIPTION
I was confused by the anti-confusion message. I believe this is what was meant.
