### PR TITLE
implement poll_close for the buffered stream writer

### DIFF
--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -8,7 +8,7 @@ use crate::io::glommio_file::GlommioFile;
 use crate::parking::Reactor;
 use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Constructs a file that is backed by the operating system page cache
 #[derive(Debug)]
@@ -184,6 +184,10 @@ impl BufferedFile {
 
     pub(crate) fn path(&self) -> &Path {
         self.file.path.as_ref().unwrap().as_path()
+    }
+
+    pub(crate) fn discard(self) -> (RawFd, Option<PathBuf>) {
+        self.file.discard()
     }
 }
 


### PR DESCRIPTION
We didn't implement poll_close, counting on the fact that our close
function would be called instead.

However, if we are calling close through a function that takes an
AsyncWriteExt trait the close method from the trait gets called. In that
case, we panic.

So let's go the extra mile and implement it: we'll need the file to
live inside an Option, so we can take() it. That is because the buffered
file's close() (now also accessible through discard()) consumes self.

We have a state machine similar to the one in the DMA file to handle the
transitions.

Once we have poll_close, then we no longer need our own close function.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
