### PR TITLE
replace std hashmap with ahashmap

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -32,6 +32,7 @@ enclose = "1.1.8"
 scopeguard = "1.1.0"
 pin-project-lite = "0.1.10"
 smallvec = "1.4.2"
+ahash = "0.5.8"
 
 [dev-dependencies]
 futures = "0.3.5"

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -22,8 +22,9 @@
 //! no thread context switch is necessary when going between task execution and I/O.
 //!
 
+use ahash::AHashMap;
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::ffi::CString;
 use std::fmt;
 use std::io;
@@ -107,7 +108,7 @@ impl Inner {
 
 struct Timers {
     timer_id: u64,
-    timers_by_id: HashMap<u64, Instant>,
+    timers_by_id: AHashMap<u64, Instant>,
 
     /// An ordered map of registered timers.
     ///
@@ -121,7 +122,7 @@ impl Timers {
     fn new() -> Timers {
         Timers {
             timer_id: 0,
-            timers_by_id: HashMap::new(),
+            timers_by_id: AHashMap::new(),
             timers: BTreeMap::new(),
         }
     }

--- a/glommio/src/semaphore.rs
+++ b/glommio/src/semaphore.rs
@@ -3,8 +3,9 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
+use ahash::AHashMap;
 use std::cell::RefCell;
-use std::collections::hash_map::{Entry, HashMap};
+use std::collections::hash_map::Entry;
 use std::collections::VecDeque;
 use std::future::Future;
 use std::io::{Error, ErrorKind, Result};
@@ -43,7 +44,7 @@ struct State {
     idgen: u64,
     avail: u64,
     virtual_consumed: u64,
-    waiterset: HashMap<WaiterId, (u64, Waker)>,
+    waiterset: AHashMap<WaiterId, (u64, Waker)>,
     list: VecDeque<WaiterId>,
     closed: bool,
 }
@@ -54,7 +55,7 @@ impl State {
             avail,
             virtual_consumed: 0,
             list: VecDeque::new(),
-            waiterset: HashMap::new(),
+            waiterset: AHashMap::new(),
             closed: false,
             idgen: 0,
         }

--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -3,15 +3,15 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
+use ahash::AHashMap;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::fs::{canonicalize, read_dir, read_to_string};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::vec::Vec;
 
-thread_local!(static DEV_MAP: RefCell<HashMap<(usize, usize), BlockDevice>> = RefCell::new(HashMap::new()));
+thread_local!(static DEV_MAP: RefCell<AHashMap<(usize, usize), BlockDevice>> = RefCell::new(AHashMap::new()));
 
 #[derive(Debug)]
 enum StorageCache {


### PR DESCRIPTION
This is a non-cryptographic hash, therefore faster than rust's standard
hash.

Although we have a FreeList type, which is useful for simple integer
cases, the FreeList API is a bit more restrictive than the Hash and
converting some uses would require work.

Contrast this with AHash, which was essentially a bunch of sed invocations.

This gave me a 5% boost in the storage benchmark I am about to post.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
