### PR TITLE
get_buffer_aligned: check for errors upon waking

### DIFF
--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -481,6 +481,10 @@ impl DmaStreamReader {
         buffer_id: u64,
     ) -> Poll<io::Result<ReadResult>> {
         let mut state = self.state.borrow_mut();
+        if let Some(err) = current_error!(state) {
+            return Poll::Ready(err);
+        }
+
         match state.buffermap.get(&buffer_id) {
             None => {
                 state.fill_buffer(self.state.clone(), self.file.clone());


### PR DESCRIPTION
Currently if there an error, we will just loop forever.

We need some error ingesting api to test this =(

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
