### PR TITLE
Embed the reactor into the executor

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -51,3 +51,7 @@ harness = false
 [[bench]]
 name = "shared_channel"
 harness = false
+
+[[bench]]
+name = "preempt"
+harness = false

--- a/glommio/benches/preempt.rs
+++ b/glommio/benches/preempt.rs
@@ -1,0 +1,22 @@
+use glommio::prelude::*;
+use std::time::Instant;
+
+fn main() {
+    let local_ex = LocalExecutorBuilder::new()
+        .pin_to_cpu(0)
+        .spawn(|| async move {
+            let mut runs = 0;
+            let t = Instant::now();
+            while !Local::need_preempt() {
+                runs += 1;
+            }
+
+            println!(
+                "cost of checking for need_preempt: {:#?}",
+                t.elapsed() / runs,
+            );
+        })
+        .unwrap();
+
+    local_ex.join().unwrap();
+}

--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -5,7 +5,6 @@
 //
 
 use crate::io::glommio_file::GlommioFile;
-use crate::parking::Reactor;
 use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
@@ -118,7 +117,7 @@ impl BufferedFile {
     /// });
     /// ```
     pub async fn write_at(&self, buf: Vec<u8>, pos: u64) -> io::Result<usize> {
-        let source = Reactor::get().write_buffered(self.as_raw_fd(), buf, pos);
+        let source = self.file.reactor.write_buffered(self.as_raw_fd(), buf, pos);
         enhanced_try!(source.collect_rw().await, "Writing", self.file)
     }
 
@@ -130,7 +129,7 @@ impl BufferedFile {
     ///
     /// [`DmaFile`]: struct.DmaFile.html
     pub async fn read_at(&self, pos: u64, size: usize) -> io::Result<Vec<u8>> {
-        let mut source = Reactor::get().read_buffered(self.as_raw_fd(), pos, size);
+        let mut source = self.file.reactor.read_buffered(self.as_raw_fd(), pos, size);
         let read_size = enhanced_try!(source.collect_rw().await, "Reading", self.file)?;
         let mut buffer = source.extract_buffer();
         buffer.truncate(read_size);

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -122,7 +122,7 @@ impl DmaFile {
     }
 
     /// Allocates a buffer that is suitable for using to write to this file.
-    pub fn alloc_dma_buffer(size: usize) -> DmaBuffer {
+    pub fn alloc_dma_buffer(&self, size: usize) -> DmaBuffer {
         Reactor::get().alloc_dma_buffer(size)
     }
 
@@ -175,7 +175,7 @@ impl DmaFile {
     /// ex.run(async {
     ///     let file = DmaFile::create("test.txt").await.unwrap();
     ///
-    ///     let mut buf = DmaFile::alloc_dma_buffer(4096);
+    ///     let mut buf = file.alloc_dma_buffer(4096);
     ///     let res = file.write_at(buf, 0).await.unwrap();
     ///     assert!(res <= 4096);
     ///     file.close().await.unwrap();
@@ -484,7 +484,7 @@ pub(crate) mod test {
             .await
             .expect("failed to create file");
 
-        let mut buf = DmaFile::alloc_dma_buffer(4096);
+        let mut buf = new_file.alloc_dma_buffer(4096);
         buf.memset(42);
         let res = new_file.write_at(buf, 0).await.expect("failed to write");
         assert_eq!(res, 4096);
@@ -559,7 +559,7 @@ pub(crate) mod test {
         file.truncate(size as u64).await.unwrap();
         let mut futs = vec![];
         for _ in 0..200 {
-            let mut buf = DmaFile::alloc_dma_buffer(size);
+            let mut buf = file.alloc_dma_buffer(size);
             let bytes = buf.as_bytes_mut();
             bytes[0] = 'x' as u8;
 
@@ -586,7 +586,7 @@ pub(crate) mod test {
                     let size: usize = 4096;
                     file.truncate(size as u64).await.unwrap();
 
-                    let mut buf = DmaFile::alloc_dma_buffer(size);
+                    let mut buf = file.alloc_dma_buffer(size);
                     let bytes = buf.as_bytes_mut();
                     bytes[0] = 'x' as u8;
                     file.write_at(buf, 0).await.unwrap();

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -947,7 +947,12 @@ impl AsyncWrite for DmaStreamWriter {
             match state.current_buffer.take() {
                 None => {
                     if state.pending.len() < state.write_behind {
-                        state.current_buffer = Some(DmaFile::alloc_dma_buffer(state.buffer_size));
+                        state.current_buffer = Some(
+                            self.file
+                                .as_ref()
+                                .unwrap()
+                                .alloc_dma_buffer(state.buffer_size),
+                        );
                     } else {
                         break;
                     }

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -6,11 +6,13 @@
 use crate::error::ErrorEnhancer;
 use crate::parking::Reactor;
 use crate::sys;
+use crate::Local;
 use std::convert::TryInto;
 use std::io;
 use std::mem;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 /// A wrapper over `std::fs::File` which carries a path (for better error
 /// messages) and prints a warning if closed synchronously.
@@ -26,6 +28,7 @@ pub(crate) struct GlommioFile {
     pub(crate) inode: u64,
     pub(crate) dev_major: u32,
     pub(crate) dev_minor: u32,
+    pub(crate) reactor: Rc<Reactor>,
 }
 
 impl Drop for GlommioFile {
@@ -53,6 +56,7 @@ impl FromRawFd for GlommioFile {
             inode: 0,
             dev_major: 0,
             dev_minor: 0,
+            reactor: Local::get_reactor(),
         }
     }
 }
@@ -64,7 +68,8 @@ impl GlommioFile {
         flags: libc::c_int,
         mode: libc::c_int,
     ) -> io::Result<GlommioFile> {
-        let source = Reactor::get().open_at(dir, path, flags, mode);
+        let reactor = Local::get_reactor();
+        let source = reactor.open_at(dir, path, flags, mode);
         let fd = source.collect_rw().await?;
 
         let mut file = GlommioFile {
@@ -73,6 +78,7 @@ impl GlommioFile {
             inode: 0,
             dev_major: 0,
             dev_minor: 0,
+            reactor,
         };
 
         let st = file.statx().await?;
@@ -97,9 +103,10 @@ impl GlommioFile {
     }
 
     pub(crate) async fn close(self) -> io::Result<()> {
+        let reactor = self.reactor.clone();
         // Destruct `self` into components skipping Drop.
         let (fd, path) = self.discard();
-        let source = Reactor::get().close(fd);
+        let source = reactor.close(fd);
         enhanced_try!(source.collect_rw().await, "Closing", path, Some(fd))?;
         Ok(())
     }
@@ -126,7 +133,7 @@ impl GlommioFile {
 
     pub(crate) async fn pre_allocate(&self, size: u64) -> io::Result<()> {
         let flags = libc::FALLOC_FL_ZERO_RANGE;
-        let source = Reactor::get().fallocate(self.as_raw_fd(), 0, size, flags);
+        let source = self.reactor.fallocate(self.as_raw_fd(), 0, size, flags);
         enhanced_try!(source.collect_rw().await, "Pre-allocate space", self)?;
         Ok(())
     }
@@ -155,7 +162,7 @@ impl GlommioFile {
     }
 
     pub(crate) async fn fdatasync(&self) -> io::Result<()> {
-        let source = Reactor::get().fdatasync(self.as_raw_fd());
+        let source = self.reactor.fdatasync(self.as_raw_fd());
         enhanced_try!(source.collect_rw().await, "Syncing", self)?;
         Ok(())
     }
@@ -169,7 +176,7 @@ impl GlommioFile {
     pub(crate) async fn statx(&self) -> io::Result<libc::statx> {
         let path = self.path_required("stat")?;
 
-        let source = Reactor::get().statx(self.as_raw_fd(), path);
+        let source = self.reactor.statx(self.as_raw_fd(), path);
         enhanced_try!(source.collect_rw().await, "getting file metadata", self)?;
         let stype = source.extract_source_type();
         stype.try_into()

--- a/glommio/src/networking.rs
+++ b/glommio/src/networking.rs
@@ -25,11 +25,13 @@ impl Async<TcpListener> {
     /// ```
     /// use glommio::Async;
     /// use std::net::TcpListener;
+    /// use glommio::LocalExecutor;
     ///
-    /// # futures_lite::future::block_on(async {
-    /// let listener = Async::<TcpListener>::bind(([127, 0, 0, 1], 0))?;
-    /// println!("Listening on {}", listener.get_ref().local_addr()?);
-    /// # std::io::Result::Ok(()) });
+    /// let ex = LocalExecutor::make_default();
+    /// ex.run(async move {
+    ///     let listener = Async::<TcpListener>::bind(([127, 0, 0, 1], 0)).unwrap();
+    ///     println!("Listening on {}", listener.get_ref().local_addr().unwrap());
+    /// });
     /// ```
     pub fn bind<A: Into<SocketAddr>>(addr: A) -> io::Result<Async<TcpListener>> {
         let addr = addr.into();
@@ -175,11 +177,13 @@ impl Async<UdpSocket> {
     /// ```
     /// use glommio::Async;
     /// use std::net::UdpSocket;
+    /// use glommio::LocalExecutor;
     ///
-    /// # futures_lite::future::block_on(async {
-    /// let socket = Async::<UdpSocket>::bind(([127, 0, 0, 1], 0))?;
-    /// println!("Bound to {}", socket.get_ref().local_addr()?);
-    /// # std::io::Result::Ok(()) });
+    /// let ex = LocalExecutor::make_default();
+    /// ex.run(async move {
+    ///     let socket = Async::<UdpSocket>::bind(([127, 0, 0, 1], 0)).unwrap();
+    ///     println!("Bound to {}", socket.get_ref().local_addr().unwrap());
+    /// });
     /// ```
     pub fn bind<A: Into<SocketAddr>>(addr: A) -> io::Result<Async<UdpSocket>> {
         let addr = addr.into();

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -43,8 +43,7 @@ use futures_lite::*;
 use crate::sys;
 use crate::sys::{DmaBuffer, IOBuffer, PollableStatus, Source, SourceType};
 use crate::IoRequirements;
-
-thread_local!(static LOCAL_REACTOR: Reactor = Reactor::new());
+use crate::Local;
 
 /// Waits for a notification.
 pub(crate) struct Parker {
@@ -94,13 +93,19 @@ impl fmt::Debug for Parker {
     }
 }
 
+impl fmt::Debug for Reactor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("Reactor { .. }")
+    }
+}
+
 struct Inner {}
 
 impl Inner {
     fn park(&self, timeout: Option<Duration>) -> bool {
         // If the timeout is zero, then there is no need to actually block.
         // Process available I/O events.
-        let _ = Reactor::get().react(timeout);
+        let _ = Local::get_reactor().react(timeout);
         false
     }
 }
@@ -210,7 +215,7 @@ impl SharedChannels {
 /// Every async I/O handle and every timer is registered here. Invocations of
 /// [`run()`][`crate::run()`] poll the reactor to check for new events every now and then.
 ///
-/// There is only one global instance of this type, accessible by [`Reactor::get()`].
+/// There is only one global instance of this type, accessible by [`Local::get_reactor()`].
 pub(crate) struct Reactor {
     /// Raw bindings to epoll/kqueue/wepoll.
     sys: sys::Reactor,
@@ -239,7 +244,7 @@ pub(crate) struct Reactor {
 }
 
 impl Reactor {
-    fn new() -> Reactor {
+    pub(crate) fn new() -> Reactor {
         let sys = sys::Reactor::new().expect("cannot initialize I/O event notification");
         let (preempt_ptr_head, preempt_ptr_tail) = sys.preempt_pointers();
         Reactor {
@@ -253,45 +258,9 @@ impl Reactor {
         }
     }
 
-    pub(crate) fn get() -> &'static Reactor {
-        unsafe {
-            LOCAL_REACTOR.with(|r| {
-                let rc = r as *const Reactor;
-                &*rc
-            })
-        }
-    }
-
     #[inline(always)]
-    // FIXME: This is a bit less efficient than it needs, because the scoped thread local key
-    // does lazy initialization. Every time we call into this, we are paying to test if this
-    // is initialized. This is what I got from objdump:
-    //
-    // 0:    50                      push   %rax
-    // 1:    ff 15 00 00 00 00       callq  *0x0(%rip)
-    // 7:    48 85 c0                test   %rax,%rax
-    // a:    74 17                   je     23  <== will call into the initialization routine
-    // c:    48 8b 88 38 03 00 00    mov    0x338(%rax),%rcx <== address of the head
-    // 13:   48 8b 80 40 03 00 00    mov    0x340(%rax),%rax <== address of the tail
-    // 1a:   8b 00                   mov    (%rax),%eax
-    // 1c:   3b 01                   cmp    (%rcx),%eax <== need preempt
-    // 1e:   0f 95 c0                setne  %al
-    // 21:   59                      pop    %rcx
-    // 22:   c3                      retq
-    // 23    <== initialization stuff
-    //
-    // Rust has a thread local feature that is under experimental so we can maybe switch to
-    // that someday.
-    //
-    // We will prefer to use the stable compiler and pay that unfortunate price for now.
-    #[inline(always)]
-    pub(crate) fn need_preempt() -> bool {
-        unsafe {
-            LOCAL_REACTOR.with(|r| {
-                let rc = &*(r as *const Reactor);
-                *rc.preempt_ptr_head != (*rc.preempt_ptr_tail).load(Ordering::Acquire)
-            })
-        }
+    pub(crate) fn need_preempt(&self) -> bool {
+        unsafe { *self.preempt_ptr_head != (*self.preempt_ptr_tail).load(Ordering::Acquire) }
     }
 
     pub(crate) fn eventfd(&self) -> Arc<AtomicUsize> {
@@ -538,7 +507,7 @@ impl Source {
             }
 
             self.add_waiter(cx.waker().clone());
-            Reactor::get().sys.interest(self, true, false);
+            Local::get_reactor().sys.interest(self, true, false);
             Poll::Pending
         })
         .await
@@ -552,7 +521,7 @@ impl Source {
             }
 
             self.add_waiter(cx.waker().clone());
-            Reactor::get().sys.interest(self, false, true);
+            Local::get_reactor().sys.interest(self, false, true);
             Poll::Pending
         })
         .await

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -108,7 +108,7 @@ pub(crate) mod sysfs;
 mod uring;
 
 pub use self::posix_buffers::*;
-pub use self::uring::*;
+pub(crate) use self::uring::*;
 use crate::IoRequirements;
 
 /// A buffer that can be used with DmaFile.

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -713,7 +713,7 @@ impl UringCommon for SleepableRing {
     }
 }
 
-pub struct Reactor {
+pub(crate) struct Reactor {
     // FIXME: it is starting to feel we should clean this up to a Inner pattern
     main_ring: RefCell<SleepableRing>,
     latency_ring: RefCell<SleepableRing>,


### PR DESCRIPTION
### What does this PR do?

Embeds the reactor inside the `LocalExecutor` with an `Rc`. This should improve performance in situations where we were doing two thread local accesses instead of one, as well as allow for more control when initializing the `Reactor`.
