### PR TITLE
Registered buffers

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2.73"
 socket2 = { version = "0.3.12", features = ["pair", "unix"] }
 iou = { git = "https://github.com/glommer/iou", tag = "scipio-2020-09-11" }
 uring-sys = { git = "https://github.com/glommer/uring-sys", tag = "scipio-2020-09-10" }
-nix = "0.16.0"
+nix = "0.19.0"
 aligned_alloc = "0.1"
 bitmaps = "2.1.0"
 typenum = "1.12"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -32,6 +32,7 @@ enclose = "1.1.8"
 scopeguard = "1.1.0"
 pin-project-lite = "0.1.10"
 smallvec = "1.4.2"
+buddy-alloc = "0.4.1"
 ahash = "0.5.8"
 
 [dev-dependencies]

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -73,7 +73,7 @@
 //!
 //! [`BufferedFile`]: struct.BufferedFile.html
 //! [`DmaFile`]: struct.DmaFile.html
-//! [`DmaBuffer`]: type.DmaBuffer.html
+//! [`DmaBuffer`]: struct.DmaBuffer.html
 //! [`DmaStreamWriter`]: struct.DmaStreamWriter.html
 //! [`DmaStreamReader`]: struct.DmaStreamReader.html
 //! [`AsyncReadExt`]: https://docs.rs/futures-lite/1.11.1/futures_lite/io/trait.AsyncReadExt.html

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -245,8 +245,8 @@ pub(crate) struct Reactor {
 }
 
 impl Reactor {
-    pub(crate) fn new() -> Reactor {
-        let sys = sys::Reactor::new().expect("cannot initialize I/O event notification");
+    pub(crate) fn new(io_memory: usize) -> Reactor {
+        let sys = sys::Reactor::new(io_memory).expect("cannot initialize I/O event notification");
         let (preempt_ptr_head, preempt_ptr_tail) = sys.preempt_pointers();
         Reactor {
             sys,

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -42,7 +42,7 @@ use std::time::{Duration, Instant};
 use futures_lite::*;
 
 use crate::sys;
-use crate::sys::{DmaBuffer, IOBuffer, PollableStatus, Source, SourceType};
+use crate::sys::{DirectIO, DmaBuffer, IOBuffer, PollableStatus, Source, SourceType};
 use crate::IoRequirements;
 use crate::Local;
 
@@ -319,7 +319,10 @@ impl Reactor {
     pub(crate) fn write_buffered(&self, raw: RawFd, buf: Vec<u8>, pos: u64) -> Source {
         let source = self.new_source(
             raw,
-            SourceType::Write(PollableStatus::NonPollable, IOBuffer::Buffered(buf)),
+            SourceType::Write(
+                PollableStatus::NonPollable(DirectIO::Disabled),
+                IOBuffer::Buffered(buf),
+            ),
         );
         self.sys.write_buffered(&source, pos);
         source
@@ -338,7 +341,10 @@ impl Reactor {
     }
 
     pub(crate) fn read_buffered(&self, raw: RawFd, pos: u64, size: usize) -> Source {
-        let source = self.new_source(raw, SourceType::Read(PollableStatus::NonPollable, None));
+        let source = self.new_source(
+            raw,
+            SourceType::Read(PollableStatus::NonPollable(DirectIO::Disabled), None),
+        );
         self.sys.read_buffered(&source, pos, size);
         source
     }

--- a/glommio/src/sys/dma_buffer.rs
+++ b/glommio/src/sys/dma_buffer.rs
@@ -65,24 +65,31 @@ impl BufferStorage {
 }
 
 #[derive(Debug)]
-pub struct PosixDmaBuffer {
+/// A buffer suitable for Direct I/O over io_uring
+///
+/// Direct I/O has strict requirements about alignment. On top of that, io_uring places additional
+/// restrictions on memory placement if we are to use advanced features like registered buffers.
+///
+/// The `DmaBuffer` is a buffer that adheres to those properties making it suitable for io_uring's
+/// Direct I/O.
+pub struct DmaBuffer {
     storage: BufferStorage,
     // Invariant: trim + size are at most one byte past the original allocation.
     trim: usize,
     size: usize,
 }
 
-impl PosixDmaBuffer {
-    pub(crate) fn new(size: usize) -> Option<PosixDmaBuffer> {
-        Some(PosixDmaBuffer {
+impl DmaBuffer {
+    pub(crate) fn new(size: usize) -> Option<DmaBuffer> {
+        Some(DmaBuffer {
             storage: BufferStorage::Sys(SysAlloc::new(size)?),
             size,
             trim: 0,
         })
     }
 
-    pub(crate) fn with_storage(size: usize, storage: BufferStorage) -> PosixDmaBuffer {
-        PosixDmaBuffer {
+    pub(crate) fn with_storage(size: usize, storage: BufferStorage) -> DmaBuffer {
+        DmaBuffer {
             storage,
             size,
             trim: 0,
@@ -107,26 +114,66 @@ impl PosixDmaBuffer {
         self.size -= trim;
     }
 
+    /// Returns a representation of the current addressable contents of this `DmaBuffer` as a byte
+    /// slice
     pub fn as_bytes(&self) -> &[u8] {
         unsafe { std::slice::from_raw_parts(self.as_ptr(), self.size) }
     }
 
+    /// Returns a representation of the current addressable contents of this `DmaBuffer` as a
+    /// mutable byte slice
     pub fn as_bytes_mut(&mut self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.as_mut_ptr(), self.size) }
     }
 
+    /// Returns the current number of bytes present in the addressable contents of this `DmaBuffer`
     pub fn len(&self) -> usize {
         self.size
     }
 
+    /// Indicates whether or not this buffer is empty. An empty buffer can be, for instance, the
+    /// result of a read past the end of a file.
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+
+    /// Returns a representation of the current addressable contents of this `DmaBuffer` as mutable
+    /// pointer
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         unsafe { self.storage.as_mut_ptr().add(self.trim) }
     }
 
+    /// Returns a representation of the current addressable contents of this `DmaBuffer` as pointer
     pub fn as_ptr(&self) -> *const u8 {
         unsafe { self.storage.as_ptr().add(self.trim) }
     }
 
+    /// Reads data from this buffer into a user-provided byte slice, starting at a particular
+    /// offset
+    ///
+    /// ## Returns
+    ///
+    /// The amount of bytes read.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use glommio::LocalExecutor;
+    /// use glommio::io::DmaFile;
+    ///
+    /// let ex = LocalExecutor::make_default();
+    /// ex.run(async {
+    ///     let file = DmaFile::create("test.txt").await.unwrap();
+    ///     let buf = file.alloc_dma_buffer(4096);
+    ///     let mut vec = vec![0; 64];
+    ///     let n = buf.read_at(0, &mut vec);
+    ///     assert_eq!(n, 64); // read 64 bytes, the size of the buffer
+    ///
+    ///     let n = buf.read_at(4090, &mut vec);
+    ///     assert_eq!(n, 6);  // read 6 bytes, as there are only 6 bytes left from this offset
+    ///     file.close().await.unwrap();
+    /// });
+    /// ```
     pub fn read_at(&self, offset: usize, dst: &mut [u8]) -> usize {
         if offset > self.size {
             return 0;
@@ -137,6 +184,32 @@ impl PosixDmaBuffer {
         len
     }
 
+    /// Writes data to this buffer from a user-provided byte slice, starting at a particular
+    /// offset
+    ///
+    /// ## Returns
+    ///
+    /// The amount of bytes written.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use glommio::LocalExecutor;
+    /// use glommio::io::DmaFile;
+    ///
+    /// let ex = LocalExecutor::make_default();
+    /// ex.run(async {
+    ///     let file = DmaFile::create("test.txt").await.unwrap();
+    ///     let mut buf = file.alloc_dma_buffer(4096);
+    ///     let vec = vec![1; 64];
+    ///     let n = buf.write_at(0, &vec);
+    ///     assert_eq!(n, 64); // wrote 64 bytes.
+    ///
+    ///     let n = buf.write_at(4090, &vec);
+    ///     assert_eq!(n, 6);  // wrote 6 bytes, as there are only 6 bytes left from this offset
+    ///     file.close().await.unwrap();
+    /// });
+    /// ```
     pub fn write_at(&mut self, offset: usize, src: &[u8]) -> usize {
         if offset > self.size {
             return 0;
@@ -147,6 +220,7 @@ impl PosixDmaBuffer {
         len
     }
 
+    /// Writes the specified value into all bytes of this buffer
     pub fn memset(&mut self, value: u8) {
         unsafe { std::ptr::write_bytes(self.as_mut_ptr(), value, self.size) }
     }

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -103,20 +103,17 @@ fn cstr(path: &Path) -> io::Result<CString> {
     Ok(CString::new(path.as_os_str().as_bytes())?)
 }
 
-mod posix_buffers;
+mod dma_buffer;
 pub(crate) mod sysfs;
 mod uring;
 
-pub use self::posix_buffers::*;
+pub use self::dma_buffer::DmaBuffer;
 pub(crate) use self::uring::*;
 use crate::IoRequirements;
 
-/// A buffer that can be used with DmaFile.
-pub type DmaBuffer = PosixDmaBuffer;
-
 #[derive(Debug)]
 pub(crate) enum IOBuffer {
-    Dma(PosixDmaBuffer),
+    Dma(DmaBuffer),
     Buffered(Vec<u8>),
 }
 

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -120,14 +120,22 @@ pub(crate) enum IOBuffer {
     Buffered(Vec<u8>),
 }
 
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum DirectIO {
+    Enabled,
+    Disabled,
+}
+
 // You can be NonPollable and Buffered: that is the case for a Direct I/O file
 // dispatched, say, on a RAID array (RAID do not currently support Poll, but it
 // happily supports Direct I/O). So this is a 2 x 2 = 4 Matrix of possibilibies
 // meaning we can't conflate Pollable and the buffer type.
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum PollableStatus {
+    // The pollable ring only supports Direct I/O, so always true.
     Pollable,
-    NonPollable,
+    // Non pollable can go either way
+    NonPollable(DirectIO),
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -3,7 +3,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
-use nix::poll::PollFlags;
+use iou::PollFlags;
 use rlimit::Resource;
 use std::cell::{Cell, Ref, RefCell};
 use std::collections::VecDeque;

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -3,24 +3,29 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
+use alloc::alloc::Layout;
 use iou::PollFlags;
+use log::warn;
 use rlimit::Resource;
 use std::cell::{Cell, Ref, RefCell};
 use std::collections::VecDeque;
 use std::ffi::CStr;
+use std::fmt;
 use std::io;
-use std::io::{Error, ErrorKind};
+use std::io::{Error, ErrorKind, IoSlice};
 use std::os::unix::io::RawFd;
+use std::ptr;
 use std::rc::Rc;
 use std::task::Waker;
 use std::time::Duration;
 
 use crate::free_list::{FreeList, Idx};
-use crate::sys::posix_buffers::PosixDmaBuffer;
+use crate::sys::posix_buffers::{BufferStorage, PosixDmaBuffer};
 use crate::sys::{
     self, DirectIO, IOBuffer, InnerSource, LinkStatus, PollableStatus, Source, SourceType,
 };
 use crate::{IoRequirements, Latency};
+use buddy_alloc::buddy_alloc::{BuddyAlloc, BuddyAllocParam};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -61,6 +66,118 @@ struct UringDescriptor {
     fd: RawFd,
     user_data: u64,
     args: UringOpDescriptor,
+}
+
+pub(crate) struct UringBufferAllocator {
+    data: ptr::NonNull<u8>,
+    size: usize,
+    allocator: RefCell<BuddyAlloc>,
+    layout: Layout,
+    uring_buffer_id: Cell<Option<usize>>,
+}
+
+impl fmt::Debug for UringBufferAllocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UringBufferAllocator")
+            .field("data", &self.data)
+            .finish()
+    }
+}
+
+impl UringBufferAllocator {
+    fn new(size: usize) -> Self {
+        let layout = Layout::from_size_align(size, 4096).unwrap();
+        let (data, allocator) = unsafe {
+            let data = alloc::alloc::alloc(layout) as *mut u8;
+            let data = std::ptr::NonNull::new(data).unwrap();
+            let allocator = BuddyAlloc::new(BuddyAllocParam::new(
+                data.as_ptr(),
+                layout.size(),
+                layout.align(),
+            ));
+            (data, RefCell::new(allocator))
+        };
+
+        UringBufferAllocator {
+            data,
+            size,
+            allocator,
+            layout,
+            uring_buffer_id: Cell::new(None),
+        }
+    }
+
+    fn activate_registered_buffers(&self, idx: usize) {
+        self.uring_buffer_id.set(Some(idx))
+    }
+
+    fn free(&self, ptr: ptr::NonNull<u8>) {
+        let mut allocator = self.allocator.borrow_mut();
+        allocator.free(ptr.as_ptr() as *mut u8);
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.data.as_ptr(), self.size) }
+    }
+
+    fn new_buffer(self: &Rc<Self>, size: usize) -> Option<PosixDmaBuffer> {
+        let mut alloc = self.allocator.borrow_mut();
+        match ptr::NonNull::new(alloc.malloc(size)) {
+            Some(data) => {
+                let ub = UringBuffer {
+                    allocator: self.clone(),
+                    data,
+                    uring_buffer_id: self.uring_buffer_id.get(),
+                };
+                Some(PosixDmaBuffer::with_storage(size, BufferStorage::Uring(ub)))
+            }
+            None => PosixDmaBuffer::new(size),
+        }
+    }
+}
+
+impl Drop for UringBufferAllocator {
+    fn drop(&mut self) {
+        unsafe {
+            alloc::alloc::dealloc(self.data.as_ptr(), self.layout);
+        }
+    }
+}
+
+pub(crate) struct UringBuffer {
+    allocator: Rc<UringBufferAllocator>,
+    data: ptr::NonNull<u8>,
+    uring_buffer_id: Option<usize>,
+}
+
+impl fmt::Debug for UringBuffer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UringBuffer")
+            .field("data", &self.data)
+            .field("uring_buffer_id", &self.uring_buffer_id)
+            .finish()
+    }
+}
+
+impl UringBuffer {
+    pub(crate) fn as_ptr(&self) -> *const u8 {
+        self.data.as_ptr()
+    }
+
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.data.as_ptr()
+    }
+
+    pub(crate) fn uring_buffer_id(&self) -> Option<usize> {
+        self.uring_buffer_id
+    }
+}
+
+impl Drop for UringBuffer {
+    fn drop(&mut self) {
+        let ptr = self.data;
+        self.allocator.free(ptr);
+    }
 }
 
 fn check_supported_operations(ops: &[uring_sys::IoRingOp]) -> bool {
@@ -187,23 +304,31 @@ where
             }
             UringOpDescriptor::ReadFixed(pos, len) => {
                 let mut buf = buffer_allocation(len).expect("Buffer allocation failed");
-                //let slabidx = buf.slabidx;
-
-                //sqe.prep_read_fixed(op.fd, buf.as_mut_bytes(), pos, slabidx);
-                sqe.prep_read(op.fd, buf.as_bytes_mut(), pos);
                 let src = peek_source(from_user_data(op.user_data));
 
-                if let SourceType::Read(_, slot) = &mut *src.source_type.borrow_mut() {
-                    *slot = Some(IOBuffer::Dma(buf));
-                } else {
-                    panic!("Expected DmaRead source type");
+                match &mut *src.source_type.borrow_mut() {
+                    SourceType::Read(PollableStatus::NonPollable(DirectIO::Disabled), slot) => {
+                        sqe.prep_read(op.fd, buf.as_bytes_mut(), pos);
+                        *slot = Some(IOBuffer::Dma(buf));
+                    }
+                    SourceType::Read(_, slot) => {
+                        match buf.uring_buffer_id() {
+                            None => {
+                                sqe.prep_read(op.fd, buf.as_bytes_mut(), pos);
+                            }
+                            Some(idx) => {
+                                sqe.prep_read_fixed(op.fd, buf.as_bytes_mut(), pos, idx);
+                            }
+                        };
+                        *slot = Some(IOBuffer::Dma(buf));
+                    }
+                    _ => unreachable!(),
                 };
             }
 
-            UringOpDescriptor::WriteFixed(ptr, len, pos, _) => {
+            UringOpDescriptor::WriteFixed(ptr, len, pos, buf_index) => {
                 let buf = std::slice::from_raw_parts(ptr, len);
-                //sqe.prep_write_fixed(op.fd, buf, pos, buf_index);
-                sqe.prep_write(op.fd, buf, pos);
+                sqe.prep_write_fixed(op.fd, buf, pos, buf_index);
             }
         }
     }
@@ -326,6 +451,7 @@ trait UringCommon {
     fn submit_one_event(&mut self, queue: &mut VecDeque<UringDescriptor>) -> Option<bool>;
     fn consume_one_event(&mut self, wakers: &mut Vec<Waker>) -> Option<()>;
     fn name(&self) -> &'static str;
+    fn registrar(&self) -> iou::Registrar<'_>;
 
     fn consume_sqe_queue(
         &mut self,
@@ -406,17 +532,18 @@ struct PollRing {
     submission_queue: ReactorQueue,
     submitted: u64,
     completed: u64,
+    allocator: Rc<UringBufferAllocator>,
 }
 
 impl PollRing {
-    fn new(size: usize) -> io::Result<Self> {
+    fn new(size: usize, allocator: Rc<UringBufferAllocator>) -> io::Result<Self> {
         let ring = iou::IoUring::new_with_flags(size as _, iou::SetupFlags::IOPOLL)?;
-
         Ok(PollRing {
             submitted: 0,
             completed: 0,
             ring,
             submission_queue: UringQueueState::with_capacity(size * 4),
+            allocator,
         })
     }
 
@@ -425,13 +552,17 @@ impl PollRing {
     }
 
     pub(crate) fn alloc_dma_buffer(&mut self, size: usize) -> DmaBuffer {
-        PosixDmaBuffer::new(size).expect("Buffer allocation failed")
+        self.allocator.new_buffer(size).unwrap()
     }
 }
 
 impl UringCommon for PollRing {
     fn name(&self) -> &'static str {
         "poll"
+    }
+
+    fn registrar(&self) -> iou::Registrar<'_> {
+        self.ring.registrar()
     }
 
     fn needs_kernel_enter(&self) -> bool {
@@ -469,14 +600,8 @@ impl UringCommon for PollRing {
         if let Some(mut sqe) = self.ring.next_sqe() {
             self.submitted += 1;
             let op = queue.pop_front().unwrap();
-            fill_sqe(&mut sqe, &op, |size| {
-                /* FIXME: uring registered buffers need more work...
-                let b = buffers.clone();
-                let arena = buffers[b.len() - 1].clone();
-                arena.alloc_buffer(size)
-                */
-                PosixDmaBuffer::new(size)
-            });
+            let allocator = self.allocator.clone();
+            fill_sqe(&mut sqe, &op, move |size| allocator.new_buffer(size));
             Some(true)
         } else {
             None
@@ -552,10 +677,15 @@ struct SleepableRing {
     submission_queue: ReactorQueue,
     waiting_submission: usize,
     name: &'static str,
+    allocator: Rc<UringBufferAllocator>,
 }
 
 impl SleepableRing {
-    fn new(size: usize, name: &'static str) -> io::Result<Self> {
+    fn new(
+        size: usize,
+        name: &'static str,
+        allocator: Rc<UringBufferAllocator>,
+    ) -> io::Result<Self> {
         assert_eq!(*IO_URING_RECENT_ENOUGH, true);
         Ok(SleepableRing {
             //     ring: iou::IoUring::new_with_flags(size as _, iou::SetupFlags::IOPOLL)?,
@@ -563,6 +693,7 @@ impl SleepableRing {
             submission_queue: UringQueueState::with_capacity(size * 4),
             waiting_submission: 0,
             name,
+            allocator,
         })
     }
 
@@ -668,6 +799,10 @@ impl UringCommon for SleepableRing {
         self.name
     }
 
+    fn registrar(&self) -> iou::Registrar<'_> {
+        self.ring.registrar()
+    }
+
     fn needs_kernel_enter(&self) -> bool {
         self.waiting_submission > 0
     }
@@ -708,7 +843,8 @@ impl UringCommon for SleepableRing {
         if let Some(mut sqe) = self.ring.next_sqe() {
             self.waiting_submission += 1;
             let op = queue.pop_front().unwrap();
-            fill_sqe(&mut sqe, &op, PosixDmaBuffer::new);
+            let allocator = self.allocator.clone();
+            fill_sqe(&mut sqe, &op, move |size| allocator.new_buffer(size));
             return Some(true);
         }
         None
@@ -775,8 +911,12 @@ macro_rules! flush_rings {
     }}
 }
 
+fn align_up(v: usize, align: usize) -> usize {
+    (v + align - 1) & !(align - 1)
+}
+
 impl Reactor {
-    pub(crate) fn new() -> io::Result<Reactor> {
+    pub(crate) fn new(mut io_memory: usize) -> io::Result<Reactor> {
         const MIN_MEMLOCK_LIMIT: u64 = 512 * 1024;
         let (memlock_limit, _) = Resource::MEMLOCK.get()?;
         if memlock_limit < MIN_MEMLOCK_LIMIT {
@@ -788,8 +928,37 @@ impl Reactor {
                 ),
             ));
         }
-        let mut main_ring = SleepableRing::new(128, "main")?;
-        let latency_ring = SleepableRing::new(128, "latency")?;
+
+        // always have at least some small amount of memory for the slab
+        io_memory = std::cmp::max(align_up(io_memory, 4096), 65536);
+
+        let allocator = Rc::new(UringBufferAllocator::new(io_memory));
+        let registry = vec![IoSlice::new(allocator.as_bytes())];
+
+        let mut main_ring = SleepableRing::new(128, "main", allocator.clone())?;
+        let poll_ring = PollRing::new(128, allocator.clone())?;
+
+        match main_ring.registrar().register_buffers(&registry) {
+            Err(x) => warn!(
+                "Error: registering buffers in the main ring. Skipping{:#?}",
+                x
+            ),
+            Ok(_) => match poll_ring.registrar().register_buffers(&registry) {
+                Err(x) => {
+                    warn!(
+                        "Error: registering buffers in the poll ring. Skipping{:#?}",
+                        x
+                    );
+                    main_ring.registrar().unregister_buffers().unwrap();
+                }
+                Ok(_) => {
+                    allocator.activate_registered_buffers(0);
+                }
+            },
+        }
+
+        let latency_ring = SleepableRing::new(128, "latency", allocator.clone())?;
+
         let link_fd = latency_ring.ring_fd();
         let link_rings_src = Source::new(
             IoRequirements::default(),
@@ -808,7 +977,7 @@ impl Reactor {
         Ok(Reactor {
             main_ring: RefCell::new(main_ring),
             latency_ring: RefCell::new(latency_ring),
-            poll_ring: RefCell::new(PollRing::new(128)?),
+            poll_ring: RefCell::new(poll_ring),
             link_rings_src: RefCell::new(link_rings_src),
             timeout_src: Cell::new(None),
             _eventfd: eventfd,
@@ -839,13 +1008,18 @@ impl Reactor {
     }
 
     pub(crate) fn write_dma(&self, source: &Source, pos: u64) {
-        match &*source.source_type() {
-            SourceType::Write(_, IOBuffer::Dma(buf)) => {
-                let op = UringOpDescriptor::WriteFixed(buf.as_ptr(), buf.len(), pos, 0);
-                self.queue_storage_io_request(source, op);
-            }
+        let op = match &*source.source_type() {
+            SourceType::Write(
+                PollableStatus::NonPollable(DirectIO::Disabled),
+                IOBuffer::Dma(buf),
+            ) => UringOpDescriptor::Write(buf.as_ptr(), buf.len(), pos),
+            SourceType::Write(_, IOBuffer::Dma(buf)) => match buf.uring_buffer_id() {
+                Some(id) => UringOpDescriptor::WriteFixed(buf.as_ptr(), buf.len(), pos, id),
+                None => UringOpDescriptor::Write(buf.as_ptr(), buf.len(), pos),
+            },
             x => panic!("Unexpected source type for write: {:?}", x),
-        }
+        };
+        self.queue_storage_io_request(source, op);
     }
 
     pub(crate) fn write_buffered(&self, source: &Source, pos: u64) {
@@ -1085,7 +1259,7 @@ mod tests {
 
     #[test]
     fn timeout_smoke_test() {
-        let reactor = Reactor::new().unwrap();
+        let reactor = Reactor::new(0).unwrap();
 
         fn timeout_source(millis: u64) -> (Source, UringOpDescriptor) {
             let source = Source::new(
@@ -1121,5 +1295,58 @@ mod tests {
         reactor.wait(&mut wakers, None, None, |_| 0).unwrap();
         let elapsed_ms = start.elapsed().as_millis();
         assert!(300 <= elapsed_ms && elapsed_ms < 350);
+    }
+
+    #[test]
+    fn allocator() {
+        let l = Layout::from_size_align(10 << 20, 4 << 10).unwrap();
+        let mut allocator = unsafe {
+            let data = alloc::alloc::alloc(l) as *mut u8;
+            assert_eq!(data as usize & 4095, 0);
+            let data = std::ptr::NonNull::new(data).unwrap();
+            BuddyAlloc::new(BuddyAllocParam::new(data.as_ptr(), l.size(), l.align()))
+        };
+        let x = allocator.malloc(4096);
+        assert_eq!(x as usize & 4095, 0);
+        let x = allocator.malloc(1024);
+        assert_eq!(x as usize & 4095, 0);
+        let x = allocator.malloc(1);
+        assert_eq!(x as usize & 4095, 0);
+    }
+
+    #[test]
+    fn allocator_exhaustion() {
+        // The allocator fails with a single page, because it needs extra metadata
+        // space
+        let al = Rc::new(UringBufferAllocator::new(8192));
+        al.activate_registered_buffers(1234);
+        let x = al.new_buffer(4096).unwrap();
+        let y = al.new_buffer(4096).unwrap();
+
+        match x.uring_buffer_id() {
+            Some(x) => assert_eq!(x, 1234),
+            None => panic!("Expected uring buffer"),
+        }
+
+        match y.uring_buffer_id() {
+            Some(_) => panic!("Expected non-uring buffer"),
+            None => {}
+        }
+        drop(x);
+        drop(y);
+
+        // memory is back, able to allocate again
+        let x = al.new_buffer(4096).unwrap();
+        match x.uring_buffer_id() {
+            Some(x) => assert_eq!(x, 1234),
+            None => panic!("Expected uring buffer"),
+        }
+        drop(x);
+        // Allocation for an object that is too big fails
+        let x = al.new_buffer(40960).unwrap();
+        match x.uring_buffer_id() {
+            Some(_) => panic!("Expected non-uring buffer"),
+            None => {}
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR introduces support for io_uring's registered buffers.
Registered buffers is a feature that allows the application to pre-register a memory area to be used by Direct I/O.

### Motivation

Axboe did.

### Related issues

 The first couple of patches are in other PRs (https://github.com/DataDog/glommio/pull/173) and (https://github.com/DataDog/glommio/pull/171) are sent separately and are independent, but removing them causes conflicts. I will merge those first.

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
