### PR TITLE
use cargo deadlinks to validate links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,9 @@ jobs:
           name: Version information
           command: rustc --version; cargo --version; rustup --version
       - run:
+          name: Install cargo-deadlinks
+          command: cargo install cargo-deadlinks
+      - run:
           name: Calculate dependencies
           command: cargo generate-lockfile
       - restore_cache:
@@ -70,6 +73,9 @@ jobs:
       - run:
           name: Generate documentation
           command: cargo doc --all-features
+      - run:
+          name: Validate links
+          command: cargo deadlinks --dir target/doc/glommio
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/glommio/src/channels/mod.rs
+++ b/glommio/src/channels/mod.rs
@@ -50,7 +50,7 @@ mod spsc_queue;
 /// [`TaskQueue`]: ../../struct.TaskQueueHandle.html
 /// [`LocalSender`]: struct.LocalSender.html
 /// [`LocalReceiver`]: struct.LocalReceiver.html
-/// [`ChannelError`]: struct.ChannelError.html
+/// [`ChannelError`]: ../struct.ChannelError.html
 /// [`push`]: struct.LocalSender.html#method.push
 /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
 /// [`BrokenPipe`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.BrokenPipe
@@ -127,7 +127,7 @@ pub mod local_channel;
 /// ex1.join().unwrap();
 /// ex2.join().unwrap();
 /// ```
-/// [`ChannelError`]: struct.ChannelError.html
+/// [`ChannelError`]: ../struct.ChannelError.html
 /// [`ConnectedSender`]: struct.ConnectedSender.html
 /// [`ConnectedReceiver`]: struct.ConnectedReceiver.html
 /// [`SharedSender`]: struct.SharedSender.html

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -139,7 +139,7 @@ impl<T: Send + Sized + Copy> ConnectedSender<T> {
     /// [`BrokenPipe`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.BrokenPipe
     /// [`WouldBlock`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.WouldBlock
     /// [`Other`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.Other
-    /// [`ChannelError`]: struct.ChannelError.html
+    /// [`ChannelError`]: ../struct.ChannelError.html
     pub fn try_send(&self, item: T) -> Result<(), ChannelError<T>> {
         // This is a shared channel so state can change under our noses.
         // We test if the buffer is disconnected before sending to avoid


### PR DESCRIPTION
Very predictably we have inserted new deadlinks as time went by.
Time to add cargo deadlinks.

To make sure it passes, fix the broken links we currently have.

Closes #125 