### PR TITLE
Change buffered read API

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,10 @@ futures = "0.3.5"
 futures-lite = "1.11.1"
 ansi_term = "0.12.1"
 glommio = { version = "0.2.0", path = "../glommio" }
+pretty-bytes = "0.2.2"
+clap = "2.33"
+sys-info = "0.7.0"
+fastrand = "1.4.0"
 
 [[example]]
 name = "echo"
@@ -33,3 +37,7 @@ path = "cooperative_preempt.rs"
 [[example]]
 name = "deadline"
 path = "deadline_writer.rs"
+
+[[example]]
+name = "storage"
+path = "storage.rs"

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -1,0 +1,326 @@
+use clap::{App, Arg};
+use futures_lite::stream::{self, StreamExt};
+use futures_lite::{AsyncReadExt, AsyncWriteExt};
+use glommio::io::{
+    BufferedFile, DmaFile, DmaStreamReader, DmaStreamReaderBuilder, DmaStreamWriterBuilder,
+    StreamReaderBuilder, StreamWriterBuilder,
+};
+use glommio::{enclose, Local, LocalExecutorBuilder};
+use pretty_bytes::converter;
+use std::cell::Cell;
+use std::fs;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+struct BenchDirectory {
+    path: PathBuf,
+}
+
+impl Drop for BenchDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+impl BenchDirectory {
+    fn new(path: PathBuf) -> Self {
+        fs::create_dir_all(&path).unwrap();
+        BenchDirectory { path }
+    }
+}
+
+async fn stream_write<T: AsyncWriteExt + std::marker::Unpin, S: Into<String>>(
+    mut stream: T,
+    name: S,
+    file_size: u64,
+) {
+    let contents = vec![1; 512 << 10];
+    let start = Instant::now();
+    for _ in 0..(file_size / (contents.len() as u64)) {
+        stream.write_all(&contents).await.unwrap();
+    }
+    let name = name.into();
+
+    let endw = Instant::now();
+    let time = start.elapsed();
+    let bytes = converter::convert(file_size as _);
+    let rate = converter::convert((file_size as f64 / time.as_secs_f64()) as _);
+    println!("{}: Wrote {} in {:#?}, {}/s", &name, bytes, time, rate);
+    stream.close().await.unwrap();
+    let rate = converter::convert((file_size as f64 / start.elapsed().as_secs_f64()) as _);
+    let time = endw.elapsed();
+    println!(
+        "{}: Closed in {:#?}, Amortized total {}/s",
+        &name, time, rate
+    );
+}
+
+async fn stream_scan<T: AsyncReadExt + std::marker::Unpin, S: Into<String>>(
+    mut stream: T,
+    name: S,
+) -> T {
+    let mut buf = vec![0; 4 << 10];
+    let expected = vec![1; 4 << 10];
+    let mut bytes_read = 0;
+    let mut ops = 0;
+
+    let start = Instant::now();
+    loop {
+        let res = stream.read(&mut buf).await.unwrap();
+        bytes_read += res;
+        ops += 1;
+        if res == 0 {
+            break;
+        }
+        assert_eq!(expected, buf);
+    }
+    let time = start.elapsed();
+    let name = name.into();
+
+    let bytes = converter::convert(bytes_read as _);
+    let rate = converter::convert((bytes_read as f64 / time.as_secs_f64()) as _);
+    println!(
+        "{}: Scanned {} in {:#?}, {}/s, {} IOPS",
+        &name,
+        bytes,
+        time,
+        rate,
+        (ops as f64 / time.as_secs_f64()) as usize
+    );
+    stream
+}
+
+async fn stream_scan_alt_api<S: Into<String>>(
+    mut stream: DmaStreamReader,
+    name: S,
+    buffer_size: usize,
+) {
+    let mut expected = Vec::with_capacity(buffer_size);
+    expected.resize(buffer_size, 1u8);
+
+    let mut bytes_read = 0;
+    let mut ops = 0;
+
+    let start = Instant::now();
+    loop {
+        let buffer = stream.get_buffer_aligned(buffer_size as _).await.unwrap();
+        bytes_read += buffer.len();
+        ops += 1;
+        if buffer.len() < buffer_size {
+            break;
+        }
+        assert_eq!(expected, buffer.as_bytes());
+    }
+    let time = start.elapsed();
+    let name = name.into();
+
+    let bytes = converter::convert(bytes_read as _);
+    let rate = converter::convert((bytes_read as f64 / time.as_secs_f64()) as _);
+    println!(
+        "{}: Scanned {} in {:#?}, {}/s, {} IOPS",
+        &name,
+        bytes,
+        time,
+        rate,
+        (ops as f64 / time.as_secs_f64()) as usize
+    );
+    stream.close().await.unwrap();
+}
+
+enum Reader {
+    Direct(DmaFile),
+    Buffered(BufferedFile),
+}
+
+impl Reader {
+    async fn read(&self, pos: u64, io_size: u64, expected: &[u8]) {
+        match &self {
+            Reader::Direct(file) => {
+                let res = file.read_at_aligned(pos, io_size as _).await.unwrap();
+                assert_eq!(expected, res.as_bytes());
+            }
+            Reader::Buffered(file) => {
+                let res = file.read_at(pos, io_size as _).await.unwrap();
+                assert_eq!(expected, res.as_bytes());
+            }
+        }
+    }
+
+    async fn close(self) {
+        match self {
+            Reader::Direct(file) => {
+                file.close().await.unwrap();
+            }
+            Reader::Buffered(file) => {
+                file.close().await.unwrap();
+            }
+        }
+    }
+}
+
+async fn random_read<S: Into<String>>(
+    file: Reader,
+    name: S,
+    random: u64,
+    parallelism: usize,
+    io_size: u64,
+) {
+    let end = (random / io_size) - 1;
+    let name = name.into();
+    let mut expected = Vec::with_capacity(io_size as _);
+    expected.resize(io_size as _, 1);
+
+    let file = Rc::new(file);
+    let iops = Rc::new(Cell::new(0));
+
+    let time = Instant::now();
+    let mut tasks = Vec::new();
+    for _ in 0..parallelism {
+        tasks.push(
+            Local::local(enclose! { (file, iops, expected) async move {
+                while time.elapsed() < Duration::from_secs(20) {
+                    let pos = fastrand::u64(0..end);
+                    file.read(pos * io_size, io_size as _, &expected).await;
+                    iops.set(iops.get() + 1);
+                }
+            }})
+            .detach(),
+        );
+    }
+
+    let finished = stream::iter(tasks).then(|f| f).count().await;
+
+    match Rc::try_unwrap(file) {
+        Err(_) => unreachable!(),
+        Ok(file) => file.close().await,
+    };
+
+    assert_eq!(finished, parallelism as _);
+    let bytes = converter::convert(random as _);
+    let dur = time.elapsed();
+    println!(
+        "{}: Random Read (uniform) size span of {}, for {:#?}, {} IOPS",
+        &name,
+        bytes,
+        dur,
+        (iops.get() as f64 / dur.as_secs_f64()) as usize
+    );
+}
+
+fn main() {
+    let matches = App::new("storage example")
+        .version("0.1.0")
+        .author("Glauber Costa <glauber@datadoghq.com>")
+        .about("demonstrate glommio's storage APIs")
+        .arg(
+            Arg::with_name("storage_dir")
+                .long("dir")
+                .takes_value(true)
+                .required(true)
+                .help("The directory where to write and read file for this test"),
+        )
+        .arg(
+            Arg::with_name("file_size")
+                .long("size-gb")
+                .takes_value(true)
+                .required(false)
+                .help("size of the file in GB (default: 2 * memory_size)"),
+        )
+        .get_matches();
+
+    let path = matches.value_of("storage_dir").unwrap();
+    let mut dir = PathBuf::from(path);
+    assert!(dir.exists());
+    dir.push("benchfiles");
+    assert!(!dir.exists());
+    let dir = BenchDirectory::new(dir);
+
+    let total_memory = sys_info::mem_info().unwrap().total << 10;
+
+    let file_size = matches
+        .value_of("file_size")
+        .and_then(|s| Some(s.parse::<u64>().unwrap() << 30))
+        .unwrap_or(total_memory * 2);
+
+    let random = total_memory / 10;
+
+    let local_ex = LocalExecutorBuilder::new()
+        .pin_to_cpu(0)
+        .spin_before_park(Duration::from_millis(10))
+        .spawn(move || async move {
+            let mut dio_filename = dir.path.clone();
+            dio_filename.push("benchfile-dio-1");
+
+            let mut buf_filename = dir.path.clone();
+            buf_filename.push("benchfile-buf-1");
+
+            let file = BufferedFile::create(&buf_filename).await.unwrap();
+            let stream = StreamWriterBuilder::new(file).build();
+            stream_write(stream, "Buffered I/O", file_size).await;
+
+            let file = DmaFile::create(&dio_filename).await.unwrap();
+            let stream = DmaStreamWriterBuilder::new(file)
+                .with_write_behind(1)
+                .with_buffer_size(512 << 10)
+                .build();
+            stream_write(stream, "Direct I/O", file_size).await;
+
+            let file = DmaFile::create(&dio_filename).await.unwrap();
+            let stream = DmaStreamWriterBuilder::new(file)
+                .with_write_behind(10)
+                .with_buffer_size(512 << 10)
+                .build();
+            stream_write(stream, "Direct I/O, write-behind", file_size).await;
+
+            let file = BufferedFile::open(&buf_filename).await.unwrap();
+            let stream = StreamReaderBuilder::new(file).build();
+            let stream = stream_scan(stream, "Buffered I/O").await;
+            stream.close().await.unwrap();
+
+            let file = DmaFile::open(&dio_filename).await.unwrap();
+            let stream = DmaStreamReaderBuilder::new(file)
+                .with_read_ahead(1)
+                .with_buffer_size(4 << 10)
+                .build();
+            let stream = stream_scan(stream, "Direct I/O").await;
+            stream.close().await.unwrap();
+
+            let file = DmaFile::open(&dio_filename).await.unwrap();
+            let stream = DmaStreamReaderBuilder::new(file)
+                .with_read_ahead(50)
+                .with_buffer_size(4 << 10)
+                .build();
+            let stream = stream_scan(stream, "Direct I/O, read ahead").await;
+            stream.close().await.unwrap();
+
+            let file = DmaFile::open(&dio_filename).await.unwrap();
+            let stream = DmaStreamReaderBuilder::new(file)
+                .with_read_ahead(50)
+                .with_buffer_size(4 << 10)
+                .build();
+            stream_scan_alt_api(stream, "Direct I/O, glommio API", 4 << 10).await;
+
+            let file = DmaFile::open(&dio_filename).await.unwrap();
+            let stream = DmaStreamReaderBuilder::new(file)
+                .with_read_ahead(10)
+                .with_buffer_size(512 << 10)
+                .build();
+            stream_scan_alt_api(stream, "Direct I/O, glommio API, large buffer", 512 << 10).await;
+
+            let file = BufferedFile::open(&buf_filename).await.unwrap();
+            random_read(Reader::Buffered(file), "Buffered I/O", random, 50, 4096).await;
+
+            let file = DmaFile::open(&dio_filename).await.unwrap();
+            random_read(Reader::Direct(file), "Direct I/O", random, 50, 4096).await;
+
+            let file = BufferedFile::open(&buf_filename).await.unwrap();
+            random_read(Reader::Buffered(file), "Buffered I/O", file_size, 50, 4096).await;
+
+            let file = DmaFile::open(&dio_filename).await.unwrap();
+            random_read(Reader::Direct(file), "Direct I/O", file_size, 50, 4096).await;
+        })
+        .unwrap();
+
+    local_ex.join().unwrap();
+}

--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -5,6 +5,7 @@
 //
 
 use crate::io::glommio_file::GlommioFile;
+use crate::io::read_result::ReadResult;
 use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
@@ -121,19 +122,13 @@ impl BufferedFile {
         enhanced_try!(source.collect_rw().await, "Writing", self.file)
     }
 
-    /// Reads data at the specified position into the user-provided buffer `buf`.
-    ///
-    /// Note that this differs from [`DmaFile`]'s read APIs: that reflects the
-    /// fact that buffered reads need no specific alignment and io_uring will not
-    /// be able to use its own pre-allocated buffers for it anyway.
-    ///
-    /// [`DmaFile`]: struct.DmaFile.html
-    pub async fn read_at(&self, pos: u64, size: usize) -> io::Result<Vec<u8>> {
+    /// Reads from a specific position in the file and returns the buffer.
+    pub async fn read_at(&self, pos: u64, size: usize) -> io::Result<ReadResult> {
         let mut source = self.file.reactor.read_buffered(self.as_raw_fd(), pos, size);
         let read_size = enhanced_try!(source.collect_rw().await, "Reading", self.file)?;
-        let mut buffer = source.extract_buffer();
-        buffer.truncate(read_size);
-        Ok(buffer)
+        let mut buffer = source.extract_dma_buffer();
+        buffer.trim_to_size(read_size);
+        Ok(ReadResult::from_whole_buffer(buffer))
     }
 
     /// Issues fdatasync into the underlying file.
@@ -256,18 +251,18 @@ mod test {
 
         let rb = reader.read_at(0, 6).await.unwrap();
         assert_eq!(rb.len(), 6);
-        check_contents!(rb, 0);
+        check_contents!(rb.as_bytes(), 0);
 
         // Can read again from the same position
         let rb = reader.read_at(0, 6).await.unwrap();
         assert_eq!(rb.len(), 6);
-        check_contents!(rb, 0);
+        check_contents!(rb.as_bytes(), 0);
 
         // Can read again from a random, unaligned position, and will hit
         // EOF.
         let rb = reader.read_at(3, 6).await.unwrap();
         assert_eq!(rb.len(), 3);
-        check_contents!(rb[0..3], 3);
+        check_contents!(rb.as_bytes()[0..3], 3);
 
         writer.close().await.unwrap();
         reader.close().await.unwrap();
@@ -287,13 +282,13 @@ mod test {
 
         let rb = reader.read_at(0, 6).await.unwrap();
         assert_eq!(rb.len(), 6);
-        for i in rb {
-            assert_eq!(i, 0);
+        for i in rb.as_bytes() {
+            assert_eq!(*i, 0);
         }
 
         let rb = reader.read_at(10, 6).await.unwrap();
         assert_eq!(rb.len(), 6);
-        check_contents!(rb, 0);
+        check_contents!(rb.as_bytes(), 0);
 
         writer.close().await.unwrap();
         reader.close().await.unwrap();

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -5,7 +5,7 @@
 
 use crate::io::BufferedFile;
 use crate::parking::Reactor;
-use crate::sys::Source;
+use crate::sys::{DmaBuffer, Source};
 use crate::Local;
 use futures_lite::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, SeekFrom};
 use futures_lite::ready;
@@ -157,6 +157,12 @@ impl Buffer {
     fn replace_buffer(&mut self, buf: Vec<u8>) {
         self.buffer_pos = 0;
         self.data = buf;
+    }
+
+    fn replenish_buffer(&mut self, buf: DmaBuffer) {
+        self.buffer_pos = 0;
+        self.data.resize(buf.len(), 0u8);
+        buf.read_at(0, &mut self.data);
     }
 
     fn remaining_unconsumed_bytes(&self) -> usize {
@@ -524,14 +530,14 @@ impl AsyncBufRead for StreamReader {
                 match res {
                     Err(x) => Poll::Ready(Err(x)),
                     Ok(sz) => {
-                        let mut buf = source.extract_buffer();
+                        let mut buf = source.extract_dma_buffer();
                         let old_pos = self.file_pos;
                         let new_pos = std::cmp::min(old_pos + sz as u64, self.max_pos);
                         let added_size = new_pos - old_pos;
                         self.file_pos += added_size;
-                        buf.truncate(added_size as usize);
+                        buf.trim_to_size(added_size as usize);
 
-                        self.buffer.replace_buffer(buf);
+                        self.buffer.replenish_buffer(buf);
                         let this = self.project();
                         Poll::Ready(Ok(&this.buffer.unconsumed_bytes()))
                     }
@@ -615,9 +621,9 @@ impl AsyncBufRead for Stdin {
                 match res {
                     Err(x) => Poll::Ready(Err(x)),
                     Ok(sz) => {
-                        let mut buf = source.extract_buffer();
-                        buf.truncate(sz);
-                        self.buffer.replace_buffer(buf);
+                        let mut buf = source.extract_dma_buffer();
+                        buf.trim_to_size(sz);
+                        self.buffer.replenish_buffer(buf);
                         let this = self.project();
                         Poll::Ready(Ok(&this.buffer.unconsumed_bytes()))
                     }


### PR DESCRIPTION
### What does this PR do?

Changes the buffered read API so that it returns a DmaBuffer too (actually a `ReadResult`)
Those buffers won't be registered but will come from our internal buddy allocator, which is a lot faster than the system's allocator for this.

At this point, we should probably change the `DmaBuffer` name. However because Buffered writes still won't use them and
they are internal to `ReadResult` we will leave it be.

I am also attaching a benchmark that I have used to measure that, and in general inform my latest iterations of changes.
The benchmark is by now mature ready to go.
