### PR TITLE
update ci to a newer toolset and disable cargo deadlinks temporarily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
-# Scipio Circle-CI configuration file
+# Glommio Circle-CI configuration file
 
 version: 2
 
 jobs:
   cargobuild:
     docker:
-      - image: circleci/rust:1.46.0
+      - image: circleci/rust:1.48.0
     steps:
       - checkout
       - run:
@@ -30,7 +30,7 @@ jobs:
 
   cargofmt:
     docker:
-      - image: circleci/rust:1.46.0
+      - image: circleci/rust:1.48.0
     steps:
       - checkout
       - run:
@@ -55,7 +55,7 @@ jobs:
 
   cargodoc:
     docker:
-      - image: circleci/rust:1.46.0
+      - image: circleci/rust:1.48.0
     steps:
       - checkout
       - run:
@@ -73,9 +73,10 @@ jobs:
       - run:
           name: Generate documentation
           command: cargo doc --all-features
-      - run:
-          name: Validate links
-          command: cargo deadlinks --dir target/doc/glommio
+          # temporarily disabled.
+          # - run:
+          # name: Validate links
+          # command: cargo deadlinks --dir target/doc/glommio
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/glommio/src/channels/local_channel.rs
+++ b/glommio/src/channels/local_channel.rs
@@ -222,7 +222,7 @@ impl<T> LocalSender<T> {
     /// });
     /// ```
     ///
-    /// [`send`]: struct.LocalSender.html#method.send
+    /// [`try_send`]: struct.LocalSender.html#method.try_send
     pub async fn send(&self, item: T) -> Result<(), ChannelError<T>> {
         if !self.is_full() {
             self.try_send(item)
@@ -366,6 +366,7 @@ impl<T> LocalReceiver<T> {
     /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
     /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
     /// [`StreamExt`]: https://docs.rs/futures-lite/1.11.2/futures_lite/stream/index.html
+    /// [`next`]: https://docs.rs/futures-lite/1.11.2/futures_lite/stream/trait.StreamExt.html#method.next
     /// [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
     pub async fn recv(&self) -> Option<T> {
         let waiter = future::poll_fn(|cx| self.recv_one(cx));

--- a/glommio/src/channels/mod.rs
+++ b/glommio/src/channels/mod.rs
@@ -22,7 +22,7 @@ mod spsc_queue;
 ///
 /// * The [`LocalReceiver`] never sees an error, as it is implemented as a stream
 ///   interface compatible with [`StreamExt`]. When the sender is no longer available the receiver's call to [`next`] will return [`None`].
-/// * The [`LocalSender`] will return a [`ChannelError`] encapsulating a [`BrokenPipe`] error if it tries to [`push`] into
+/// * The [`LocalSender`] will return a [`ChannelError`] encapsulating a [`BrokenPipe`] error if it tries to [`send`] into
 ///   a channel that no longer has a receiver.
 ///
 /// # Examples
@@ -51,7 +51,7 @@ mod spsc_queue;
 /// [`LocalSender`]: struct.LocalSender.html
 /// [`LocalReceiver`]: struct.LocalReceiver.html
 /// [`ChannelError`]: ../struct.ChannelError.html
-/// [`push`]: struct.LocalSender.html#method.push
+/// [`send`]: struct.LocalSender.html#method.send
 /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
 /// [`BrokenPipe`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.BrokenPipe
 /// [`channel`]: https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -260,6 +260,7 @@ impl<T: Send + Sized + Copy> ConnectedReceiver<T> {
     /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
     /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
     /// [`StreamExt`]: https://docs.rs/futures-lite/1.11.2/futures_lite/stream/index.html
+    /// [`next`]: https://docs.rs/futures-lite/1.11.2/futures_lite/stream/trait.StreamExt.html#method.next
     /// [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
     pub async fn recv(&self) -> Option<T> {
         let waiter = future::poll_fn(|cx| self.recv_one(cx));

--- a/glommio/src/controllers/deadline_queue.rs
+++ b/glommio/src/controllers/deadline_queue.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant};
 pub trait DeadlineSource {
     /// What type is returned by the [`action`] method
     ///
-    /// [`action`]: trait.DeadlineSource.html#method.action
+    /// [`action`]: trait.DeadlineSource.html#tymethod.action
     type Output;
 
     /// Returns a [`Duration`] indicating when we would like this operation to complete.
@@ -58,7 +58,7 @@ pub trait DeadlineSource {
     /// add it to the queue and increase its total units as the buffer is written to. This can
     /// lead to smoother operation as opposed to just adding a lot of units at once.
     ///
-    /// [`processed_units`]: trait.DeadlineSource.html#method.processed_units
+    /// [`processed_units`]: trait.DeadlineSource.html#tymethod.processed_units
     fn total_units(&self) -> u64;
 
     /// The amount of units that were already processed.
@@ -70,7 +70,7 @@ pub trait DeadlineSource {
     /// For example, you can buffer all updates and just inform that processed_units == total_units
     /// at the end of the process, but then the controller would be a step function.
     ///
-    /// [`total_units`]: trait.DeadlineSource.html#method.total_units
+    /// [`total_units`]: trait.DeadlineSource.html#tymethod.total_units
     fn processed_units(&self) -> u64;
 }
 

--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -514,7 +514,7 @@ impl LocalExecutorBuilder {
     ///
     /// [`LocalExecutorBuilder`]: struct.LocalExecutorBuilder.html
     ///
-    /// [`LocalExecutorBuilder::make`]: struct.LocalExecutor.html#method.make
+    /// [`LocalExecutorBuilder::make`]: struct.LocalExecutorBuilder.html#method.make
     ///
     /// [`LocalExecutor::run`]:struct.LocalExecutor.html#method.run
     #[must_use = "This spawns an executor on a thread, so you must acquire its handle and then join() to keep it alive"]

--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -76,7 +76,7 @@ impl BufferedFile {
         let flags = libc::O_CLOEXEC | libc::O_CREAT | libc::O_TRUNC | libc::O_WRONLY;
         Ok(BufferedFile {
             file: enhanced_try!(
-                GlommioFile::open_at(-1 as _, path.as_ref(), flags, 0o644).await,
+                GlommioFile::open_at(-1_i32, path.as_ref(), flags, 0o644).await,
                 "Creating",
                 Some(path.as_ref()),
                 None
@@ -91,7 +91,7 @@ impl BufferedFile {
         let flags = libc::O_CLOEXEC | libc::O_RDONLY;
         Ok(BufferedFile {
             file: enhanced_try!(
-                GlommioFile::open_at(-1 as _, path.as_ref(), flags, 0o644).await,
+                GlommioFile::open_at(-1_i32, path.as_ref(), flags, 0o644).await,
                 "Reading",
                 Some(path.as_ref()),
                 None

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -146,7 +146,7 @@ impl DmaFile {
         // try to open the file with O_DIRECT if the underlying media supports it
         let flags =
             libc::O_DIRECT | libc::O_CLOEXEC | libc::O_CREAT | libc::O_TRUNC | libc::O_WRONLY;
-        let res = DmaFile::open_at(-1 as _, path.as_ref(), flags, 0o644).await;
+        let res = DmaFile::open_at(-1_i32, path.as_ref(), flags, 0o644).await;
 
         let mut f = enhanced_try!(res, "Creating", Some(path.as_ref()), None)?;
         f.o_direct_alignment = 4096;
@@ -157,7 +157,7 @@ impl DmaFile {
     pub async fn open<P: AsRef<Path>>(path: P) -> io::Result<DmaFile> {
         // try to open the file with O_DIRECT if the underlying media supports it
         let flags = libc::O_DIRECT | libc::O_CLOEXEC | libc::O_RDONLY;
-        let res = DmaFile::open_at(-1 as _, path.as_ref(), flags, 0o644).await;
+        let res = DmaFile::open_at(-1_i32, path.as_ref(), flags, 0o644).await;
 
         let mut f = enhanced_try!(res, "Opening", Some(path.as_ref()), None)?;
         f.o_direct_alignment = 512;

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -453,7 +453,7 @@ impl DmaStreamReader {
     ///
     /// [`DmaStreamReader`]: struct.DmaStreamReader.html
     /// [`DmaStreamReaderBuilder`]: struct.DmaStreamReaderBuilder.html
-    /// [`AsyncReadExt`]: https://docs.rs/futures/0.3.5/futures/io/trait.AsyncReadExt.html
+    /// [`AsyncReadExt`]: https://docs.rs/futures-lite/1.11.2/futures_lite/io/trait.AsyncReadExt.html
     /// [`ReadResult`]: struct.ReadResult.html
     pub async fn get_buffer_aligned(&mut self, len: u64) -> io::Result<ReadResult> {
         if len == 0 {

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -74,8 +74,8 @@
 //! [`DmaBuffer`]: struct.DmaBuffer.html
 //! [`DmaStreamWriter`]: struct.DmaStreamWriter.html
 //! [`DmaStreamReader`]: struct.DmaStreamReader.html
-//! [`AsyncReadExt`]: ../../futures_lite/io/trait.AsyncReadExt.html
-//! [`AsyncWriteExt`]: ../../futures_lite/io/trait.AsyncReadExt.html
+//! [`AsyncReadExt`]: https://docs.rs/futures-lite/1.11.2/futures_lite/io/trait.AsyncReadExt.html
+//! [`AsyncWriteExt`]: https://docs.rs/futures-lite/1.11.2/futures_lite/io/trait.AsyncWriteExt.html
 
 macro_rules! enhanced_try {
     ($expr:expr, $op:expr, $path:expr, $fd:expr) => {{

--- a/glommio/src/io/read_result.rs
+++ b/glommio/src/io/read_result.rs
@@ -9,10 +9,10 @@ use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 /// ReadResult encapsulates a buffer, returned by read operations like [`get_buffer_aligned`] and
-/// [`read_dma`]
+/// [`read_at`]
 ///
-/// [`get_buffer_aligned`]: struct.StreamReader.html#method.get_buffer_aligned
-/// [`read_dma`]: struct.DmaFile.html#method.read_dma
+/// [`get_buffer_aligned`]: struct.DmaStreamReader.html#method.get_buffer_aligned
+/// [`read_at`]: struct.DmaFile.html#method.read_at
 pub struct ReadResult {
     buffer: Option<Rc<DmaBuffer>>,
     offset: usize,

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -110,7 +110,6 @@
 //! * [async-io](https://github.com/stjepang/async-io)
 //! * [async-task](https://github.com/stjepang/async-task)
 //! * [async-executor](https://github.com/stjepang/async-executor)
-//! * [multitask](https://github.com/stjepang/async-multitask)
 //!
 //! Aside from Stjepan's work, this is also inspired greatly by the [Seastar](http://seastar.io)
 //! Framework for C++ that powers I/O intensive systems that are pushing the performance envelope,

--- a/glommio/src/sync/rwlock.rs
+++ b/glommio/src/sync/rwlock.rs
@@ -79,8 +79,11 @@ impl Debug for LockClosedError {
     }
 }
 
-///Error which indicates reason of the error returned by [`try_read`] and ['try_write'] methods
-///on ['RwLock']
+/// Error which indicates reason of the error returned by [`try_read`] and ['try_write'] methods
+/// on ['RwLock']
+///
+/// [`try_read`]: struct.RwLock.html#method.try_read
+/// [`try_write`]: struct.RwLock.html#method.try_write
 pub enum TryLockError {
     ///Lock is closed and can not be used to request access to the lock
     Closed(LockClosedError),


### PR DESCRIPTION
In preparation to use the beta channel I am updating the CI image.
Also running the beta locally, plus a newer cargo deadlinks, it
catches some new issues that it didn't catch before.

The ones that look like real issues I am fixing.

But cargo deadlinks is now complaining about missing snippets that we
don't even refer to in other crates, like this:

Found invalid urls in io/struct.DmaStreamReader.html:
	Fragment #method.poll_read_vectored at /home/glauber/glommio/target/doc/futures_io/if_std/trait.AsyncRead.html does not exist!

This might even be a cargo deadlinks issue. Even if we are doing
something wrong, we'll just delay this for now and I am unfortunately
disabling cargo deadlinks until this can pass locally. Otherwise everyone
gets blocked.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
