### PR TITLE
Preventing Semaphore keeping of duplicates of wakers

### DIFF
--- a/glommio/src/sync/rwlock.rs
+++ b/glommio/src/sync/rwlock.rs
@@ -289,12 +289,22 @@ impl State {
         debug_assert!(!(self.readers > 0 && self.writers > 0));
 
         let entry = self.waiters_map.entry(id);
-        if let Vacant(entry) = entry {
-            entry.insert((kind, waker));
-            self.waiters.push_back(id);
+        match entry {
+            Vacant(entry) => {
+                entry.insert((kind, waker));
+                self.waiters.push_back(id);
 
-            if kind == WaiterKind::WRITER {
-                self.queued_writers += 1;
+                if kind == WaiterKind::WRITER {
+                    self.queued_writers += 1;
+                }
+            }
+            Occupied(mut entry) => {
+                if cfg!(debug_assert) {
+                    let (stored_kind, _) = entry.get();
+                    assert_eq!(*stored_kind, kind);
+                }
+
+                *entry.get_mut() = (kind, waker);
             }
         }
     }
@@ -843,6 +853,10 @@ mod test {
     use crate::sync::rwlock::LockClosedError;
     use crate::sync::rwlock::RwLock;
     use crate::sync::rwlock::TryLockError;
+    use crate::timer::Timer;
+    use crate::LocalExecutor;
+    use crate::Task;
+    use std::time::Duration;
 
     use crate::sync::Semaphore;
     use crate::Local;
@@ -1223,5 +1237,39 @@ mod test {
             Err(LockClosedError) => (),
             Ok(_) => panic!("get_mut of closed lock is Ok"),
         }
+    }
+
+    #[test]
+    fn rwlock_overflow() {
+        let ex = LocalExecutor::make_default();
+
+        let lock = Rc::new(RwLock::new(()));
+        let c_lock = lock.clone();
+
+        let cond = Rc::new(RefCell::new(0));
+        let c_cond = cond.clone();
+
+        let semaphore = Rc::new(Semaphore::new(0));
+        let c_semaphore = semaphore.clone();
+
+        ex.spawn(async move {
+            c_semaphore.acquire(1).await.unwrap();
+
+            let _g = c_lock.read().await.unwrap();
+            wait_on_cond!(c_cond, 1);
+
+            for _ in 0..100 {
+                Timer::new(Duration::from_micros(100)).await;
+            }
+
+            assert_eq!(c_lock.rw.borrow().waiters.len(), 1);
+        })
+        .detach();
+
+        ex.run(async move {
+            semaphore.signal(1);
+            *cond.borrow_mut() = 1;
+            let _ = lock.write().await.unwrap();
+        })
     }
 }


### PR DESCRIPTION
### What does this PR do?
Because LocalExecutor checks readiness of root future by using loop-pooling without the help of wakers there are could be situations when Semaphore future can be pooled many times generating an excessive amount of wakers stored in the waiting queue. This simple code 

```
        let ex = LocalExecutor::make_default();
        let semaphore = Rc::new(Semaphore::new(0));
        let semaphore_c = semaphore.clone();

        ex.spawn(async move {
            for _ in 0..100 {
                Timer::new(Duration::from_micros(100)).await;
            }
            assert_eq!(1, semaphore_c.state.borrow().list.len());

            semaphore_c.signal(1);
        })
        .detach();

        ex.run(async move {
            let _ = semaphore.acquire(1).await.unwrap();
        });
```

ends up with :
1. 10K of waiters registered inside of Semaphore.
2. Panic on the call of the release method.
  
RwLock does not have such problems but it keeps the earliest weaker to wake up the fiber but the good practice is to keep the latest one. This part also was implemented.

### Motivation

What inspired you to submit this pull request? - My desire to increase the stability of glommio 

### Checklist

[x] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
