### PR TITLE
Sync+Send was removed from the task.

### DIFF
--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -80,9 +80,6 @@ pub struct Task<T> {
     pub(crate) _marker: PhantomData<T>,
 }
 
-unsafe impl<T> Send for Task<T> {}
-unsafe impl<T> Sync for Task<T> {}
-
 impl<T> Task<T> {
     /// Schedules the task.
     ///


### PR DESCRIPTION
### What does this PR do?

Removes Send and Sync markers from the Task

### Motivation
It is incorrect to mark Task to be Send and Sync because underlying Future and tag are not marked to be Send and Sync.

### Additional Notes

1. async-task does mark Task as Send+Sync but it is directly noted in Task::spawn_local method's documentation that usage of the task which holds not thread-safe Future and tag in a different thread will cause a panic. 
2. It opens the gates to replace the atomic state field but it requires additional investigation. 

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
