### PR TITLE
Dma file stream

### DIFF
--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -77,7 +77,7 @@ impl DmaStreamReaderBuilder {
             start: 0,
             end: u64::MAX,
             buffer_size: 128 << 10,
-            read_ahead: 1,
+            read_ahead: 4,
             file,
         }
     }
@@ -622,7 +622,7 @@ impl DmaStreamWriterBuilder {
     pub fn new(file: DmaFile) -> DmaStreamWriterBuilder {
         DmaStreamWriterBuilder {
             buffer_size: 128 << 10,
-            write_behind: 1,
+            write_behind: 4,
             flush_on_close: true,
             file: Rc::new(file),
         }

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -179,7 +179,7 @@ impl DmaStreamReaderState {
     }
 
     fn replenish_read_ahead(&mut self, state: Rc<RefCell<Self>>, file: Rc<DmaFile>) {
-        while self.buffermap.len() + self.pending.len() < self.read_ahead {
+        for _ in self.buffermap.len() + self.pending.len()..self.read_ahead {
             self.fill_buffer(state.clone(), file.clone());
         }
     }


### PR DESCRIPTION
Improvements to the DmaStreamReader API and implementation
- a bug is fixed with user-defined premature EoF
- there is a now a constructor that takes an Rc
- default for read ahead is increased (and write behind changed to match)