### PR TITLE
state field of Task's state machine was changed from AtomicUsize to usize

### DIFF
--- a/glommio/src/task/header.rs
+++ b/glommio/src/task/header.rs
@@ -4,9 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
 use core::alloc::Layout;
-use core::cell::UnsafeCell;
 use core::fmt;
-use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task::Waker;
 
 use crate::task::raw::TaskVTable;
@@ -20,12 +18,12 @@ pub(crate) struct Header {
     /// Current state of the task.
     ///
     /// Contains flags representing the current state and the reference count.
-    pub(crate) state: AtomicUsize,
+    pub(crate) state: usize,
 
     /// The task that is blocked on the `JoinHandle`.
     ///
     /// This waker needs to be woken up once the task completes or is closed.
-    pub(crate) awaiter: UnsafeCell<Option<Waker>>,
+    pub(crate) awaiter: Option<Waker>,
 
     /// The virtual table.
     ///
@@ -39,53 +37,34 @@ impl Header {
     ///
     /// This method will mark the task as closed, but it won't reschedule the task or drop its
     /// future.
-    pub(crate) fn cancel(&self) {
-        let mut state = self.state.load(Ordering::Acquire);
-
-        loop {
-            // If the task has been completed or closed, it can't be canceled.
-            if state & (COMPLETED | CLOSED) != 0 {
-                break;
-            }
-
-            // Mark the task as closed.
-            match self.state.compare_exchange_weak(
-                state,
-                state | CLOSED,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => break,
-                Err(s) => state = s,
-            }
+    pub(crate) fn cancel(&mut self) {
+        // If the task has been completed or closed, it can't be canceled.
+        if self.state & (COMPLETED | CLOSED) != 0 {
+            return;
         }
+
+        // Mark the task as closed.
+        self.state |= CLOSED;
     }
 
     /// Notifies the awaiter blocked on this task.
     ///
     /// If the awaiter is the same as the current waker, it will not be notified.
     #[inline]
-    pub(crate) fn notify(&self, current: Option<&Waker>) {
-        // Mark the awaiter as being notified.
-        let state = self.state.fetch_or(NOTIFYING, Ordering::AcqRel);
+    pub(crate) fn notify(&mut self, current: Option<&Waker>) {
+        // Take the waker out.
+        let waker = self.awaiter.take();
 
-        // If the awaiter was not being notified nor registered...
-        if state & (NOTIFYING | REGISTERING) == 0 {
-            // Take the waker out.
-            let waker = unsafe { (*self.awaiter.get()).take() };
+        // Mark the state as not being notified anymore nor containing an awaiter.
+        self.state &= !AWAITER;
 
-            // Mark the state as not being notified anymore nor containing an awaiter.
-            self.state
-                .fetch_and(!NOTIFYING & !AWAITER, Ordering::Release);
-
-            if let Some(w) = waker {
-                // We need a safeguard against panics because waking can panic.
-                abort_on_panic(|| match current {
-                    None => w.wake(),
-                    Some(c) if !w.will_wake(c) => w.wake(),
-                    Some(_) => {}
-                });
-            }
+        if let Some(w) = waker {
+            // We need a safeguard against panics because waking can panic.
+            abort_on_panic(|| match current {
+                None => w.wake(),
+                Some(c) if !w.will_wake(c) => w.wake(),
+                Some(_) => {}
+            });
         }
     }
 
@@ -93,75 +72,11 @@ impl Header {
     ///
     /// This method is called when `JoinHandle` is polled and the task has not completed.
     #[inline]
-    pub(crate) fn register(&self, waker: &Waker) {
-        // Load the state and synchronize with it.
-        let mut state = self.state.fetch_or(0, Ordering::Acquire);
-
-        loop {
-            // There can't be two concurrent registrations because `JoinHandle` can only be polled
-            // by a unique pinned reference.
-            debug_assert!(state & REGISTERING == 0);
-
-            // If we're in the notifying state at this moment, just wake and return without
-            // registering.
-            if state & NOTIFYING != 0 {
-                abort_on_panic(|| waker.wake_by_ref());
-                return;
-            }
-
-            // Mark the state to let other threads know we're registering a new awaiter.
-            match self.state.compare_exchange_weak(
-                state,
-                state | REGISTERING,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => {
-                    state |= REGISTERING;
-                    break;
-                }
-                Err(s) => state = s,
-            }
-        }
-
+    pub(crate) fn register(&mut self, waker: &Waker) {
         // Put the waker into the awaiter field.
-        unsafe {
-            abort_on_panic(|| (*self.awaiter.get()) = Some(waker.clone()));
-        }
+        abort_on_panic(|| self.awaiter = Some(waker.clone()));
 
-        // This variable will contain the newly registered waker if a notification comes in before
-        // we complete registration.
-        let mut waker = None;
-
-        loop {
-            // If there was a notification, take the waker out of the awaiter field.
-            if state & NOTIFYING != 0 {
-                if let Some(w) = unsafe { (*self.awaiter.get()).take() } {
-                    abort_on_panic(|| waker = Some(w));
-                }
-            }
-
-            // The new state is not being notified nor registered, but there might or might not be
-            // an awaiter depending on whether there was a concurrent notification.
-            let new = if waker.is_none() {
-                (state & !NOTIFYING & !REGISTERING) | AWAITER
-            } else {
-                state & !NOTIFYING & !REGISTERING & !AWAITER
-            };
-
-            match self
-                .state
-                .compare_exchange_weak(state, new, Ordering::AcqRel, Ordering::Acquire)
-            {
-                Ok(_) => break,
-                Err(s) => state = s,
-            }
-        }
-
-        // If there was a notification during registration, wake the awaiter now.
-        if let Some(w) = waker {
-            abort_on_panic(|| w.wake());
-        }
+        self.state |= AWAITER;
     }
 
     /// Returns the offset at which the tag of type `T` is stored.
@@ -176,7 +91,7 @@ impl Header {
 
 impl fmt::Debug for Header {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let state = self.state.load(Ordering::SeqCst);
+        let state = self.state;
 
         f.debug_struct("Header")
             .field("scheduled", &(state & SCHEDULED != 0))

--- a/glommio/src/task/join_handle.rs
+++ b/glommio/src/task/join_handle.rs
@@ -8,7 +8,6 @@ use core::future::Future;
 use core::marker::{PhantomData, Unpin};
 use core::pin::Pin;
 use core::ptr::NonNull;
-use core::sync::atomic::Ordering;
 use core::task::{Context, Poll, Waker};
 
 use crate::task::header::Header;
@@ -28,9 +27,6 @@ pub struct JoinHandle<R, T> {
     pub(crate) _marker: PhantomData<(R, T)>,
 }
 
-unsafe impl<R: Send, T> Send for JoinHandle<R, T> {}
-unsafe impl<R, T> Sync for JoinHandle<R, T> {}
-
 impl<R, T> Unpin for JoinHandle<R, T> {}
 
 impl<R, T> JoinHandle<R, T> {
@@ -41,47 +37,33 @@ impl<R, T> JoinHandle<R, T> {
     /// When a task is canceled, its future will not be polled again.
     pub fn cancel(&self) {
         let ptr = self.raw_task.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *mut Header;
 
         unsafe {
-            let mut state = (*header).state.load(Ordering::Acquire);
+            let state = (*header).state;
 
-            loop {
-                // If the task has been completed or closed, it can't be canceled.
-                if state & (COMPLETED | CLOSED) != 0 {
-                    break;
-                }
+            // If the task has been completed or closed, it can't be canceled.
+            if state & (COMPLETED | CLOSED) != 0 {
+                return;
+            }
 
-                // If the task is not scheduled nor running, we'll need to schedule it.
-                let new = if state & (SCHEDULED | RUNNING) == 0 {
-                    (state | SCHEDULED | CLOSED) + REFERENCE
-                } else {
-                    state | CLOSED
-                };
+            // If the task is not scheduled nor running, we'll need to schedule it.
+            let new = if state & (SCHEDULED | RUNNING) == 0 {
+                (state | SCHEDULED | CLOSED) + REFERENCE
+            } else {
+                state | CLOSED
+            };
 
-                // Mark the task as closed.
-                match (*header).state.compare_exchange_weak(
-                    state,
-                    new,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                ) {
-                    Ok(_) => {
-                        // If the task is not scheduled nor running, schedule it one more time so
-                        // that its future gets dropped by the executor.
-                        if state & (SCHEDULED | RUNNING) == 0 {
-                            ((*header).vtable.schedule)(ptr);
-                        }
+            // Mark the task as closed.
+            (*header).state = new;
 
-                        // Notify the awaiter that the task has been closed.
-                        if state & AWAITER != 0 {
-                            (*header).notify(None);
-                        }
+            if state & (SCHEDULED | RUNNING) == 0 {
+                ((*header).vtable.schedule)(ptr);
+            }
 
-                        break;
-                    }
-                    Err(s) => state = s,
-                }
+            // Notify the awaiter that the task has been closed.
+            if state & AWAITER != 0 {
+                (*header).notify(None);
             }
         }
     }
@@ -112,7 +94,7 @@ impl<R, T> JoinHandle<R, T> {
 impl<R, T> Drop for JoinHandle<R, T> {
     fn drop(&mut self) {
         let ptr = self.raw_task.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *mut Header;
 
         // A place where the output will be stored in case it needs to be dropped.
         let mut output = None;
@@ -121,71 +103,49 @@ impl<R, T> Drop for JoinHandle<R, T> {
             // Optimistically assume the `JoinHandle` is being dropped just after creating the
             // task. This is a common case so if the handle is not used, the overhead of it is only
             // one compare-exchange operation.
-            if let Err(mut state) = (*header).state.compare_exchange_weak(
-                SCHEDULED | HANDLE | REFERENCE,
-                SCHEDULED | REFERENCE,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                loop {
-                    // If the task has been completed but not yet closed, that means its output
-                    // must be dropped.
-                    if state & COMPLETED != 0 && state & CLOSED == 0 {
-                        // Mark the task as closed in order to grab its output.
-                        match (*header).state.compare_exchange_weak(
-                            state,
-                            state | CLOSED,
-                            Ordering::AcqRel,
-                            Ordering::Acquire,
-                        ) {
-                            Ok(_) => {
-                                // Read the output.
-                                output =
-                                    Some((((*header).vtable.get_output)(ptr) as *mut R).read());
+            if (*header).state == SCHEDULED | HANDLE | REFERENCE {
+                (*header).state = SCHEDULED | REFERENCE;
+                return;
+            }
 
-                                // Update the state variable because we're continuing the loop.
-                                state |= CLOSED;
-                            }
-                            Err(s) => state = s,
-                        }
+            let state = (*header).state;
+            // If the task has been completed but not yet closed, that means its output
+            // must be dropped.
+            if state & COMPLETED != 0 && state & CLOSED == 0 {
+                // Mark the task as closed in order to grab its output.
+                (*header).state |= CLOSED;
+                // Read the output.
+                output = Some((((*header).vtable.get_output)(ptr) as *mut R).read());
+
+                (*header).state &= !HANDLE;
+
+                // If this is the last reference to the task, we need to destroy it.
+                if state & !(REFERENCE - 1) == 0 {
+                    ((*header).vtable.destroy)(ptr)
+                }
+            } else {
+                // If this is the last reference to the task and it's not closed, then
+                // close it and schedule one more time so that its future gets dropped by
+                // the executor.
+                let new = if state & (!(REFERENCE - 1) | CLOSED) == 0 {
+                    SCHEDULED | CLOSED | REFERENCE
+                } else {
+                    state & !HANDLE
+                };
+
+                (*header).state = new;
+                // If this is the last reference to the task, we need to either
+                // schedule dropping its future or destroy it.
+                if state & !(REFERENCE - 1) == 0 {
+                    if state & CLOSED == 0 {
+                        ((*header).vtable.schedule)(ptr);
                     } else {
-                        // If this is the last reference to the task and it's not closed, then
-                        // close it and schedule one more time so that its future gets dropped by
-                        // the executor.
-                        let new = if state & (!(REFERENCE - 1) | CLOSED) == 0 {
-                            SCHEDULED | CLOSED | REFERENCE
-                        } else {
-                            state & !HANDLE
-                        };
-
-                        // Unset the handle flag.
-                        match (*header).state.compare_exchange_weak(
-                            state,
-                            new,
-                            Ordering::AcqRel,
-                            Ordering::Acquire,
-                        ) {
-                            Ok(_) => {
-                                // If this is the last reference to the task, we need to either
-                                // schedule dropping its future or destroy it.
-                                if state & !(REFERENCE - 1) == 0 {
-                                    if state & CLOSED == 0 {
-                                        ((*header).vtable.schedule)(ptr);
-                                    } else {
-                                        ((*header).vtable.destroy)(ptr);
-                                    }
-                                }
-
-                                break;
-                            }
-                            Err(s) => state = s,
-                        }
+                        ((*header).vtable.destroy)(ptr);
                     }
                 }
             }
         }
 
-        // Drop the output if it was taken out of the task.
         drop(output);
     }
 }
@@ -195,78 +155,46 @@ impl<R, T> Future for JoinHandle<R, T> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let ptr = self.raw_task.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *mut Header;
 
         unsafe {
-            let mut state = (*header).state.load(Ordering::Acquire);
+            let state = (*header).state;
 
-            loop {
-                // If the task has been closed, notify the awaiter and return `None`.
-                if state & CLOSED != 0 {
-                    // If the task is scheduled or running, we need to wait until its future is
-                    // dropped.
-                    if state & (SCHEDULED | RUNNING) != 0 {
-                        // Replace the waker with one associated with the current task.
-                        (*header).register(cx.waker());
-
-                        // Reload the state after registering. It is possible changes occurred just
-                        // before registration so we need to check for that.
-                        state = (*header).state.load(Ordering::Acquire);
-
-                        // If the task is still scheduled or running, we need to wait because its
-                        // future is not dropped yet.
-                        if state & (SCHEDULED | RUNNING) != 0 {
-                            return Poll::Pending;
-                        }
-                    }
-
-                    // Even though the awaiter is most likely the current task, it could also be
-                    // another task.
-                    (*header).notify(Some(cx.waker()));
-                    return Poll::Ready(None);
-                }
-
-                // If the task is not completed, register the current task.
-                if state & COMPLETED == 0 {
+            // If the task has been closed, notify the awaiter and return `None`.
+            if state & CLOSED != 0 {
+                // If the task is scheduled or running, we need to wait until its future is
+                // dropped.
+                if state & (SCHEDULED | RUNNING) != 0 {
                     // Replace the waker with one associated with the current task.
                     (*header).register(cx.waker());
-
-                    // Reload the state after registering. It is possible that the task became
-                    // completed or closed just before registration so we need to check for that.
-                    state = (*header).state.load(Ordering::Acquire);
-
-                    // If the task has been closed, restart.
-                    if state & CLOSED != 0 {
-                        continue;
-                    }
-
-                    // If the task is still not completed, we're blocked on it.
-                    if state & COMPLETED == 0 {
-                        return Poll::Pending;
-                    }
+                    return Poll::Pending;
                 }
 
-                // Since the task is now completed, mark it as closed in order to grab its output.
-                match (*header).state.compare_exchange(
-                    state,
-                    state | CLOSED,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                ) {
-                    Ok(_) => {
-                        // Notify the awaiter. Even though the awaiter is most likely the current
-                        // task, it could also be another task.
-                        if state & AWAITER != 0 {
-                            (*header).notify(Some(cx.waker()));
-                        }
-
-                        // Take the output from the task.
-                        let output = ((*header).vtable.get_output)(ptr) as *mut R;
-                        return Poll::Ready(Some(output.read()));
-                    }
-                    Err(s) => state = s,
-                }
+                // Even though the awaiter is most likely the current task, it could also be
+                // another task.
+                (*header).notify(Some(cx.waker()));
+                return Poll::Ready(None);
             }
+
+            // If the task is not completed, register the current task.
+            if state & COMPLETED == 0 {
+                // Replace the waker with one associated with the current task.
+                (*header).register(cx.waker());
+
+                return Poll::Pending;
+            }
+
+            (*header).state |= CLOSED;
+
+            // Notify the awaiter. Even though the awaiter is most likely the current
+            // task, it could also be another task.
+            if state & AWAITER != 0 {
+                (*header).notify(Some(cx.waker()));
+            }
+
+            // Take the output from the task.
+            let output = ((*header).vtable.get_output)(ptr) as *mut R;
+            Poll::Ready(Some(output.read()))
         }
     }
 }

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -4,13 +4,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
 use alloc::alloc::Layout;
-use core::cell::UnsafeCell;
 use core::future::Future;
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop};
 use core::pin::Pin;
 use core::ptr::NonNull;
-use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use crate::task::header::Header;
@@ -122,8 +120,8 @@ where
 
             // Write the header as the first field of the task.
             (raw.header as *mut Header).write(Header {
-                state: AtomicUsize::new(SCHEDULED | HANDLE | REFERENCE),
-                awaiter: UnsafeCell::new(None),
+                state: SCHEDULED | HANDLE | REFERENCE,
+                awaiter: None,
                 vtable: &TaskVTable {
                     schedule: Self::schedule,
                     drop_future: Self::drop_future,
@@ -209,56 +207,28 @@ where
 
         let raw = Self::from_ptr(ptr);
 
-        let mut state = (*raw.header).state.load(Ordering::Acquire);
+        let state = (*raw.header).state;
 
-        loop {
-            // If the task is completed or closed, it can't be woken up.
-            if state & (COMPLETED | CLOSED) != 0 {
+        // If the task is completed or closed, it can't be woken up.
+        if state & (COMPLETED | CLOSED) != 0 {
+            // Drop the waker.
+            Self::drop_waker(ptr);
+            return;
+        }
+
+        // If the task is already scheduled do nothing.
+        if state & SCHEDULED != 0 {
+            // Drop the waker.
+            Self::drop_waker(ptr);
+        } else {
+            // Mark the task as scheduled.
+            (*(raw.header as *mut Header)).state = state | SCHEDULED;
+            if state & RUNNING == 0 {
+                // Schedule the task.
+                Self::schedule(ptr);
+            } else {
                 // Drop the waker.
                 Self::drop_waker(ptr);
-                break;
-            }
-
-            // If the task is already scheduled, we just need to synchronize with the thread that
-            // will run the task by "publishing" our current view of the memory.
-            if state & SCHEDULED != 0 {
-                // Update the state without actually modifying it.
-                match (*raw.header).state.compare_exchange_weak(
-                    state,
-                    state,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                ) {
-                    Ok(_) => {
-                        // Drop the waker.
-                        Self::drop_waker(ptr);
-                        break;
-                    }
-                    Err(s) => state = s,
-                }
-            } else {
-                // Mark the task as scheduled.
-                match (*raw.header).state.compare_exchange_weak(
-                    state,
-                    state | SCHEDULED,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                ) {
-                    Ok(_) => {
-                        // If the task is not yet scheduled and isn't currently running, now is the
-                        // time to schedule it.
-                        if state & RUNNING == 0 {
-                            // Schedule the task.
-                            Self::schedule(ptr);
-                        } else {
-                            // Drop the waker.
-                            Self::drop_waker(ptr);
-                        }
-
-                        break;
-                    }
-                    Err(s) => state = s,
-                }
             }
         }
     }
@@ -267,64 +237,41 @@ where
     unsafe fn wake_by_ref(ptr: *const ()) {
         let raw = Self::from_ptr(ptr);
 
-        let mut state = (*raw.header).state.load(Ordering::Acquire);
+        let state = (*raw.header).state;
 
-        loop {
-            // If the task is completed or closed, it can't be woken up.
-            if state & (COMPLETED | CLOSED) != 0 {
-                break;
-            }
+        // If the task is completed or closed, it can't be woken up.
+        if state & (COMPLETED | CLOSED) != 0 {
+            return;
+        }
 
-            // If the task is already scheduled, we just need to synchronize with the thread that
-            // will run the task by "publishing" our current view of the memory.
-            if state & SCHEDULED != 0 {
-                // Update the state without actually modifying it.
-                match (*raw.header).state.compare_exchange_weak(
-                    state,
-                    state,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                ) {
-                    Ok(_) => break,
-                    Err(s) => state = s,
-                }
+        // If the task is already scheduled, we just need to synchronize with the thread that
+        // will run the task by "publishing" our current view of the memory.
+        if state & SCHEDULED == 0 {
+            // If the task is not running, we can schedule right away.
+            let new = if state & RUNNING == 0 {
+                (state | SCHEDULED) + REFERENCE
             } else {
-                // If the task is not running, we can schedule right away.
-                let new = if state & RUNNING == 0 {
-                    (state | SCHEDULED) + REFERENCE
-                } else {
-                    state | SCHEDULED
+                state | SCHEDULED
+            };
+
+            // Mark the task as scheduled.
+            (*(raw.header as *mut Header)).state = new;
+
+            if state & RUNNING == 0 {
+                // If the reference count overflowed, abort.
+                if state > isize::max_value() as usize {
+                    abort();
+                }
+
+                // Schedule the task. There is no need to call `Self::schedule(ptr)`
+                // because the schedule function cannot be destroyed while the waker is
+                // still alive.
+                let task = Task {
+                    raw_task: NonNull::new_unchecked(ptr as *mut ()),
+                    _marker: PhantomData,
                 };
 
-                // Mark the task as scheduled.
-                match (*raw.header).state.compare_exchange_weak(
-                    state,
-                    new,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                ) {
-                    Ok(_) => {
-                        // If the task is not running, now is the time to schedule.
-                        if state & RUNNING == 0 {
-                            // If the reference count overflowed, abort.
-                            if state > isize::max_value() as usize {
-                                abort();
-                            }
-
-                            // Schedule the task. There is no need to call `Self::schedule(ptr)`
-                            // because the schedule function cannot be destroyed while the waker is
-                            // still alive.
-                            let task = Task {
-                                raw_task: NonNull::new_unchecked(ptr as *mut ()),
-                                _marker: PhantomData,
-                            };
-                            (*raw.schedule)(task);
-                        }
-
-                        break;
-                    }
-                    Err(s) => state = s,
-                }
+                (*raw.schedule)(task);
             }
         }
     }
@@ -335,7 +282,8 @@ where
 
         // Increment the reference count. With any kind of reference-counted data structure,
         // relaxed ordering is appropriate when incrementing the counter.
-        let state = (*raw.header).state.fetch_add(REFERENCE, Ordering::Relaxed);
+        let state = (*raw.header).state;
+        (*(raw.header as *mut Header)).state += REFERENCE;
 
         // If the reference count overflowed, abort.
         if state > isize::max_value() as usize {
@@ -355,7 +303,8 @@ where
         let raw = Self::from_ptr(ptr);
 
         // Decrement the reference count.
-        let new = (*raw.header).state.fetch_sub(REFERENCE, Ordering::AcqRel) - REFERENCE;
+        let new = (*raw.header).state - REFERENCE;
+        (*(raw.header as *mut Header)).state = new;
 
         // If this was the last reference to the task and the `JoinHandle` has been dropped too,
         // then we need to decide how to destroy the task.
@@ -363,9 +312,7 @@ where
             if new & (COMPLETED | CLOSED) == 0 {
                 // If the task was not completed nor closed, close it and schedule one more time so
                 // that its future gets dropped by the executor.
-                (*raw.header)
-                    .state
-                    .store(SCHEDULED | CLOSED | REFERENCE, Ordering::Release);
+                (*(raw.header as *mut Header)).state = SCHEDULED | CLOSED | REFERENCE;
                 Self::schedule(ptr);
             } else {
                 // Otherwise, destroy the task right away.
@@ -383,7 +330,8 @@ where
         let raw = Self::from_ptr(ptr);
 
         // Decrement the reference count.
-        let new = (*raw.header).state.fetch_sub(REFERENCE, Ordering::AcqRel) - REFERENCE;
+        let new = (*raw.header).state - REFERENCE;
+        (*(raw.header as *mut Header)).state = new;
 
         // If this was the last reference to the task and the `JoinHandle` has been dropped too,
         // then destroy the task.
@@ -459,53 +407,42 @@ where
     unsafe fn run(ptr: *const ()) -> bool {
         let raw = Self::from_ptr(ptr);
 
+        let mut state = (*raw.header).state;
+
+        // Update the task's state before polling its future.
+        // If the task has already been closed, drop the task reference and return.
+        if state & CLOSED != 0 {
+            // Drop the future.
+            Self::drop_future(ptr);
+
+            // Mark the task as unscheduled.
+            (*(raw.header as *mut Header)).state &= !SCHEDULED;
+
+            // Notify the awaiter that the future has been dropped.
+            if state & AWAITER != 0 {
+                (*(raw.header as *mut Header)).notify(None);
+            }
+
+            // Drop the task reference.
+            Self::drop_task(ptr);
+            return false;
+        }
+
+        state = (state & !SCHEDULED) | RUNNING;
+        (*(raw.header as *mut Header)).state = state;
+
         // Create a context from the raw task pointer and the vtable inside the its header.
         let waker = ManuallyDrop::new(Waker::from_raw(RawWaker::new(ptr, &Self::RAW_WAKER_VTABLE)));
         let cx = &mut Context::from_waker(&waker);
-
-        let mut state = (*raw.header).state.load(Ordering::Acquire);
-
-        // Update the task's state before polling its future.
-        loop {
-            // If the task has already been closed, drop the task reference and return.
-            if state & CLOSED != 0 {
-                // Drop the future.
-                Self::drop_future(ptr);
-
-                // Mark the task as unscheduled.
-                let state = (*raw.header).state.fetch_and(!SCHEDULED, Ordering::AcqRel);
-
-                // Notify the awaiter that the future has been dropped.
-                if state & AWAITER != 0 {
-                    (*raw.header).notify(None);
-                }
-
-                // Drop the task reference.
-                Self::drop_task(ptr);
-                return false;
-            }
-
-            // Mark the task as unscheduled and running.
-            match (*raw.header).state.compare_exchange_weak(
-                state,
-                (state & !SCHEDULED) | RUNNING,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => {
-                    // Update the state because we're continuing with polling the future.
-                    state = (state & !SCHEDULED) | RUNNING;
-                    break;
-                }
-                Err(s) => state = s,
-            }
-        }
 
         // Poll the inner future, but surround it with a guard that closes the task in case polling
         // panics.
         let guard = Guard(raw);
         let poll = <F as Future>::poll(Pin::new_unchecked(&mut *raw.future), cx);
         mem::forget(guard);
+
+        //state could be updated after the coll to the poll
+        state = (*raw.header).state;
 
         match poll {
             Poll::Ready(out) => {
@@ -517,96 +454,67 @@ where
                 let mut output = None;
 
                 // The task is now completed.
-                loop {
-                    // If the handle is dropped, we'll need to close it and drop the output.
-                    let new = if state & HANDLE == 0 {
-                        (state & !RUNNING & !SCHEDULED) | COMPLETED | CLOSED
-                    } else {
-                        (state & !RUNNING & !SCHEDULED) | COMPLETED
-                    };
+                // If the handle is dropped, we'll need to close it and drop the output.
+                let new = if state & HANDLE == 0 {
+                    (state & !RUNNING & !SCHEDULED) | COMPLETED | CLOSED
+                } else {
+                    (state & !RUNNING & !SCHEDULED) | COMPLETED
+                };
 
-                    // Mark the task as not running and completed.
-                    match (*raw.header).state.compare_exchange_weak(
-                        state,
-                        new,
-                        Ordering::AcqRel,
-                        Ordering::Acquire,
-                    ) {
-                        Ok(_) => {
-                            // If the handle is dropped or if the task was closed while running,
-                            // now it's time to drop the output.
-                            if state & HANDLE == 0 || state & CLOSED != 0 {
-                                // Read the output.
-                                output = Some(raw.output.read());
-                            }
+                (*(raw.header as *mut Header)).state = new;
 
-                            // Notify the awaiter that the task has been completed.
-                            if state & AWAITER != 0 {
-                                (*raw.header).notify(None);
-                            }
-
-                            // Drop the task reference.
-                            Self::drop_task(ptr);
-                            break;
-                        }
-                        Err(s) => state = s,
-                    }
+                // If the handle is dropped or if the task was closed while running,
+                // now it's time to drop the output.
+                if state & HANDLE == 0 || state & CLOSED != 0 {
+                    // Read the output.
+                    output = Some(raw.output.read());
                 }
 
-                // Drop the output if it was taken out of the task.
+                // Notify the awaiter that the task has been completed.
+                if state & AWAITER != 0 {
+                    (*(raw.header as *mut Header)).notify(None);
+                }
+
+                // Drop the task reference.
+                Self::drop_task(ptr);
+
                 drop(output);
             }
             Poll::Pending => {
-                let mut future_dropped = false;
-
                 // The task is still not completed.
-                loop {
-                    // If the task was closed while running, we'll need to unschedule in case it
-                    // was woken up and then destroy it.
-                    let new = if state & CLOSED != 0 {
-                        state & !RUNNING & !SCHEDULED
-                    } else {
-                        state & !RUNNING
-                    };
 
-                    if state & CLOSED != 0 && !future_dropped {
-                        // The thread that closed the task didn't drop the future because it was
-                        // running so now it's our responsibility to do so.
-                        Self::drop_future(ptr);
-                        future_dropped = true;
-                    }
+                // If the task was closed while running, we'll need to unschedule in case it
+                // was woken up and then destroy it.
+                let new = if state & CLOSED != 0 {
+                    state & !RUNNING & !SCHEDULED
+                } else {
+                    state & !RUNNING
+                };
 
-                    // Mark the task as not running.
-                    match (*raw.header).state.compare_exchange_weak(
-                        state,
-                        new,
-                        Ordering::AcqRel,
-                        Ordering::Acquire,
-                    ) {
-                        Ok(state) => {
-                            // If the task was closed while running, we need to notify the awaiter.
-                            // If the task was woken up while running, we need to schedule it.
-                            // Otherwise, we just drop the task reference.
-                            if state & CLOSED != 0 {
-                                // Notify the awaiter that the future has been dropped.
-                                if state & AWAITER != 0 {
-                                    (*raw.header).notify(None);
-                                }
-                                // Drop the task reference.
-                                Self::drop_task(ptr);
-                            } else if state & SCHEDULED != 0 {
-                                // The thread that woke the task up didn't reschedule it because
-                                // it was running so now it's our responsibility to do so.
-                                Self::schedule(ptr);
-                                return true;
-                            } else {
-                                // Drop the task reference.
-                                Self::drop_task(ptr);
-                            }
-                            break;
-                        }
-                        Err(s) => state = s,
+                if state & CLOSED != 0 {
+                    Self::drop_future(ptr);
+                }
+
+                (*(raw.header as *mut Header)).state = new;
+
+                // If the task was closed while running, we need to notify the awaiter.
+                // If the task was woken up while running, we need to schedule it.
+                // Otherwise, we just drop the task reference.
+                if state & CLOSED != 0 {
+                    // Notify the awaiter that the future has been dropped.
+                    if state & AWAITER != 0 {
+                        (*(raw.header as *mut Header)).notify(None);
                     }
+                    // Drop the task reference.
+                    Self::drop_task(ptr);
+                } else if state & SCHEDULED != 0 {
+                    // The thread that woke the task up didn't reschedule it because
+                    // it was running so now it's our responsibility to do so.
+                    Self::schedule(ptr);
+                    return true;
+                } else {
+                    // Drop the task reference.
+                    Self::drop_task(ptr);
                 }
             }
         }
@@ -629,54 +537,23 @@ where
                 let ptr = raw.header as *const ();
 
                 unsafe {
-                    let mut state = (*raw.header).state.load(Ordering::Acquire);
+                    // Mark the task as not running and not scheduled.
+                    (*(raw.header as *mut Header)).state =
+                        ((*(raw.header)).state & !RUNNING & !SCHEDULED) | CLOSED;
 
-                    loop {
-                        // If the task was closed while running, then unschedule it, drop its
-                        // future, and drop the task reference.
-                        if state & CLOSED != 0 {
-                            // The thread that closed the task didn't drop the future because it
-                            // was running so now it's our responsibility to do so.
-                            RawTask::<F, R, S, T>::drop_future(ptr);
+                    // drop tasks future, and drop the task reference.
 
-                            // Mark the task as not running and not scheduled.
-                            (*raw.header)
-                                .state
-                                .fetch_and(!RUNNING & !SCHEDULED, Ordering::AcqRel);
+                    // The thread that closed the task didn't drop the future because it
+                    // was running so now it's our responsibility to do so.
+                    RawTask::<F, R, S, T>::drop_future(ptr);
 
-                            // Notify the awaiter that the future has been dropped.
-                            if state & AWAITER != 0 {
-                                (*raw.header).notify(None);
-                            }
-
-                            // Drop the task reference.
-                            RawTask::<F, R, S, T>::drop_task(ptr);
-                            break;
-                        }
-
-                        // Mark the task as not running, not scheduled, and closed.
-                        match (*raw.header).state.compare_exchange_weak(
-                            state,
-                            (state & !RUNNING & !SCHEDULED) | CLOSED,
-                            Ordering::AcqRel,
-                            Ordering::Acquire,
-                        ) {
-                            Ok(state) => {
-                                // Drop the future because the task is now closed.
-                                RawTask::<F, R, S, T>::drop_future(ptr);
-
-                                // Notify the awaiter that the future has been dropped.
-                                if state & AWAITER != 0 {
-                                    (*raw.header).notify(None);
-                                }
-
-                                // Drop the task reference.
-                                RawTask::<F, R, S, T>::drop_task(ptr);
-                                break;
-                            }
-                            Err(s) => state = s,
-                        }
+                    // Notify the awaiter that the future has been dropped.
+                    if (*raw.header).state & AWAITER != 0 {
+                        (*(raw.header as *mut Header)).notify(None);
                     }
+
+                    // Drop the task reference.
+                    RawTask::<F, R, S, T>::drop_task(ptr);
                 }
             }
         }

--- a/glommio/src/task/state.rs
+++ b/glommio/src/task/state.rs
@@ -53,17 +53,6 @@ pub(crate) const HANDLE: usize = 1 << 4;
 /// check that tells us if we need to wake anyone.
 pub(crate) const AWAITER: usize = 1 << 5;
 
-/// Set if an awaiter is being registered.
-///
-/// This flag is set when `JoinHandle` is polled and we are registering a new awaiter.
-pub(crate) const REGISTERING: usize = 1 << 6;
-
-/// Set if the awaiter is being notified.
-///
-/// This flag is set when notifying the awaiter. If an awaiter is concurrently registered and
-/// notified, whichever side came first will take over the reposibility of resolving the race.
-pub(crate) const NOTIFYING: usize = 1 << 7;
-
 /// A single reference.
 ///
 /// The lower bits in the state contain various flags representing the task state, while the upper
@@ -72,4 +61,4 @@ pub(crate) const NOTIFYING: usize = 1 << 7;
 ///
 /// Note that the reference counter only tracks the `Task` and `Waker`s. The `JoinHandle` is
 /// tracked separately by the `HANDLE` flag.
-pub(crate) const REFERENCE: usize = 1 << 8;
+pub(crate) const REFERENCE: usize = 1 << 6;


### PR DESCRIPTION
### What does this PR do?

state field of Task's state machine was changed from AtomicUsize to usize.
States which were used only to ensure thread safety (REGISTRING and NOTIFYING) were removed as not needed.

### Motivation

Removing of usage of membars during changing of a state of the state machine.

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`

### Notes from maintainer:

The effects of this are visible on the executor benchmark. Quite consistently I get a 70s speedup in task execution

Before:
```
cost to run task no task queue: 216ns
cost to run task in task queue: 377ns
```
After

```
cost to run task no task queue: 129ns
cost to run task in task queue: 301ns
```

There are similar (albeit a bit less) speed ups in the contended cases for semaphore and local channel.

Very good job, Andrey!