### PR TITLE
reduce visibility of Runnable and other multitask entities

### DIFF
--- a/glommio/src/multitask.rs
+++ b/glommio/src/multitask.rs
@@ -31,7 +31,7 @@ use std::task::{Context, Poll};
 /// Once a `Runnable` is run, it "vanishes" and only reappears when its future is woken. When it's
 /// woken up, its schedule function is called, which means the `Runnable` gets pushed into a task
 /// queue in an executor.
-pub type Runnable = task_impl::Task;
+pub(crate) type Runnable = task_impl::Task;
 
 /// A spawned future.
 ///
@@ -47,7 +47,7 @@ pub type Runnable = task_impl::Task;
 /// ```
 #[must_use = "tasks get canceled when dropped, use `.detach()` to run them in the background"]
 #[derive(Debug)]
-pub struct Task<T>(Option<JoinHandle<T>>);
+pub(crate) struct Task<T>(Option<JoinHandle<T>>);
 
 impl<T> Task<T> {
     /// Detaches the task to let it keep running in the background.
@@ -153,7 +153,7 @@ impl LocalQueue {
 
 /// A single-threaded executor.
 #[derive(Debug)]
-pub struct LocalExecutor {
+pub(crate) struct LocalExecutor {
     local_queue: Rc<LocalQueue>,
 
     /// Callback invoked to wake the executor up.


### PR DESCRIPTION
While reviewing Andrey's code that touched the task core, I noticed
that Runnable is fully public, and that should not be the case.

As a matter of fact, nothing in the multitask file should be public,
since it only exists to implement an internal queue of the main
executor.

Reduce the visibility to all currently public types to pub(crate).

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
