### PR TITLE
only store space for a single waker per source

### DIFF
--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -3,7 +3,6 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
-use smallvec::SmallVec;
 use std::cell::{Cell, RefCell};
 use std::convert::TryFrom;
 use std::ffi::CString;
@@ -208,14 +207,14 @@ pub(crate) struct Wakers {
     pub(crate) result: Option<io::Result<usize>>,
 
     /// Tasks waiting for the next event.
-    pub(crate) waiters: SmallVec<[Waker; 4]>,
+    pub(crate) waiter: Option<Waker>,
 }
 
 impl Wakers {
     pub(crate) fn new() -> Self {
         Wakers {
             result: None,
-            waiters: SmallVec::new(),
+            waiter: None,
         }
     }
 }

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -357,7 +357,9 @@ where
         if !was_cancelled && try_process(&*src).is_none() {
             let mut w = src.wakers.borrow_mut();
             w.result = Some(result);
-            wakers.extend_from_slice(&w.waiters.as_slice());
+            if let Some(waiter) = w.waiter.take() {
+                wakers.push(waiter);
+            }
         }
         return Some(());
     }
@@ -654,7 +656,7 @@ impl Source {
     }
     pub(crate) fn add_waiter(&self, waker: Waker) {
         let mut w = self.inner.wakers.borrow_mut();
-        w.waiters.push(waker);
+        w.waiter.replace(waker);
     }
 
     pub(crate) fn raw(&self) -> RawFd {


### PR DESCRIPTION
Matthias recently opened an issue unrelated to this, in which he linked
the following document from rust's official RFC:

https://github.com/rust-lang/rfcs/blob/master/text/2592-futures.md#rationale-drawbacks-and-alternatives-to-the-wakeup-design-waker

Reading through it, one of the comments in the Future trait confirmed
what I suspected but was not sure:

    /// Note that on multiple calls to `poll`, only the most recent
    /// [`Waker`] passed to `poll` should be scheduled to receive a
    /// wakeup.
    ///

Since we have a 1:1 mapping between Source and operation at the io_uring
layer, we don't need to store a vec of wakers, just the most recent one.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
