### PR TITLE
avoid allocation for time registration

### DIFF
--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -614,6 +614,12 @@ impl InnerSource {
 }
 
 impl Source {
+    fn cancel(&mut self) {
+        if let Some(EnqueuedSource { id, queue }) = self.inner.enqueued.take() {
+            queue.borrow_mut().cancel_request(id);
+        }
+    }
+
     fn latency_req(&self) -> Latency {
         self.inner.io_requirements.latency_req
     }
@@ -664,9 +670,7 @@ impl Source {
 
 impl Drop for Source {
     fn drop(&mut self) {
-        if let Some(EnqueuedSource { id, queue }) = self.inner.enqueued.take() {
-            queue.borrow_mut().cancel_request(id);
-        }
+        self.cancel();
     }
 }
 
@@ -699,17 +703,15 @@ impl SleepableRing {
         self.ring.raw().ring_fd
     }
 
-    fn arm_timer(&mut self, d: Duration) -> Source {
-        let source = Source::new(
-            IoRequirements::default(),
-            -1,
-            SourceType::Timeout(TimeSpec64::from(d)),
-        );
-        let new_id = add_source(&source, self.submission_queue.clone());
+    fn arm_timer(&mut self, d: Duration, source: &mut Source) {
+        source.update_source_type(SourceType::Timeout(TimeSpec64::from(d)));
+
         let op = match &*source.source_type() {
             SourceType::Timeout(ts) => UringOpDescriptor::Timeout(&ts.raw as *const _),
             _ => unreachable!(),
         };
+
+        let new_id = add_source(&source, self.submission_queue.clone());
 
         // This assumes SQEs will be processed in the order they are
         // seen. Because remove does not do anything asynchronously
@@ -724,7 +726,6 @@ impl SleepableRing {
         // No need to submit, the next ring enter will submit for us. Because
         // we just flushed and we got put in front of the queue we should get a SQE.
         // Still it would be nice to verify if we did.
-        source
     }
 
     fn install_eventfd(&mut self, eventfd_src: &Source) -> bool {
@@ -858,7 +859,7 @@ pub(crate) struct Reactor {
 
     link_rings_src: RefCell<Source>,
 
-    timeout_src: Cell<Option<Source>>,
+    timeout_src: RefCell<Source>,
 
     // This keeps the eventfd alive. Drop will close it when we're done
     _eventfd: std::fs::File,
@@ -971,6 +972,8 @@ impl Reactor {
             eventfd.as_raw_fd(),
             SourceType::Read(PollableStatus::NonPollable(DirectIO::Disabled), None),
         );
+
+        let timeout_src = Source::new(IoRequirements::default(), -1, SourceType::Invalid);
         assert_eq!(main_ring.install_eventfd(&eventfd_src), true);
 
         Ok(Reactor {
@@ -978,7 +981,7 @@ impl Reactor {
             latency_ring: RefCell::new(latency_ring),
             poll_ring: RefCell::new(poll_ring),
             link_rings_src: RefCell::new(link_rings_src),
-            timeout_src: Cell::new(None),
+            timeout_src: RefCell::new(timeout_src),
             _eventfd: eventfd,
             eventfd_memory: Arc::new(AtomicUsize::new(0)),
             eventfd_src,
@@ -1147,17 +1150,19 @@ impl Reactor {
         let mut main_ring = self.main_ring.borrow_mut();
         let mut lat_ring = self.latency_ring.borrow_mut();
 
+        let mut timeout_src = self.timeout_src.borrow_mut();
+
         // Cancel the old timer regardless of whether or not we can sleep:
         // if we won't sleep, we will register the new timer with its new
         // value.
         //
         // But if we will sleep, there might be a timer registered that needs
         // to be removed otherwise we'll wake up when it expires.
-        drop(self.timeout_src.take());
+        timeout_src.cancel();
         let mut should_sleep = match preempt_timer {
             None => true,
             Some(dur) => {
-                self.timeout_src.set(Some(lat_ring.arm_timer(dur)));
+                lat_ring.arm_timer(dur, &mut timeout_src);
                 false
             }
         };
@@ -1177,7 +1182,7 @@ impl Reactor {
             // We are about to go to sleep. It's ok to sleep, but if there
             // is a timer set, we need to make sure we wake up to handle it.
             if let Some(dur) = user_timer {
-                self.timeout_src.set(Some(lat_ring.arm_timer(dur)));
+                lat_ring.arm_timer(dur, &mut timeout_src);
                 flush_rings!(lat_ring)?;
             }
             // From this moment on the remote executors are aware that we are sleeping


### PR DESCRIPTION
The idea of always using a new source for the timer and relying on the old
one being dropped for cancellation is neat, but Sources as they are right now
must live in the heap.

That means that this code path always triggers a memory allocation. It is
best to cancel explicitly (we were already dropping explicitly, so that is
easy), and use the same source all the time, just updating its SourceType.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
