### PR TITLE
improve efficiency of the executor

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 futures = "0.3.5"
 futures-lite = "1.11.1"
 ansi_term = "0.12.1"
-glommio = { version = "0.2.0", path = "../glommio" }
+glommio = { version = "0.3.0", path = "../glommio" }
 pretty-bytes = "0.2.2"
 clap = "2.33"
 sys-info = "0.7.0"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glommio"
-version = "0.2.0"
+version = "0.3.0"
 authors = [ "Glauber Costa <glauber@datadoghq.com>",
             "Hippolyte Barraud <hippolyte.barraud@datadoghq.com>",
             "DataDog"]

--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -840,6 +840,8 @@ impl LocalExecutor {
                     let now = Instant::now();
                     let mut queue_ref = queue.borrow_mut();
                     queue_ref.prepare_to_run(now);
+                    self.reactor
+                        .inform_io_requirements(queue_ref.io_requirements);
                     now
                 };
 
@@ -851,7 +853,6 @@ impl LocalExecutor {
                     }
 
                     if let Some(r) = queue_ref.get_task() {
-                        Local::get_reactor().inform_io_requirements(queue_ref.io_requirements);
                         drop(queue_ref);
                         r.run();
                         tasks_executed_this_loop += 1;

--- a/glommio/src/multitask.rs
+++ b/glommio/src/multitask.rs
@@ -51,58 +51,11 @@ pub(crate) struct Task<T>(Option<JoinHandle<T>>);
 
 impl<T> Task<T> {
     /// Detaches the task to let it keep running in the background.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::time::Duration;
-    /// use glommio::LocalExecutor;
-    /// use glommio::timer::Timer;
-    ///
-    /// let ex = LocalExecutor::make_default();
-    ///
-    /// // Spawn a deamon future.
-    /// ex.spawn(async {
-    ///     for i in 0..10 {
-    ///         println!("I'm a daemon task looping ({}/{})).", i+1, 10);
-    ///         Timer::new(Duration::from_secs(1)).await;
-    ///     }
-    /// })
-    /// .detach();
-    /// ```
     pub(crate) fn detach(mut self) -> JoinHandle<T> {
         self.0.take().unwrap()
     }
 
     /// Cancels the task and waits for it to stop running.
-    ///
-    /// Returns the task's output if it was completed just before it got canceled, or [`None`] if
-    /// it didn't complete.
-    ///
-    /// While it's possible to simply drop the [`Task`] to cancel it, this is a cleaner way of
-    /// canceling because it also waits for the task to stop running.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::thread;
-    /// use std::time::Duration;
-    /// use glommio::LocalExecutor;
-    /// use glommio::timer::Timer;
-    /// use futures_lite::future::block_on;
-    ///
-    /// let ex = LocalExecutor::make_default();
-    ///
-    /// let task = ex.spawn(async {
-    ///     Timer::new(std::time::Duration::from_millis(100)).await;
-    ///     println!("jello, world!");
-    /// });
-    ///
-    /// // task may or may not print
-    /// ex.run(async {
-    ///     task.cancel().await;
-    /// });
-    /// ```
     pub(crate) async fn cancel(self) -> Option<T> {
         let mut task = self;
         let handle = task.0.take().unwrap();

--- a/glommio/src/sync/semaphore.rs
+++ b/glommio/src/sync/semaphore.rs
@@ -619,17 +619,17 @@ mod test {
         let semaphore = Rc::new(Semaphore::new(0));
         let semaphore_c = semaphore.clone();
 
-        ex.spawn(async move {
-            for _ in 0..100 {
-                Timer::new(Duration::from_micros(100)).await;
-            }
-            assert_eq!(1, semaphore_c.state.borrow().list.len());
-
-            semaphore_c.signal(1);
-        })
-        .detach();
-
         ex.run(async move {
+            Local::local(async move {
+                for _ in 0..100 {
+                    Timer::new(Duration::from_micros(100)).await;
+                }
+                assert_eq!(1, semaphore_c.state.borrow().list.len());
+
+                semaphore_c.signal(1);
+            })
+            .detach();
+
             let _ = semaphore.acquire(1).await.unwrap();
         });
     }


### PR DESCRIPTION
Improves efficiency of spawning tasks in the executor, by pre-computing the task queue index

Before:
```
cost to run task no task queue: 126ns
cost to run task in task queue: 300ns
```

After
```
cost to run task no task queue: 93ns
cost to run task in task queue: 257ns
```

No regressions found in any of the existing benchmarks. Semaphore and local channel show similar improvements for the contended case.