### PR TITLE
refactoring / maybe some improvements

### DIFF
--- a/glommio/src/multitask.rs
+++ b/glommio/src/multitask.rs
@@ -123,10 +123,9 @@ impl<T> Future for Task<T> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match Pin::new(&mut self.0.as_mut().unwrap()).poll(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(output) => Poll::Ready(output.expect("task has failed")),
-        }
+        Pin::new(&mut self.0.as_mut().unwrap())
+            .poll(cx)
+            .map(|output| output.expect("task has failed"))
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR gets rid of some `unwrap()`s, mainly in destructors, which should make it easier to guarantee that these `Drop` impls can't crash the program (otherwise, panic'ing in `Drop` impls could cause an abort if the `Drop` was invoced while panic-unwinding).

### Motivation

I wanted to get familiar with the code and inspected the code for somewhat common maybe-code-smells I was familiar with.

### Related issues

None.

### Additional Notes

I was able to run the test and bench suite. I dropped changes which hadn't the intended effect.

### Checklist

No new unit tests should be needed, as no new functionality was added, only existing functionality was refactored without "completely" breaking fn signatures
* [X] If applicable, I have discussed my architecture
* [X] The new code I am adding is formatted using `rustfmt`
