### PR TITLE
LocalExecutor::available_executors is converted from AHashMap to Vec.

### DIFF
--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -714,12 +714,16 @@ impl LocalExecutor {
 
         let available_executors = &mut self.queues.borrow_mut().available_executors;
 
-        if available_executors.len() == index {
-            available_executors.push(Some(tq));
-        } else if available_executors.len() > index {
-            available_executors[index] = Some(tq);
-        } else {
-            unreachable!()
+        match available_executors.len().cmp(&index) {
+            std::cmp::Ordering::Equal => {
+                available_executors.push(Some(tq));
+            }
+            std::cmp::Ordering::Greater => {
+                available_executors[index] = Some(tq);
+            }
+            std::cmp::Ordering::Less => {
+                unreachable!()
+            }
         }
 
         TaskQueueHandle { index }


### PR DESCRIPTION
### What does this PR do?

Checking the id generation of task queues I found out that ids of the queues:
1. Do not need to be a unique overall time of the application.
2. Managed internally.

That means that Map could be replaced by Vec<Option> with VecDeque which contains a collection of ids of removed queues.
There is could be a situation when queues will be massively created and then removed.
Which will create a list of "null" references to the queues which only consumes memory,
but the same is true for the Map, also such a situation when such a massive spike of removal
of queues is hardly possible on practice.

### Motivation

Improving the performance of LocalExecutor

### Additional Notes

I personally did notice noticeable speed up on benches, there is small speed up but not something outstanding. 
But that could depend on hardware and amount of queues. 
Nonetheless, conversion to the faster data structure never hurts.

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
