### PR TITLE
channels: reduce code repetition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.gdb_history
 .idea
 *.iml
 /target

--- a/glommio/src/channels/local_channel.rs
+++ b/glommio/src/channels/local_channel.rs
@@ -4,14 +4,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
 use crate::channels::{ChannelCapacity, ChannelError};
-use futures_lite::future;
-use futures_lite::stream::Stream;
-use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::io;
-use std::pin::Pin;
-use std::rc::Rc;
+use futures_lite::{future, stream::Stream};
 use std::task::{Context, Poll, Waker};
+use std::{cell::RefCell, collections::VecDeque, io, pin::Pin, rc::Rc};
 
 #[derive(Debug)]
 /// Send endpoint to the `local_channel`
@@ -62,9 +57,68 @@ struct State<T> {
     send_waiters: Option<VecDeque<Waker>>,
 }
 
-#[derive(Debug, Clone)]
+impl<T> State<T> {
+    fn push(&mut self, item: T) -> Result<Option<Waker>, ChannelError<T>> {
+        if self.recv_waiters.is_none() {
+            Err(ChannelError::new(io::ErrorKind::BrokenPipe, item))
+        } else if self.is_full() {
+            Err(ChannelError::new(io::ErrorKind::WouldBlock, item))
+        } else {
+            self.channel.push_back(item);
+            Ok(self.recv_waiters.as_mut().and_then(|x| x.pop_front()))
+        }
+    }
+
+    fn is_full(&self) -> bool {
+        match self.capacity {
+            ChannelCapacity::Unbounded => false,
+            ChannelCapacity::Bounded(x) => self.channel.len() >= x,
+        }
+    }
+
+    fn wait_for_room(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        if !self.is_full() {
+            Poll::Ready(())
+        } else {
+            self.send_waiters
+                .as_mut()
+                .unwrap()
+                .push_back(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    fn recv_one(&mut self, cx: &mut Context<'_>) -> Poll<Option<(T, Option<Waker>)>> {
+        match self.channel.pop_front() {
+            Some(item) => Poll::Ready(Some((
+                item,
+                self.send_waiters.as_mut().and_then(|x| x.pop_front()),
+            ))),
+            None => match self.send_waiters.is_some() {
+                true => {
+                    self.recv_waiters
+                        .as_mut()
+                        .unwrap()
+                        .push_back(cx.waker().clone());
+                    Poll::Pending
+                }
+                false => Poll::Ready(None),
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
 struct LocalChannel<T> {
     state: Rc<RefCell<State<T>>>,
+}
+
+impl<T> Clone for LocalChannel<T> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+        }
+    }
 }
 
 impl<T> LocalChannel<T> {
@@ -75,51 +129,21 @@ impl<T> LocalChannel<T> {
             ChannelCapacity::Bounded(x) => VecDeque::with_capacity(x),
         };
 
-        let state = Rc::new(RefCell::new(State {
-            capacity,
-            channel,
-            send_waiters: Some(VecDeque::new()),
-            recv_waiters: Some(VecDeque::new()),
-        }));
+        let channel = LocalChannel {
+            state: Rc::new(RefCell::new(State {
+                capacity,
+                channel,
+                send_waiters: Some(VecDeque::new()),
+                recv_waiters: Some(VecDeque::new()),
+            })),
+        };
 
         (
             LocalSender {
-                channel: LocalChannel {
-                    state: state.clone(),
-                },
+                channel: channel.clone(),
             },
-            LocalReceiver {
-                channel: LocalChannel { state },
-            },
+            LocalReceiver { channel },
         )
-    }
-
-    fn push(&self, item: T) -> Result<(), ChannelError<T>> {
-        let mut state = self.state.borrow_mut();
-        if state.recv_waiters.is_none() {
-            return Err(ChannelError::new(io::ErrorKind::BrokenPipe, item));
-        }
-
-        if let ChannelCapacity::Bounded(x) = state.capacity {
-            if state.channel.len() >= x {
-                return Err(ChannelError::new(io::ErrorKind::WouldBlock, item));
-            }
-        }
-
-        state.channel.push_back(item);
-        if let Some(w) = state.recv_waiters.as_mut().and_then(|x| x.pop_front()) {
-            drop(state);
-            w.wake();
-        }
-        Ok(())
-    }
-
-    fn is_full(&self) -> bool {
-        let state = self.state.borrow();
-        match state.capacity {
-            ChannelCapacity::Unbounded => false,
-            ChannelCapacity::Bounded(x) => state.channel.len() >= x,
-        }
     }
 }
 
@@ -197,7 +221,10 @@ impl<T> LocalSender<T> {
     /// [`Other`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.Other
     /// [`io::Error`]: https://doc.rust-lang.org/std/io/struct.Error.html
     pub fn try_send(&self, item: T) -> Result<(), ChannelError<T>> {
-        self.channel.push(item)
+        if let Some(w) = self.channel.state.borrow_mut().push(item)? {
+            w.wake();
+        }
+        Ok(())
     }
 
     /// Sends data into this channel when it is ready to receive it
@@ -223,10 +250,7 @@ impl<T> LocalSender<T> {
     ///
     /// [`try_send`]: struct.LocalSender.html#method.try_send
     pub async fn send(&self, item: T) -> Result<(), ChannelError<T>> {
-        if self.is_full() {
-            let waiter = future::poll_fn(|cx| self.wait_for_room(cx));
-            waiter.await;
-        }
+        future::poll_fn(|cx| self.wait_for_room(cx)).await;
         self.try_send(item)
     }
 
@@ -246,8 +270,9 @@ impl<T> LocalSender<T> {
     ///     drop(receiver);
     /// });
     /// ```
+    #[inline]
     pub fn is_full(&self) -> bool {
-        self.channel.is_full()
+        self.channel.state.borrow().is_full()
     }
 
     /// Returns the number of items still queued in this channel
@@ -269,22 +294,26 @@ impl<T> LocalSender<T> {
     ///     drop(receiver);
     /// });
     /// ```
+    #[inline]
     pub fn len(&self) -> usize {
-        let state = self.channel.state.borrow();
-        state.channel.len()
+        self.channel.state.borrow().channel.len()
     }
 
     fn wait_for_room(&self, cx: &mut Context<'_>) -> Poll<()> {
-        if !self.channel.is_full() {
-            Poll::Ready(())
-        } else {
-            let mut state = self.channel.state.borrow_mut();
-            state
-                .send_waiters
-                .as_mut()
-                .unwrap()
-                .push_back(cx.waker().clone());
-            Poll::Pending
+        // NOTE: it is important that the borrow is dropped
+        // if Poll::Pending is returned
+        self.channel.state.borrow_mut().wait_for_room(cx)
+    }
+}
+
+fn wake_up_all(ws: &mut Option<VecDeque<Waker>>) {
+    if let Some(ref mut waiters) = ws {
+        // replace core::mem::replace with core::mem::take,
+        // as soon as we drop support for rustc < 1.40.0
+        // we assume here that wakes don't try to acquire a borrow on
+        // the channel.state
+        for w in core::mem::replace(waiters, VecDeque::new()) {
+            w.wake();
         }
     }
 }
@@ -295,15 +324,7 @@ impl<T> Drop for LocalSender<T> {
         // Will not wake up senders, but we are dropping the sender so nobody
         // wants to wake up anyway.
         state.send_waiters.take();
-
-        if let Some(ref mut waiters) = &mut state.recv_waiters {
-            let waiters = core::mem::replace(waiters, VecDeque::new());
-            drop(state);
-
-            for w in waiters {
-                w.wake();
-            }
-        }
+        wake_up_all(&mut state.recv_waiters);
     }
 }
 
@@ -311,21 +332,14 @@ impl<T> Drop for LocalReceiver<T> {
     fn drop(&mut self) {
         let mut state = self.channel.state.borrow_mut();
         state.recv_waiters.take();
-
-        if let Some(ref mut waiters) = &mut state.send_waiters {
-            let waiters = core::mem::replace(waiters, VecDeque::new());
-            drop(state);
-
-            for w in waiters {
-                w.wake();
-            }
-        }
+        wake_up_all(&mut state.send_waiters);
     }
 }
 
 impl<T> Stream for LocalReceiver<T> {
     type Item = T;
 
+    #[inline]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.recv_one(cx)
     }
@@ -362,32 +376,18 @@ impl<T> LocalReceiver<T> {
     /// [`next`]: https://docs.rs/futures-lite/1.11.2/futures_lite/stream/trait.StreamExt.html#method.next
     /// [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
     pub async fn recv(&self) -> Option<T> {
-        let waiter = future::poll_fn(|cx| self.recv_one(cx));
-        waiter.await
+        future::poll_fn(|cx| self.recv_one(cx)).await
     }
 
     fn recv_one(&self, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        let mut state = self.channel.state.borrow_mut();
-        match state.channel.pop_front() {
-            Some(item) => {
-                if let Some(w) = state.send_waiters.as_mut().and_then(|x| x.pop_front()) {
-                    drop(state);
+        self.channel.state.borrow_mut().recv_one(cx).map(|opt| {
+            opt.map(|(ret, mw)| {
+                if let Some(w) = mw {
                     w.wake();
                 }
-                Poll::Ready(Some(item))
-            }
-            None => match state.send_waiters.is_some() {
-                true => {
-                    state
-                        .recv_waiters
-                        .as_mut()
-                        .unwrap()
-                        .push_back(cx.waker().clone());
-                    Poll::Pending
-                }
-                false => Poll::Ready(None),
-            },
-        }
+                ret
+            })
+        })
     }
 }
 

--- a/glommio/src/channels/local_channel.rs
+++ b/glommio/src/channels/local_channel.rs
@@ -308,11 +308,9 @@ impl<T> LocalSender<T> {
 
 fn wake_up_all(ws: &mut Option<VecDeque<Waker>>) {
     if let Some(ref mut waiters) = ws {
-        // replace core::mem::replace with core::mem::take,
-        // as soon as we drop support for rustc < 1.40.0
         // we assume here that wakes don't try to acquire a borrow on
         // the channel.state
-        for w in core::mem::replace(waiters, VecDeque::new()) {
+        for w in core::mem::take(waiters) {
             w.wake();
         }
     }

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -4,7 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
 //
-use crate::channels::spsc_queue::{make, Consumer, Producer};
+use crate::channels::spsc_queue::{make, BufferHalf, Consumer, Producer};
 use crate::channels::ChannelError;
 use crate::parking::Reactor;
 use crate::{enclose, Local};

--- a/glommio/src/channels/spsc_queue.rs
+++ b/glommio/src/channels/spsc_queue.rs
@@ -209,7 +209,7 @@ pub(crate) fn make<T: Copy>(capacity: usize) -> (Producer<T>, Consumer<T>) {
     )
 }
 
-fn allocate_buffer<T>(capacity: usize) -> Arc<Vec<T>> {
+fn allocate_buffer<T: Copy>(capacity: usize) -> Arc<Vec<Cell<T>>> {
     let size = capacity.next_power_of_two();
     let mut vec = Vec::with_capacity(size);
     unsafe {

--- a/glommio/src/channels/spsc_queue.rs
+++ b/glommio/src/channels/spsc_queue.rs
@@ -16,7 +16,7 @@ const fn cacheline_pad(used: usize) -> usize {
 /// ring buffer, as well as a head and tail atomicUsize which the producer and consumer
 /// use to track location in the ring.
 #[repr(C)]
-struct Buffer<T: Copy> {
+pub(crate) struct Buffer<T: Copy> {
     buffer_storage: Arc<Vec<Cell<T>>>,
 
     /// The bounded size as specified by the user.  If the queue reaches capacity, it will block
@@ -151,6 +151,14 @@ impl<T: Copy> Buffer<T> {
     pub(crate) fn consumer_disconnected(&self) -> bool {
         self.consumer_disconnected.load(Ordering::Acquire) != 0
     }
+
+    /// Returns the current size of the queue
+    ///
+    /// This value represents the current size of the queue.  This value can be from 0-`capacity`
+    /// inclusive.
+    pub(crate) fn size(&self) -> usize {
+        self.tail.load(Ordering::Acquire) - self.head.load(Ordering::Acquire)
+    }
 }
 
 /// Handles deallocation of heap memory when the buffer is dropped
@@ -210,6 +218,59 @@ fn allocate_buffer<T>(capacity: usize) -> Arc<Vec<T>> {
     Arc::new(vec)
 }
 
+pub(crate) trait BufferHalf {
+    type Item: Copy;
+
+    fn buffer(&self) -> &Buffer<Self::Item>;
+    fn eventfd(&self) -> &Cell<Option<Arc<AtomicUsize>>>;
+    fn opposite_eventfd(&self) -> &Cell<Option<Arc<AtomicUsize>>>;
+
+    fn must_notify(&self) -> Option<RawFd> {
+        let eventfd = self.opposite_eventfd();
+        let mem = eventfd.take();
+        let ret = mem.as_ref().map(|x| x.load(Ordering::Acquire) as _);
+        eventfd.set(mem);
+        match ret {
+            None | Some(0) => None,
+            Some(x) => Some(x),
+        }
+    }
+
+    fn connect(&self, eventfd: Arc<AtomicUsize>) {
+        let old = self.eventfd().replace(Some(eventfd));
+        assert_eq!(old.is_none(), true);
+    }
+
+    /// Returns the total capacity of this queue
+    ///
+    /// This value represents the total capacity of the queue when it is full.  It does not
+    /// represent the current usage.  For that, call `size()`.
+    fn capacity(&self) -> usize {
+        self.buffer().capacity
+    }
+
+    /// Returns the current size of the queue
+    ///
+    /// This value represents the current size of the queue.  This value can be from 0-`capacity`
+    /// inclusive.
+    fn size(&self) -> usize {
+        self.buffer().size()
+    }
+}
+
+impl<T: Copy> BufferHalf for Producer<T> {
+    type Item = T;
+    fn buffer(&self) -> &Buffer<T> {
+        &*self.buffer
+    }
+    fn eventfd(&self) -> &Cell<Option<Arc<AtomicUsize>>> {
+        &(*self.buffer).producer_eventfd
+    }
+    fn opposite_eventfd(&self) -> &Cell<Option<Arc<AtomicUsize>>> {
+        &(*self.buffer).consumer_eventfd
+    }
+}
+
 impl<T: Copy> Producer<T> {
     /// Attempt to push a value onto the buffer.
     ///
@@ -218,22 +279,6 @@ impl<T: Copy> Producer<T> {
     /// this method will return `Some(v)``, where `v` is your original value.
     pub(crate) fn try_push(&self, v: T) -> Option<T> {
         (*self.buffer).try_push(v)
-    }
-
-    pub(crate) fn must_notify(&self) -> Option<RawFd> {
-        let mem = (*self.buffer).consumer_eventfd.take();
-        let ret = mem.as_ref().map(|x| x.load(Ordering::Acquire) as _);
-        (*self.buffer).consumer_eventfd.set(mem);
-        match ret {
-            None => None,
-            Some(0) => None,
-            Some(x) => Some(x),
-        }
-    }
-
-    pub(crate) fn connect(&self, eventfd: Arc<AtomicUsize>) {
-        let old = (*self.buffer).producer_eventfd.replace(Some(eventfd));
-        assert_eq!(old.is_none(), true);
     }
 
     /// Disconnects the producer, signaling to the consumer that no new values are going to be
@@ -248,21 +293,6 @@ impl<T: Copy> Producer<T> {
     pub(crate) fn consumer_disconnected(&self) -> bool {
         (*self.buffer).consumer_disconnected()
     }
-    /// Returns the total capacity of this queue
-    ///
-    /// This value represents the total capacity of the queue when it is full.  It does not
-    /// represent the current usage.  For that, call `size()`.
-    pub(crate) fn capacity(&self) -> usize {
-        (*self.buffer).capacity
-    }
-
-    /// Returns the current size of the queue
-    ///
-    /// This value represents the current size of the queue.  This value can be from 0-`capacity`
-    /// inclusive.
-    pub(crate) fn size(&self) -> usize {
-        (*self.buffer).tail.load(Ordering::Acquire) - (*self.buffer).head.load(Ordering::Acquire)
-    }
 
     /// Returns the available space in the queue
     ///
@@ -273,23 +303,20 @@ impl<T: Copy> Producer<T> {
     }
 }
 
+impl<T: Copy> BufferHalf for Consumer<T> {
+    type Item = T;
+    fn buffer(&self) -> &Buffer<T> {
+        &(*self.buffer)
+    }
+    fn eventfd(&self) -> &Cell<Option<Arc<AtomicUsize>>> {
+        &(*self.buffer).consumer_eventfd
+    }
+    fn opposite_eventfd(&self) -> &Cell<Option<Arc<AtomicUsize>>> {
+        &(*self.buffer).producer_eventfd
+    }
+}
+
 impl<T: Copy> Consumer<T> {
-    pub(crate) fn connect(&self, eventfd: Arc<AtomicUsize>) {
-        let old = (*self.buffer).consumer_eventfd.replace(Some(eventfd));
-        assert_eq!(old.is_none(), true);
-    }
-
-    pub(crate) fn must_notify(&self) -> Option<RawFd> {
-        let mem = (*self.buffer).producer_eventfd.take();
-        let ret = mem.as_ref().map(|x| x.load(Ordering::Acquire) as _);
-        (*self.buffer).producer_eventfd.set(mem);
-        match ret {
-            None => None,
-            Some(0) => None,
-            Some(x) => Some(x),
-        }
-    }
-
     /// Disconnects the consumer, signaling to the producer that no new values are going to be
     /// consumed. After this is done, any attempt on the producer to try_push should fail
     ///
@@ -310,22 +337,6 @@ impl<T: Copy> Consumer<T> {
     /// being popped off the queue.
     pub(crate) fn try_pop(&self) -> Option<T> {
         (*self.buffer).try_pop()
-    }
-
-    /// Returns the total capacity of this queue
-    ///
-    /// This value represents the total capacity of the queue when it is full.  It does not
-    /// represent the current usage.  For that, call `size()`.
-    pub(crate) fn capacity(&self) -> usize {
-        (*self.buffer).capacity
-    }
-
-    /// Returns the current size of the queue
-    ///
-    /// This value represents the current size of the queue.  This value can be from 0-`capacity`
-    /// inclusive.
-    pub(crate) fn size(&self) -> usize {
-        (*self.buffer).tail.load(Ordering::Acquire) - (*self.buffer).head.load(Ordering::Acquire)
     }
 }
 

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -183,7 +183,7 @@ impl Buffer {
     }
 
     fn consumed_bytes(&mut self) -> Vec<u8> {
-        std::mem::replace(&mut self.data, Vec::new())
+        std::mem::take(&mut self.data)
     }
 
     fn unconsumed_bytes(&self) -> &[u8] {

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -711,7 +711,7 @@ impl DmaStreamWriterState {
                 self.file_pos = final_pos;
             }
         }
-        let mut drainers = std::mem::replace(&mut self.pending, AHashMap::new());
+        let mut drainers = std::mem::take(&mut self.pending);
         let flush_on_close = self.flush_on_close;
         self.file_status = FileStatus::Closing;
         Local::local(async move {

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -194,7 +194,7 @@ impl SharedChannels {
     }
 
     fn process_shared_channels(&mut self, wakers: &mut Vec<Waker>) -> usize {
-        let current_wakers = std::mem::replace(&mut self.wakers_map, BTreeMap::new());
+        let current_wakers = mem::take(&mut self.wakers_map);
         let mut added = 0;
         for (id, mut pending) in current_wakers.into_iter() {
             let room = self.check_map.get(&id).unwrap()();


### PR DESCRIPTION
### What does this PR do?

This PR tries to reduce some repetition in the implementation of `channels` APIs.

### Motivation

Excess code repetition reduces the maintainablity of code.

### Checklist

No APIs were added, so no new unit tests are needed.
* [ ] If applicable, I have discussed my architecture
* [X] The new code I am adding is formatted using `rustfmt`
