### PR TITLE
Fix the `echo` example

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -34,15 +34,9 @@ async fn server(conns: usize) {
 
     let mut servers = vec![];
     for _ in 0..conns {
-        let l = listener.clone();
+        let (stream, _) = listener.accept().await.unwrap();
         servers.push(Local::local(async move {
-            let (stream, _) = l.accept().await.unwrap();
-            loop {
-                let x = copy(&stream, &mut &stream).await.unwrap();
-                if x == 0 {
-                    break;
-                }
-            }
+            while 0 != copy(&stream, &mut &stream).await.unwrap() {}
         }));
     }
     join_all(servers).await;


### PR DESCRIPTION
### What does this PR do?
This PR should fix an issue with the `echo` example, which seems to dead-lock itself in a race condition between multiple `accept` calls...

### Related issues

This PR is related to #207.
