### PR TITLE
 Semaphore implementation was changed to use intrusive linked list  as a container for the awaiting futures.

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -33,6 +33,7 @@ pin-project-lite = "0.1.10"
 smallvec = "1.4.2"
 buddy-alloc = "0.4.1"
 ahash = "0.5.7"
+intrusive-collections = "0.9.0"
 
 [dev-dependencies]
 futures = "0.3.5"

--- a/glommio/src/sync/semaphore.rs
+++ b/glommio/src/sync/semaphore.rs
@@ -52,7 +52,7 @@ impl Waiter {
                     .cursor_mut_from_ptr(self.node.as_ref())
             };
 
-            if !cursor.remove().is_some() {
+            if cursor.remove().is_none() {
                 panic!("Waiter has to be linked into the list of waiting futures");
             }
         }
@@ -179,7 +179,7 @@ fn process_wakes(sem: Rc<RefCell<SemaphoreState>>, units: u64) {
             if waiter_state.units <= available_units {
                 let w = waiter_state.waker.take();
 
-                if let Some(_) = w {
+                if w.is_some() {
                     waker = w;
                 } else {
                     panic!("Future was linked into the waiting list without a waker");


### PR DESCRIPTION
 Semaphore implementation was changed to use an intrusive linked list as a container for the awaiting futures.

### What does this PR do?

 Fix of the issue #195. Part 1.
 Both AHashMap and VecDeque were removed and replaced by the linked list.
 As a result speed of the processing of acquire and release operations has to be improved.
 Heap allocations inevitable to happen inside of the collections
 were removed.

### Motivation

Remove heap allocations inside of synchronization primitives and increase their overall performance.

### Related issues

 Issue #195

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
