### PR TITLE
doc: make unresolved links fatal

### DIFF
--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -249,6 +249,7 @@
 //! });
 //! ```
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![cfg_attr(doc, deny(broken_intra_doc_links))]
 #[macro_use]
 extern crate nix;
 extern crate alloc;


### PR DESCRIPTION
### What does this PR do?

This PR makes the rustdoc warning "unresolved links" fatal.

### Motivation

https://github.com/DataDog/glommio/issues/220#issuecomment-743758354
