### PR TITLE
Rc containers were removed from semaphore implementation.

### DIFF
--- a/glommio/benches/tokio_tcp.rs
+++ b/glommio/benches/tokio_tcp.rs
@@ -64,7 +64,7 @@ async fn main() -> io::Result<()> {
     // round trips
     let mut stream = TcpStream::connect("127.0.0.1:8001").await?;
     let t = Instant::now();
-    for i in 0..runs {
+    for _ in 0..runs {
         let mut byte = [65u8; 1];
         assert_eq!(1, stream.write(&byte).await.unwrap());
         assert_eq!(1, stream.read(&mut byte).await.unwrap());

--- a/glommio/src/sync/semaphore.rs
+++ b/glommio/src/sync/semaphore.rs
@@ -543,7 +543,7 @@ mod test {
     use crate::timer::Timer;
     use crate::{enclose, Local, LocalExecutor};
 
-    use futures::future::join3;
+    use futures_lite::future::or;
     use std::cell::Cell;
     use std::rc::Rc;
     use std::time::{Duration, Instant};
@@ -820,7 +820,7 @@ mod test {
             })
             .detach();
 
-            join3(t3, t2, t1).await;
+            or(or(t1, t2), t3).await;
         });
     }
 }

--- a/glommio/src/sync/semaphore.rs
+++ b/glommio/src/sync/semaphore.rs
@@ -141,6 +141,17 @@ impl<'a> Waiter<'a> {
     }
 }
 
+impl<'a> Drop for Waiter<'a> {
+    fn drop(&mut self) {
+        if self.node.link.is_linked() {
+            //if node is linked that is for sure is pinned so that is safe
+            //to make it pinned directly
+            let waiter_node = unsafe { Pin::new_unchecked(&mut self.node) };
+            Self::remove_from_waiting_queue(waiter_node, &mut self.semaphore.state.borrow_mut())
+        }
+    }
+}
+
 impl<'a> Future for Waiter<'a> {
     type Output = Result<()>;
 


### PR DESCRIPTION
### What does this PR do?

Because Rc is a boxed type, Rc containers which were used inside of semaphore implementation of the waiting queue
were replaced by NonNull-s of Pinned waiting nodes.

To ensure safety the following changes were done:
1. Futures lifetimes were restricted by a lifetime of the Semaphore.
 That is quite a minor restriction because that is typically how sync primitives are used anyway.
2. All waiting nodes were made Pinned.
3. On Drop of the semaphore assertion that waiting queue is empty was added.
4. Permits also were bound to the Semaphore lifetime.

Also, test to ensure the order of execution of waiting tasks was added.

Implementation was check by ASAN.

### Motivation

Remove all heap allocations from semaphore implementation.

### Related issues

Issue #195

### Additional Notes

Unfortunately, ASAN reports that the Reactor is leaking (on code without any changes) so I bound to compare results of the execution of tests before and after the change.

Before change:
SUMMARY: AddressSanitizer: 671739684 byte(s) leaked in 1056 allocation(s).

After change:
SUMMARY: AddressSanitizer: 671739684 byte(s) leaked in 1056 allocation(s).

Leak reported by ASAN:

```
   #0 0x563be1e254fd in malloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
    #1 0x563be49d8bd5 in std::sys::unix::alloc::_$LT$impl$u20$core..alloc..global..GlobalAlloc$u20$for$u20$std..alloc..System$GT$::alloc::h4094fbb2da8d8ff0 /home/andrey/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/alloc.rs:14:13
    #2 0x563be49cc6c1 in __rdl_alloc /home/andrey/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/alloc.rs:356:13
    #3 0x563be4009afe in alloc::alloc::alloc::hf3853c4e036525f8 /home/andrey/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:86:14
    #4 0x563be4009e61 in alloc::alloc::Global::alloc_impl::hd79981f77dd5de27 /home/andrey/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:166:73
    #5 0x563be400b724 in _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::h002ccb1a0bdb6212 /home/andrey/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:226:9
    #6 0x563be40097ea in alloc::alloc::exchange_malloc::h8efbecb76da3dc18 /home/andrey/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:316:11
    #7 0x563be39b958e in alloc::sync::Arc$LT$T$GT$::new::hed85b5c301f28c4c /home/andrey/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/sync.rs:330:25
    #8 0x563be3b6c8e7 in glommio::sys::uring::Reactor::new::hc0d3a6d8fa7d6649 /home/andrey/glommio/glommio/src/sys/uring.rs:1036:29
    #9 0x563be2a10a85 in glommio::parking::Reactor::new::hb5c81574e074abb3 /home/andrey/glommio/glommio/src/parking.rs:250:19
    #10 0x563be417448c in glommio::executor::LocalExecutor::new::h05fdf8ae72f3f90a /home/andrey/glommio/glommio/src/executor.rs:621:30
    #11 0x563be417279a in glommio::executor::LocalExecutorBuilder::make::h34c7f7dd1a78a261 /home/andrey/glommio/glommio/src/executor.rs:460:13
    #12 0x563be41740d7 in glommio::executor::LocalExecutor::make_default::h2629e83df605e8fb /home/andrey/glommio/glommio/src/executor.rs:612:9
```

### Checklist

[x] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
