### PR TITLE
fix Tcp bind

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 concurrent-queue = "1.1.2"
 futures-lite = "1.11.1"
 libc = "0.2.73"
-socket2 = { version = "0.3.12", features = ["pair", "unix"] }
+socket2 = { version = "0.3.18", features = ["unix", "reuseport"] }
 iou = { git = "https://github.com/glommer/iou", tag = "glommio-2020-11-30" }
 uring-sys = { git = "https://github.com/glommer/uring-sys", tag = "scipio-2020-09-10" }
 nix = "0.19.0"


### PR DESCRIPTION
Discovered by Bryan.
The problem is that bind currently doesn't actually uphold ReusePort:
we bind first, and only then set ReusePort, while we should do the opposite.

The test is broken, because in some (most?) runs the executors will end up
serializing. That is because all tests run in parallel and turn all CPUs
busy.

The test is patched to make sure we are keeping the executors alive,
therefore keeping the socket alive too, until the other executor tries
to bind. Before the fix, the test now fails every time. After the fix,
the test no longer fails.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
