### PR TITLE
Trait Default is implemented for LocalExecutor.

### DIFF
--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 fn main() {
-    let ex = LocalExecutor::make_default();
+    let ex = LocalExecutor::default();
     let left = Rc::new(RefCell::new(false));
     let right = Rc::new(RefCell::new(false));
 

--- a/glommio/src/channels/local_channel.rs
+++ b/glommio/src/channels/local_channel.rs
@@ -30,7 +30,7 @@ pub struct LocalSender<T> {
 /// use glommio::channels::local_channel;
 /// use futures_lite::StreamExt;
 ///
-/// let ex = LocalExecutor::make_default();
+/// let ex = LocalExecutor::default();
 /// ex.run(async move {
 ///     let (sender, mut receiver) = local_channel::new_unbounded();
 ///
@@ -199,7 +199,7 @@ impl<T> LocalChannel<T> {
 /// use glommio::channels::local_channel;
 /// use futures_lite::StreamExt;
 ///
-/// let ex = LocalExecutor::make_default();
+/// let ex = LocalExecutor::default();
 /// ex.run(async move {
 ///     let (sender, mut receiver) = local_channel::new_unbounded();
 ///     let h = Local::local(async move {
@@ -222,7 +222,7 @@ pub fn new_unbounded<T>() -> (LocalSender<T>, LocalReceiver<T>) {
 /// use glommio::channels::local_channel;
 /// use futures_lite::StreamExt;
 ///
-/// let ex = LocalExecutor::make_default();
+/// let ex = LocalExecutor::default();
 /// ex.run(async move {
 ///     let (sender, mut receiver) = local_channel::new_bounded(1);
 ///     assert_eq!(sender.is_full(), false);
@@ -249,7 +249,7 @@ impl<T> LocalSender<T> {
     /// use glommio::channels::local_channel;
     /// use futures_lite::StreamExt;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let (sender, mut receiver) = local_channel::new_bounded(1);
     ///     sender.try_send(0);
@@ -284,7 +284,7 @@ impl<T> LocalSender<T> {
     /// use glommio::{LocalExecutor, Local};
     /// use glommio::channels::local_channel;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let (sender, receiver) = local_channel::new_bounded(1);
     ///     sender.send(0).await.unwrap();
@@ -305,7 +305,7 @@ impl<T> LocalSender<T> {
     /// use glommio::{LocalExecutor, Local};
     /// use glommio::channels::local_channel;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let (sender, receiver) = local_channel::new_bounded(1);
     ///     assert_eq!(sender.is_full(), false);
@@ -327,7 +327,7 @@ impl<T> LocalSender<T> {
     /// use glommio::channels::local_channel;
     /// use futures_lite::StreamExt;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let (sender, mut receiver) = local_channel::new_unbounded();
     ///     sender.try_send(0);
@@ -406,7 +406,7 @@ impl<T> LocalReceiver<T> {
     /// use glommio::{LocalExecutor, Local};
     /// use glommio::channels::local_channel;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let (sender, receiver) = local_channel::new_bounded(1);
     ///     sender.send(0).await.unwrap();

--- a/glommio/src/channels/mod.rs
+++ b/glommio/src/channels/mod.rs
@@ -32,7 +32,7 @@ mod spsc_queue;
 /// use glommio::channels::local_channel;
 /// use futures_lite::stream::StreamExt;
 ///
-/// let ex = LocalExecutor::make_default();
+/// let ex = LocalExecutor::default();
 /// ex.run(async move {
 ///     let task_queue =
 ///         Local::create_task_queue(

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -127,7 +127,7 @@ impl<T: Send + Sized + Copy> ConnectedSender<T> {
     /// use glommio::channels::shared_channel;
     /// use futures_lite::StreamExt;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let (sender, receiver) = shared_channel::new_bounded(1);
     ///     let sender = sender.connect();
@@ -181,7 +181,7 @@ impl<T: Send + Sized + Copy> ConnectedSender<T> {
     /// use glommio::prelude::*;
     /// use glommio::channels::shared_channel;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let (sender, receiver) = shared_channel::new_bounded(1);
     ///     let sender = sender.connect();
@@ -251,7 +251,7 @@ impl<T: Send + Sized + Copy> ConnectedReceiver<T> {
     /// use glommio::prelude::*;
     /// use glommio::channels::shared_channel;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let (sender, receiver) = shared_channel::new_bounded(1);
     ///     let sender = sender.connect();

--- a/glommio/src/controllers/deadline_queue.rs
+++ b/glommio/src/controllers/deadline_queue.rs
@@ -342,7 +342,7 @@ impl<T: 'static> DeadlineQueue<T> {
     /// use glommio::controllers::DeadlineQueue;
     /// use std::time::Duration;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     ///
     /// ex.run(async {
     ///     DeadlineQueue::<usize>::new("example", Duration::from_millis(250));
@@ -451,7 +451,7 @@ impl<T: 'static> DeadlineQueue<T> {
     ///     }
     /// }
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     ///
     /// ex.run(async {
     ///     let mut queue = DeadlineQueue::new("example", Duration::from_millis(250));

--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -53,7 +53,7 @@ impl BufferedFile {
     /// use glommio::io::BufferedFile;
     /// use std::os::unix::io::AsRawFd;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let mut wfile = BufferedFile::create("myfile.txt").await.unwrap();
     ///     let mut rfile = BufferedFile::open("myfile.txt").await.unwrap();
@@ -113,7 +113,7 @@ impl BufferedFile {
     /// use glommio::LocalExecutor;
     /// use glommio::io::BufferedFile;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = BufferedFile::create("test.txt").await.unwrap();
     ///

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -61,7 +61,7 @@ pin_project! {
 /// use glommio::LocalExecutor;
 /// use futures_lite::AsyncBufReadExt;
 ///
-/// let ex = LocalExecutor::make_default();
+/// let ex = LocalExecutor::default();
 /// ex.run(async {
 ///     let mut sin = stdin();
 ///     loop {
@@ -223,7 +223,7 @@ impl StreamReaderBuilder {
     /// use glommio::io::{BufferedFile, StreamReaderBuilder};
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = BufferedFile::open("myfile.txt").await.unwrap();
     ///     let _reader = StreamReaderBuilder::new(file).build();
@@ -294,7 +294,7 @@ impl StreamWriterBuilder {
     /// use glommio::io::{BufferedFile, StreamWriterBuilder};
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = BufferedFile::create("myfile.txt").await.unwrap();
     ///     let _reader = StreamWriterBuilder::new(file).build();

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -74,7 +74,7 @@ impl DmaFile {
     /// use glommio::io::DmaFile;
     /// use std::os::unix::io::AsRawFd;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let mut wfile = DmaFile::create("myfile.txt").await.unwrap();
     ///     let mut rfile = DmaFile::open("myfile.txt").await.unwrap();
@@ -186,7 +186,7 @@ impl DmaFile {
     /// use glommio::LocalExecutor;
     /// use glommio::io::DmaFile;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::create("test.txt").await.unwrap();
     ///

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -56,7 +56,7 @@ impl DmaStreamReaderBuilder {
     /// use glommio::{LocalExecutor, Local};
     /// use std::rc::Rc;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = Rc::new(DmaFile::open("myfile.txt").await.unwrap());
     ///     let _reader = DmaStreamReaderBuilder::from_rc(file.clone()).build();
@@ -95,7 +95,7 @@ impl DmaStreamReaderBuilder {
     /// use glommio::io::{DmaFile, DmaStreamReaderBuilder};
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::open("myfile.txt").await.unwrap();
     ///     let _reader = DmaStreamReaderBuilder::new(file).build();
@@ -334,7 +334,7 @@ impl DmaStreamReader {
     /// use glommio::io::{DmaFile, DmaStreamReaderBuilder};
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::open("myfile.txt").await.unwrap();
     ///     let mut reader = DmaStreamReaderBuilder::new(file).build();
@@ -402,7 +402,7 @@ impl DmaStreamReader {
     /// use glommio::io::{DmaFile, DmaStreamReaderBuilder};
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::open("myfile.txt").await.unwrap();
     ///     let mut reader = DmaStreamReaderBuilder::new(file).build();
@@ -440,7 +440,7 @@ impl DmaStreamReader {
     /// use glommio::io::{DmaFile, DmaStreamReaderBuilder};
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::open("myfile.txt").await.unwrap();
     ///     let mut reader = DmaStreamReaderBuilder::new(file).build();
@@ -476,7 +476,7 @@ impl DmaStreamReader {
     /// use glommio::io::{DmaFile, DmaStreamReaderBuilder};
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::open("myfile.txt").await.unwrap();
     ///     let mut reader = DmaStreamReaderBuilder::new(file).build();
@@ -609,7 +609,7 @@ impl DmaStreamWriterBuilder {
     /// use glommio::io::{DmaFile, DmaStreamWriterBuilder};
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::create("myfile.txt").await.unwrap();
     ///     let _reader = DmaStreamWriterBuilder::new(file).build();
@@ -866,7 +866,7 @@ impl DmaStreamWriter {
     /// use glommio::LocalExecutor;
     /// use futures::io::AsyncWriteExt;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::create("myfile.txt").await.unwrap();
     ///     let mut writer = DmaStreamWriterBuilder::new(file).build();
@@ -899,7 +899,7 @@ impl DmaStreamWriter {
     /// use glommio::LocalExecutor;
     /// use futures::io::AsyncWriteExt;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::create("myfile.txt").await.unwrap();
     ///     let mut writer = DmaStreamWriterBuilder::new(file).build();
@@ -936,7 +936,7 @@ impl DmaStreamWriter {
     /// use glommio::LocalExecutor;
     /// use futures::io::AsyncWriteExt;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::create("myfile.txt").await.unwrap();
     ///        let mut writer = DmaStreamWriterBuilder::new(file)

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -235,7 +235,7 @@
 //!
 //! use std::time::Duration;
 //!
-//! let local_ex = LocalExecutor::make_default();
+//! let local_ex = LocalExecutor::default();
 //! local_ex.run(async {
 //!     let timeout = async {
 //!         Timer::new(Duration::from_secs(10)).await;
@@ -297,7 +297,7 @@ macro_rules! test_executor {
     use crate::executor::{LocalExecutor, Task};
     use futures::future::join_all;
 
-    let local_ex = LocalExecutor::make_default();
+    let local_ex = LocalExecutor::default();
     local_ex.run(async move {
         let mut joins = Vec::new();
         $(

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -78,7 +78,7 @@ impl TcpListener {
     /// use glommio::net::TcpListener;
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let listener = TcpListener::bind("127.0.0.1:8000").unwrap();
     ///     println!("Listening on {}", listener.local_addr().unwrap());
@@ -126,7 +126,7 @@ impl TcpListener {
     /// use glommio::net::TcpListener;
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let listener = TcpListener::bind("127.0.0.1:8000").unwrap();
     ///     let stream = listener.shared_accept().await.unwrap();
@@ -159,7 +159,7 @@ impl TcpListener {
     /// use glommio::LocalExecutor;
     /// use futures_lite::stream::StreamExt;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let listener = TcpListener::bind("127.0.0.1:8000").unwrap();
     ///     let stream = listener.accept().await.unwrap();
@@ -183,7 +183,7 @@ impl TcpListener {
     /// use glommio::LocalExecutor;
     /// use futures_lite::stream::StreamExt;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let listener = TcpListener::bind("127.0.0.1:8000").unwrap();
     ///     let mut incoming = listener.incoming();
@@ -206,7 +206,7 @@ impl TcpListener {
     /// use glommio::net::TcpListener;
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let listener = TcpListener::bind("127.0.0.1:8000").unwrap();
     ///     println!("Listening on {}", listener.local_addr().unwrap());
@@ -244,7 +244,7 @@ impl AcceptedTcpStream {
     /// use glommio::{LocalExecutorBuilder, LocalExecutor};
     /// use glommio::channels::shared_channel;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///
     ///    let (sender, receiver) = shared_channel::new_bounded(1);
@@ -345,7 +345,7 @@ impl TcpStream {
     /// use glommio::net::TcpStream;
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     TcpStream::connect("127.0.0.1:10000").await.unwrap();
     /// })
@@ -459,7 +459,7 @@ impl TcpStream {
     /// use glommio::net::TcpStream;
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let stream = TcpStream::connect("127.0.0.1:10000").await.unwrap();
     ///     println!("My peer: {:?}", stream.peer_addr());
@@ -477,7 +477,7 @@ impl TcpStream {
     /// use glommio::net::TcpStream;
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let stream = TcpStream::connect("127.0.0.1:10000").await.unwrap();
     ///     println!("My peer: {:?}", stream.local_addr());

--- a/glommio/src/networking.rs
+++ b/glommio/src/networking.rs
@@ -27,7 +27,7 @@ impl Async<UdpSocket> {
     /// use std::net::UdpSocket;
     /// use glommio::LocalExecutor;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let socket = Async::<UdpSocket>::bind(([127, 0, 0, 1], 0)).unwrap();
     ///     println!("Bound to {}", socket.get_ref().local_addr().unwrap());

--- a/glommio/src/sync/rwlock.rs
+++ b/glommio/src/sync/rwlock.rs
@@ -11,7 +11,7 @@
 //! use glommio::sync::RwLock;
 //! use glommio::LocalExecutor;
 //! let lock = RwLock::new(5);
-//! let ex = LocalExecutor::make_default();
+//! let ex = LocalExecutor::default();
 //!
 //! ex.run( async move {
 //!    // many reader locks can be held at once
@@ -172,7 +172,7 @@ intrusive_adapter!(WaiterAdapter = Rc<WaiterNode> : WaiterNode {link : LinkedLis
 ///use glommio::LocalExecutor;
 ///
 /// let lock = RwLock::new(5);
-/// let ex = LocalExecutor::make_default();
+/// let ex = LocalExecutor::default();
 ///
 /// ex.run( async move {
 ///    // many reader locks can be held at once
@@ -452,7 +452,7 @@ impl<T> RwLock<T> {
     /// use glommio::LocalExecutor;
     ///
     /// let mut lock = RwLock::new(0);
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     ///
     /// ex.run(async move {
     ///     *lock.get_mut().unwrap() = 10;
@@ -493,7 +493,7 @@ impl<T> RwLock<T> {
     /// let lock = Rc::new(RwLock::new(1));
     /// let c_lock = lock.clone();
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     ///
     /// ex.run(async move {
     ///     let first_reader = Local::local(async move {
@@ -550,7 +550,7 @@ impl<T> RwLock<T> {
     /// use glommio::LocalExecutor;
     ///
     /// let lock = RwLock::new(1);
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     ///
     /// ex.run(async move {
     ///     let mut n = lock.write().await.unwrap();
@@ -638,7 +638,7 @@ impl<T> RwLock<T> {
     /// use glommio::LocalExecutor;
     ///
     /// let lock = RwLock::new(1);
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     ///
     /// ex.run(async move {
     ///   let n = lock.read().await.unwrap();
@@ -698,7 +698,7 @@ impl<T> RwLock<T> {
     /// let semaphore = Rc::new(Semaphore::new(0));
     /// let c_semaphore = semaphore.clone();
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///      let closer = Local::local(async move {
     ///          //await till read lock will be acquired
@@ -749,7 +749,7 @@ impl<T> RwLock<T> {
     /// use glommio::LocalExecutor;
     ///
     /// let lock = RwLock::new(String::new());
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     ///
     /// ex.run(async move {
     ///     {
@@ -1269,7 +1269,7 @@ mod test {
 
     #[test]
     fn rwlock_overflow() {
-        let ex = LocalExecutor::make_default();
+        let ex = LocalExecutor::default();
 
         let lock = Rc::new(RwLock::new(()));
         let c_lock = lock.clone();

--- a/glommio/src/sync/semaphore.rs
+++ b/glommio/src/sync/semaphore.rs
@@ -258,7 +258,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(1);
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     {
     ///         let permit = sem.acquire_permit(1).await.unwrap();
@@ -286,7 +286,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(1);
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     sem.acquire(1).await.unwrap();
     ///     sem.signal(1); // Has to be signaled explicitly. Be careful
@@ -331,7 +331,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(1);
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     ///
     /// ex.run(async move {
     ///     assert!(sem.try_acquire(1).unwrap());
@@ -371,7 +371,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(1);
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     ///
     /// ex.run(async move {
     ///   let permit = sem.acquire_permit(1).await.unwrap();
@@ -409,7 +409,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(0);
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     // Note that we can signal to expand to more units than the original capacity had.
     ///     sem.signal(1);
@@ -432,7 +432,7 @@ impl Semaphore {
     ///
     /// let sem = Semaphore::new(0);
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     // Note that we can signal to expand to more units than the original capacity had.
     ///     sem.close();
@@ -650,7 +650,7 @@ mod test {
 
     #[test]
     fn semaphore_overflow() {
-        let ex = LocalExecutor::make_default();
+        let ex = LocalExecutor::default();
         let semaphore = Rc::new(Semaphore::new(0));
         let semaphore_c = semaphore.clone();
 

--- a/glommio/src/sys/dma_buffer.rs
+++ b/glommio/src/sys/dma_buffer.rs
@@ -163,7 +163,7 @@ impl DmaBuffer {
     /// use glommio::LocalExecutor;
     /// use glommio::io::DmaFile;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::create("test.txt").await.unwrap();
     ///     let buf = file.alloc_dma_buffer(4096);
@@ -199,7 +199,7 @@ impl DmaBuffer {
     /// use glommio::LocalExecutor;
     /// use glommio::io::DmaFile;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async {
     ///     let file = DmaFile::create("test.txt").await.unwrap();
     ///     let mut buf = file.alloc_dma_buffer(4096);

--- a/glommio/src/timer/mod.rs
+++ b/glommio/src/timer/mod.rs
@@ -15,7 +15,7 @@ pub use timer_impl::{Timer, TimerActionOnce, TimerActionRepeat};
 /// use glommio::timer::sleep;
 /// use std::time::Duration;
 ///
-/// let ex = LocalExecutor::make_default();
+/// let ex = LocalExecutor::default();
 ///
 /// ex.run(async {
 ///     sleep(Duration::from_millis(100)).await;

--- a/glommio/src/timer/timer_impl.rs
+++ b/glommio/src/timer/timer_impl.rs
@@ -66,7 +66,7 @@ impl Inner {
 ///     Timer::new(dur).await;
 /// }
 ///
-/// let ex = LocalExecutor::make_default();
+/// let ex = LocalExecutor::default();
 ///
 /// ex.run(async {
 ///     sleep(Duration::from_millis(100)).await;
@@ -88,7 +88,7 @@ impl Timer {
     /// use glommio::LocalExecutor;
     /// use std::time::Duration;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     Timer::new(Duration::from_millis(100)).await;
     /// });
@@ -131,7 +131,7 @@ impl Timer {
     /// use glommio::LocalExecutor;
     /// use std::time::Duration;
     ///
-    /// let ex = LocalExecutor::make_default();
+    /// let ex = LocalExecutor::default();
     /// ex.run(async move {
     ///     let mut t = Timer::new(Duration::from_secs(1));
     ///     t.reset(Duration::from_millis(100));


### PR DESCRIPTION
### What does this PR do?

Trait Default is implemented for LocalExecutor.

make_default method is replaced by default.

### Motivation

Make library API to be more aligned with std API.

### Additional Notes

All documentation links and examples are updated.

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[x] The new code I am adding is formatted using `rustfmt`
