### PR TITLE
make every future go through a task queue.

### DIFF
--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -525,10 +525,7 @@ impl LocalExecutorBuilder {
             }
             le.init().unwrap();
             le.run(async move {
-                let task = Task::local(async move {
-                    fut_gen().await;
-                });
-                task.await;
+                fut_gen().await;
             })
         })
     }
@@ -689,7 +686,7 @@ impl LocalExecutor {
         me.yielded = true;
     }
 
-    fn spawn<T: 'static>(&self, future: impl Future<Output = T> + 'static) -> Task<T> {
+    fn spawn<T>(&self, future: impl Future<Output = T>) -> Task<T> {
         let tq = self
             .queues
             .borrow()
@@ -708,8 +705,7 @@ impl LocalExecutor {
         handle: TaskQueueHandle,
     ) -> Result<Task<T>, QueueNotFoundError>
     where
-        T: 'static,
-        F: Future<Output = T> + 'static,
+        F: Future<Output = T>,
     {
         let tq = self
             .get_queue(&handle)
@@ -830,17 +826,20 @@ impl LocalExecutor {
     /// assert_eq!(res, 6);
     /// ```
     pub fn run<T>(&self, future: impl Future<Output = T>) -> T {
-        pin!(future);
-
         let waker = waker_fn(|| {});
         let cx = &mut Context::from_waker(&waker);
 
         let spin_before_park = self.spin_before_park().unwrap_or_default();
 
         LOCAL_EX.set(self, || {
+            let future = self.spawn(async move { future.await }).detach();
+            pin!(future);
+
             loop {
                 if let Poll::Ready(t) = future.as_mut().poll(cx) {
-                    break t;
+                    // can't be canceled, and join handle is None only upon
+                    // cancellation or panic. So in case of panic this just propagates
+                    break t.unwrap();
                 }
 
                 // We want to do I/O before we call run_task_queues,
@@ -856,7 +855,7 @@ impl LocalExecutor {
                         // is exhausted. But if we sleep (park) we'll never know so we
                         // test again here. We can't test *just* here because the main
                         // future is probably the one setting up the task queues and etc.
-                        break t;
+                        break t.unwrap();
                     } else {
                         let spin_start = Instant::now();
                         while !self.reactor.spin_poll_io().unwrap() {
@@ -1791,6 +1790,17 @@ mod test {
             assert!(ratios[1] > ratios[0]);
             assert!(ratios[0] < 0.25);
             assert!(ratios[1] > 0.50);
+        });
+    }
+
+    #[test]
+    fn multiple_spawn() {
+        // Issue 241
+        LocalExecutor::default().run(async {
+            Local::local(async {}).detach().await;
+            // In issue 241, the presence of the second detached waiter caused
+            // the program to hang.
+            Local::local(async {}).detach().await;
         });
     }
 }

--- a/glommio/src/multitask.rs
+++ b/glommio/src/multitask.rs
@@ -125,10 +125,10 @@ impl LocalExecutor {
     }
 
     /// Spawns a thread-local future onto this executor.
-    pub(crate) fn spawn<T: 'static>(
+    pub(crate) fn spawn<T>(
         &self,
         tq: Rc<RefCell<TaskQueue>>,
-        future: impl Future<Output = T> + 'static,
+        future: impl Future<Output = T>,
     ) -> Task<T> {
         let tq = Rc::downgrade(&tq);
 

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -85,8 +85,8 @@ impl<F, R, S> Clone for RawTask<F, R, S> {
 
 impl<F, R, S> RawTask<F, R, S>
 where
-    F: Future<Output = R> + 'static,
-    S: Fn(Task) + 'static,
+    F: Future<Output = R>,
+    S: Fn(Task),
 {
     const RAW_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
         Self::clone_waker,
@@ -375,13 +375,13 @@ where
 
         struct Guard<'a, F, R, S>(&'a RawTask<F, R, S>)
         where
-            F: Future<Output = R> + 'static,
-            S: Fn(Task) + 'static;
+            F: Future<Output = R>,
+            S: Fn(Task);
 
         impl<'a, F, R, S> Drop for Guard<'a, F, R, S>
         where
-            F: Future<Output = R> + 'static,
-            S: Fn(Task) + 'static,
+            F: Future<Output = R>,
+            S: Fn(Task),
         {
             fn drop(&mut self) {
                 let raw = self.0;
@@ -573,13 +573,13 @@ where
         /// A guard that closes the task if polling its future panics.
         struct Guard<F, R, S>(RawTask<F, R, S>)
         where
-            F: Future<Output = R> + 'static,
-            S: Fn(Task) + 'static;
+            F: Future<Output = R>,
+            S: Fn(Task);
 
         impl<F, R, S> Drop for Guard<F, R, S>
         where
-            F: Future<Output = R> + 'static,
-            S: Fn(Task) + 'static,
+            F: Future<Output = R>,
+            S: Fn(Task),
         {
             fn drop(&mut self) {
                 let raw = self.0;

--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -26,9 +26,8 @@ use crate::task::JoinHandle;
 /// [`JoinHandle`]: struct.JoinHandle.html
 pub(crate) fn spawn_local<F, R, S>(future: F, schedule: S) -> (Task, JoinHandle<R>)
 where
-    F: Future<Output = R> + 'static,
-    R: 'static,
-    S: Fn(Task) + 'static,
+    F: Future<Output = R>,
+    S: Fn(Task),
 {
     // Allocate large futures on the heap.
     let raw_task = if mem::size_of::<F>() >= 2048 {


### PR DESCRIPTION
We currently have a weird leftover requirement that the first future
that we pass to run() be special. It doesn't run in a task queue, because
that is the future we run to completion.

Such requirement creates an asymmetry that was sooner or later bound to
cause issues, as there are many things that you cannot do if you don't
have a task queue where you are running.

This patch moves the initial future inside a task queue as well. Now
everything is symmetric and there are no special cases.

Our spawn functions all force futures to be 'static, so we need to
remove this requirement. We keep the requirement in outter functions
because the ability to .detach() them means that we truly cannot
control the lifetime.

Fixes #241

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
[] The new code I am adding is formatted using `rustfmt`
