### PR TITLE
+DmaOpenOptions

### DIFF
--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -154,10 +154,6 @@ impl DmaFile {
         let mut f = enhanced_try!(res, opdesc, Some(path), None)?;
         // FIXME: Don't assume 512 or 4096, we can read this info from sysfs
         // currently, we just use the minimal {values which make sense}
-        // NOTE(zserik): if we later add a opts.append "option", then
-        // the following condition should be replaced with a method call which
-        // evaluates to `opts.write || opts.append`
-        // (because we don't want to make both members `pub(super)`)
         f.o_direct_alignment = if opts.write { 4096 } else { 512 };
         Ok(f)
     }

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -3,6 +3,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
+use crate::io::dma_open_options::DmaOpenOptions;
 use crate::io::glommio_file::GlommioFile;
 use crate::io::read_result::ReadResult;
 use crate::sys::sysfs;
@@ -94,7 +95,7 @@ impl DmaFile {
         dir: RawFd,
         path: &Path,
         flags: libc::c_int,
-        mode: libc::c_int,
+        mode: libc::mode_t,
     ) -> io::Result<DmaFile> {
         let mut pollable = PollableStatus::Pollable;
         let res = GlommioFile::open_at(dir, path, flags, mode).await;
@@ -136,6 +137,31 @@ impl DmaFile {
         })
     }
 
+    pub(super) async fn open_with_options<'a>(
+        dir: RawFd,
+        path: &'a Path,
+        opdesc: &'static str,
+        opts: &'a DmaOpenOptions,
+    ) -> io::Result<DmaFile> {
+        // try to open the file with O_DIRECT if the underlying media supports it
+        let flags = libc::O_CLOEXEC
+            | libc::O_DIRECT
+            | opts.get_access_mode()?
+            | opts.get_creation_mode()?
+            | (opts.custom_flags as libc::c_int & !libc::O_ACCMODE);
+
+        let res = DmaFile::open_at(dir, path, flags, opts.mode).await;
+        let mut f = enhanced_try!(res, opdesc, Some(path), None)?;
+        // FIXME: Don't assume 512 or 4096, we can read this info from sysfs
+        // currently, we just use the minimal {values which make sense}
+        // NOTE(zserik): if we later add a opts.append "option", then
+        // the following condition should be replaced with a method call which
+        // evaluates to `opts.write || opts.append`
+        // (because we don't want to make both members `pub(super)`)
+        f.o_direct_alignment = if opts.write { 4096 } else { 512 };
+        Ok(f)
+    }
+
     /// Allocates a buffer that is suitable for using to write to this file.
     pub fn alloc_dma_buffer(&self, size: usize) -> DmaBuffer {
         self.file.reactor.upgrade().unwrap().alloc_dma_buffer(size)
@@ -143,25 +169,17 @@ impl DmaFile {
 
     /// Similar to `create()` in the standard library, but returns a DMA file
     pub async fn create<P: AsRef<Path>>(path: P) -> io::Result<DmaFile> {
-        // try to open the file with O_DIRECT if the underlying media supports it
-        let flags =
-            libc::O_DIRECT | libc::O_CLOEXEC | libc::O_CREAT | libc::O_TRUNC | libc::O_WRONLY;
-        let res = DmaFile::open_at(-1_i32, path.as_ref(), flags, 0o644).await;
-
-        let mut f = enhanced_try!(res, "Creating", Some(path.as_ref()), None)?;
-        f.o_direct_alignment = 4096;
-        Ok(f)
+        DmaOpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path.as_ref())
+            .await
     }
 
     /// Similar to `open()` in the standard library, but returns a DMA file
     pub async fn open<P: AsRef<Path>>(path: P) -> io::Result<DmaFile> {
-        // try to open the file with O_DIRECT if the underlying media supports it
-        let flags = libc::O_DIRECT | libc::O_CLOEXEC | libc::O_RDONLY;
-        let res = DmaFile::open_at(-1_i32, path.as_ref(), flags, 0o644).await;
-
-        let mut f = enhanced_try!(res, "Opening", Some(path.as_ref()), None)?;
-        f.o_direct_alignment = 512;
-        Ok(f)
+        DmaOpenOptions::new().read(true).open(path.as_ref()).await
     }
 
     /// Write the buffer in `buf` to a specific position in the file.

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -14,7 +14,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 use std::rc::Rc;
 
-type Result<T> = crate::Result<T, ()>;
+pub(super) type Result<T> = crate::Result<T, ()>;
 
 pub(crate) fn align_up(v: u64, align: u64) -> u64 {
     (v + align - 1) & !(align - 1)
@@ -144,7 +144,7 @@ impl DmaFile {
         path: &'a Path,
         opdesc: &'static str,
         opts: &'a DmaOpenOptions,
-    ) -> io::Result<DmaFile> {
+    ) -> Result<DmaFile> {
         // try to open the file with O_DIRECT if the underlying media supports it
         let flags = libc::O_CLOEXEC
             | libc::O_DIRECT

--- a/glommio/src/io/dma_open_options.rs
+++ b/glommio/src/io/dma_open_options.rs
@@ -1,0 +1,192 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the
+// MIT/Apache-2.0 License, at your convenience
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//
+use crate::io::dma_file::DmaFile;
+use std::io;
+use std::path::Path;
+
+/// Options and flags which can be used to configure how a file is opened.
+///
+/// This builder exposes the ability to configure how a [`DmaFile`] is opened
+/// and what operations are permitted on the open file.
+/// The [`DmaFile::open`] and [`DmaFile::create`] methods are aliases for commonly used options using this builder.
+#[derive(Clone, Debug)]
+pub struct DmaOpenOptions {
+    read: bool,
+    pub(super) write: bool,
+    truncate: bool,
+    create: bool,
+    create_new: bool,
+    // system-specific
+    pub(super) custom_flags: libc::c_int,
+    pub(super) mode: libc::mode_t,
+}
+
+impl Default for DmaOpenOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DmaOpenOptions {
+    /// Creates a blank new set of options ready for configuration.
+    ///
+    /// All options are initially set to false.
+    pub fn new() -> Self {
+        Self {
+            read: false,
+            write: false,
+            truncate: false,
+            create: false,
+            create_new: false,
+            // system-specific
+            custom_flags: 0,
+            // previously, we defaulted to 0o644, but 0o666 is usedd by libstd
+            mode: 0o666,
+        }
+    }
+
+    // the following methods are directly taken from std/sys/unix/fs.rs
+    // NOTE(zserik): I omitted `append` from the following methods.
+    //               I don't think it makes much sense for unbuffered files.
+
+    /// Sets the option for read access.
+    ///
+    /// This option, when true, will indicate that the file should be read-able if opened.
+    pub fn read(&mut self, read: bool) -> &mut Self {
+        self.read = read;
+        self
+    }
+
+    /// Sets the option for write access.
+    ///
+    /// This option, when true, will indicate that the file should be write-able if opened.
+    ///
+    /// If the file already exists, any write calls on it will overwrite its contents, without truncating it.
+    pub fn write(&mut self, write: bool) -> &mut Self {
+        self.write = write;
+        self
+    }
+
+    /// Sets the option for truncating a previous file.
+    ///
+    /// If a file is successfully opened with this option set it will truncate the file to 0 length if it already exists.
+    ///
+    /// The file must be opened with write access for truncate to work.
+    pub fn truncate(&mut self, truncate: bool) -> &mut Self {
+        self.truncate = truncate;
+        self
+    }
+
+    /// Sets the option to create a new file, or open it if it already exists.
+    ///
+    /// In order for the file to be created, [`DmaOpenOptions::write`] access must be used.
+    pub fn create(&mut self, create: bool) -> &mut Self {
+        self.create = create;
+        self
+    }
+
+    /// Sets the option to create a new file, failing if it already exists.
+    ///
+    /// No file is allowed to exist at the target location, also no (dangling) symlink. In this way, if the call succeeds, the file returned is guaranteed to be new.
+    ///
+    /// This option is useful because it is atomic. Otherwise between checking whether a file exists and creating a new one, the file may have been created by another process (a TOCTOU race condition / attack).
+    ///
+    /// If `.create_new(true)` is set, `.create()` and `.truncate()` are ignored.
+    ///
+    /// The file must be opened with write or append access in order to create a new file.
+    pub fn create_new(&mut self, create_new: bool) -> &mut Self {
+        self.create_new = create_new;
+        self
+    }
+
+    /// Pass custom flags to the flags argument of `open_at`.
+    pub fn custom_flags(&mut self, flags: i32) -> &mut Self {
+        self.custom_flags = flags;
+        self
+    }
+
+    /// Sets the mode bits that a new file will be created with.
+    pub fn mode(&mut self, mode: libc::mode_t) -> &mut Self {
+        self.mode = mode;
+        self
+    }
+
+    pub(super) fn get_access_mode(&self) -> io::Result<libc::c_int> {
+        /*
+        Ok(match (self.read, self.write, self.append) {
+            (true, false, false) => libc::O_RDONLY,
+            (false, true, false) => libc::O_WRONLY,
+            (true, true, false) => libc::O_RDWR,
+            (false, _, true) => libc::O_WRONLY | libc::O_APPEND,
+            (true, _, true) => libc::O_RDWR | libc::O_APPEND,
+            (false, false, false) => return Err(io::Error::from_raw_os_error(libc::EINVAL)),
+        })
+        */
+
+        Ok(match (self.read, self.write) {
+            (true, false) => libc::O_RDONLY,
+            (false, true) => libc::O_WRONLY,
+            (true, true) => libc::O_RDWR,
+            (false, false) => return Err(io::Error::from_raw_os_error(libc::EINVAL)),
+        })
+    }
+
+    pub(super) fn get_creation_mode(&self) -> io::Result<libc::c_int> {
+        /*
+        match (self.write, self.append) {
+            (true, false) => {}
+            (false, false) => {
+                if self.truncate || self.create || self.create_new {
+                    return Err(io::Error::from_raw_os_error(libc::EINVAL));
+                }
+            }
+            (_, true) => {
+                if self.truncate && !self.create_new {
+                    return Err(io::Error::from_raw_os_error(libc::EINVAL));
+                }
+            }
+        }
+        */
+
+        if !self.write && (self.truncate || self.create || self.create_new) {
+            return Err(io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        Ok(match (self.create, self.truncate, self.create_new) {
+            (false, false, false) => 0,
+            (true, false, false) => libc::O_CREAT,
+            (false, true, false) => libc::O_TRUNC,
+            (true, true, false) => libc::O_CREAT | libc::O_TRUNC,
+            (_, _, true) => libc::O_CREAT | libc::O_EXCL,
+        })
+    }
+
+    /// Similiar to `OpenOptions::open()` in the standard library, but returns a DMA file
+    pub async fn open<P: AsRef<Path>>(&self, path: P) -> io::Result<DmaFile> {
+        DmaFile::open_with_options(
+            -1_i32,
+            path.as_ref(),
+            if self.create || self.create_new {
+                "Creating"
+            } else {
+                "Opening"
+            },
+            self,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    /*
+    use super::*;
+    use crate::test_utils::*;
+    use crate::{ByteSliceMutExt, Local};
+    */
+
+    // TODO: add tests
+}

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -69,7 +69,7 @@ impl GlommioFile {
         dir: RawFd,
         path: &Path,
         flags: libc::c_int,
-        mode: libc::c_int,
+        mode: libc::mode_t,
     ) -> io::Result<GlommioFile> {
         let reactor = Local::get_reactor();
         let path = if dir == -1 && path.is_relative() {

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -108,6 +108,7 @@ mod buffered_file_stream;
 mod directory;
 mod dma_file;
 mod dma_file_stream;
+mod dma_open_options;
 mod glommio_file;
 mod read_result;
 
@@ -143,5 +144,6 @@ pub use self::dma_file::DmaFile;
 pub use self::dma_file_stream::{
     DmaStreamReader, DmaStreamReaderBuilder, DmaStreamWriter, DmaStreamWriterBuilder,
 };
+pub use self::dma_open_options::DmaOpenOptions;
 pub use self::read_result::ReadResult;
 pub use crate::sys::DmaBuffer;

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -487,7 +487,7 @@ impl Reactor {
         dir: RawFd,
         path: &Path,
         flags: libc::c_int,
-        mode: libc::c_int,
+        mode: libc::mode_t,
     ) -> Source {
         let path = CString::new(path.as_os_str().as_bytes()).expect("path contained null!");
 

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -1195,7 +1195,7 @@ impl Reactor {
         self.queue_standard_request(source, op);
     }
 
-    pub(crate) fn open_at(&self, source: &Source, flags: libc::c_int, mode: libc::c_int) {
+    pub(crate) fn open_at(&self, source: &Source, flags: libc::c_int, mode: libc::mode_t) {
         let pathptr = match &*source.source_type() {
             SourceType::Open(cstring) => cstring.as_c_str().as_ptr(),
             _ => panic!("Wrong source type!"),


### PR DESCRIPTION
### What does this PR do?

This PR adds a struct `DmaOpenOptions`, which allows to more freely choose `open_at` arguments via an already established builder pattern taken from libstd (e.g. it is modeled after [std::fs::OpenOptions](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html))

### Motivation

Previously, it was not possible afaik to open a file exclusively (`create_new`).

### Related issues

Fixes #249 (`create_new`)

### Additional Notes

This PR changes the default DmaFile opening mode from 0o644 to 0o666, to behave more similiar to the rust standard library.
Additionally, it changes the type of the `mode` argument of `read_at` in several places from `libc::c_int` to the more appropriate `libc::mode_t`.

I omitted `append` from the `DmaOpenOptions` methods. I don't think it makes much sense for unbuffered files.

Unit tests are still missing, which might be a bit challenging, at it is really hard to test every use case with such an kinda "open-end" builder pattern.

### Checklist

* [ ] I have added unit tests to the code I am submitting
* [ ] My unit tests cover both failure and success scenarios
* [X] If applicable, I have discussed my architecture
* [X] The new code I am adding is formatted using `rustfmt`
