### PR TITLE
Add TTL methods to TcpStream and TcpListener

### DIFF
--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -411,6 +411,48 @@ impl TcpStream {
         self.stream.rx_buf_size
     }
 
+    /// Gets the value of the `IP_TTL` option for this socket.
+    ///
+    /// This option configures the time-to-live field that is used in every packet sent from this
+    /// socket.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use glommio::net::TcpStream;
+    /// use glommio::LocalExecutor;
+    ///
+    /// let ex = LocalExecutor::default();
+    /// ex.run(async move {
+    ///     let stream = TcpStream::connect("127.0.0.1:10000").await.unwrap();
+    ///     stream.set_ttl(100).expect("could not set TTL");
+    ///     assert_eq!(stream.ttl().unwrap(), 100);
+    /// });
+    /// ```
+    pub fn ttl(&self) -> Result<u32> {
+        Ok(self.stream.stream.ttl()?)
+    }
+
+    /// Sets the value of the `IP_TTL` option for this socket.
+    ///
+    /// This option configures the time-to-live field that is used in every packet sent from this
+    /// socket.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use glommio::net::TcpStream;
+    /// use glommio::LocalExecutor;
+    ///
+    /// let ex = LocalExecutor::default();
+    /// ex.run(async move {
+    ///     let stream = TcpStream::connect("127.0.0.1:10000").await.unwrap();
+    ///     stream.set_ttl(100).expect("could not set TTL");
+    ///     assert_eq!(stream.ttl().unwrap(), 100);
+    /// });
+    /// ```
+    pub fn set_ttl(&self, ttl: u32) -> Result<()> {
+        Ok(self.stream.stream.set_ttl(ttl)?)
+    }
+
     /// Receives data on the socket from the remote address to which it is connected, without removing that data from the queue.
     ///
     /// On success, returns the number of bytes peeked.
@@ -522,6 +564,17 @@ mod tests {
             let listener = TcpListener::bind("127.0.0.1:0").unwrap();
             listener.set_ttl(100).unwrap();
             assert_eq!(listener.ttl().unwrap(), 100);
+        });
+    }
+
+    #[test]
+    fn tcp_stream_ttl() {
+        test_executor!(async move {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            let stream = TcpStream::connect(addr).await.unwrap();
+            stream.set_ttl(100).unwrap();
+            assert_eq!(stream.ttl().unwrap(), 100);
         });
     }
 

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -215,6 +215,50 @@ impl TcpListener {
     pub fn local_addr(&self) -> Result<SocketAddr> {
         Ok(self.listener.local_addr()?)
     }
+
+    /// Gets the value of the `IP_TTL` option for this socket.
+    ///
+    /// This option configures the time-to-live field that is used in every packet sent from this
+    /// socket.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use glommio::net::TcpListener;
+    /// use glommio::LocalExecutor;
+    ///
+    /// let ex = LocalExecutor::default();
+    /// ex.run(async move {
+    ///     let listener = TcpListener::bind("127.0.0.1:8000").unwrap();
+    ///
+    ///     listener.set_ttl(100).expect("could not set TTL");
+    ///     assert_eq!(listener.ttl().unwrap(), 100);
+    /// });
+    /// ```
+    pub fn ttl(&self) -> Result<u32> {
+        Ok(self.listener.ttl()?)
+    }
+
+    /// Sets the value of the `IP_TTL` option for this socket.
+    ///
+    /// This option configures the time-to-live field that is used in every packet sent from this
+    /// socket.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use glommio::net::TcpListener;
+    /// use glommio::LocalExecutor;
+    ///
+    /// let ex = LocalExecutor::default();
+    /// ex.run(async move {
+    ///     let listener = TcpListener::bind("127.0.0.1:8000").unwrap();
+    ///
+    ///     listener.set_ttl(100).expect("could not set TTL");
+    ///     assert_eq!(listener.ttl().unwrap(), 100);
+    /// });
+    /// ```
+    pub fn set_ttl(&self, ttl: u32) -> Result<()> {
+        Ok(self.listener.set_ttl(ttl)?)
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -471,6 +515,15 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+
+    #[test]
+    fn tcp_listener_ttl() {
+        test_executor!(async move {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_ttl(100).unwrap();
+            assert_eq!(listener.ttl().unwrap(), 100);
+        });
+    }
 
     #[test]
     fn connect_local_server() {


### PR DESCRIPTION
### What does this PR do?

Adds TTL getters and setters for `TcpStream` and `TcpListener`.

### Motivation

Start work on issue #243

### Related issues

#243

### Checklist

[x] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture

### Additional Notes

The doc examples were adapted from the corresponding ones in `tokio` and `async-net`.