### PR TITLE
TcpStream nodelay methods

### DIFF
--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -419,6 +419,27 @@ impl TcpStream {
         self.stream.stream.set_nodelay(value).map_err(Into::into)
     }
 
+    /// Gets the `TCP_NODELAY` option on this socket.
+    ///
+    /// For more information about this option, see [`TcpStream::set_nodelay`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use glommio::net::TcpStream;
+    /// use glommio::LocalExecutor;
+    ///
+    /// let ex = LocalExecutor::default();
+    /// ex.run(async move {
+    ///     let stream = TcpStream::connect("127.0.0.1:10000").await.unwrap();
+    ///     stream.set_nodelay(true).expect("set_nodelay call failed");
+    ///     assert_eq!(stream.nodelay().unwrap(), true);
+    /// });
+    /// ```
+    pub fn nodelay(&self) -> Result<bool> {
+        self.stream.stream.nodelay().map_err(Into::into)
+    }
+
     /// Sets the buffer size used on the receive path
     pub fn set_buffer_size(&mut self, buffer_size: usize) {
         self.stream.rx_buf_size = buffer_size;
@@ -593,6 +614,17 @@ mod tests {
             let stream = TcpStream::connect(addr).await.unwrap();
             stream.set_ttl(100).unwrap();
             assert_eq!(stream.ttl().unwrap(), 100);
+        });
+    }
+
+    #[test]
+    fn tcp_stream_nodelay() {
+        test_executor!(async move {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            let stream = TcpStream::connect(addr).await.unwrap();
+            stream.set_nodelay(true).expect("set_nodelay call failed");
+            assert_eq!(stream.nodelay().unwrap(), true);
         });
     }
 

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -394,9 +394,27 @@ impl TcpStream {
             .map_err(Into::into)
     }
 
-    /// Sets the `TCP_NODELAY` option to this socket.
+
+    /// Sets the value of the `TCP_NODELAY` option on this socket.
     ///
-    /// Setting this to true disabled the Nagle algorithm.
+    /// If set, this option disables the Nagle algorithm. This means that
+    /// segments are always sent as soon as possible, even if there is only a
+    /// small amount of data. When not set, data is buffered until there is a
+    /// sufficient amount to send out, thereby avoiding the frequent sending of
+    /// small packets.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use glommio::net::TcpStream;
+    /// use glommio::LocalExecutor;
+    ///
+    /// let ex = LocalExecutor::default();
+    /// ex.run(async move {
+    ///     let stream = TcpStream::connect("127.0.0.1:10000").await.unwrap();
+    ///     stream.set_nodelay(true).expect("set_nodelay call failed");
+    /// });
+    /// ```
     pub fn set_nodelay(&self, value: bool) -> Result<()> {
         self.stream.stream.set_nodelay(value).map_err(Into::into)
     }

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -397,7 +397,7 @@ impl TcpStream {
     /// Sets the `TCP_NODELAY` option to this socket.
     ///
     /// Setting this to true disabled the Nagle algorithm.
-    pub fn set_nodelay(&mut self, value: bool) -> Result<()> {
+    pub fn set_nodelay(&self, value: bool) -> Result<()> {
         self.stream.stream.set_nodelay(value).map_err(Into::into)
     }
 

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -394,7 +394,6 @@ impl TcpStream {
             .map_err(Into::into)
     }
 
-
     /// Sets the value of the `TCP_NODELAY` option on this socket.
     ///
     /// If set, this option disables the Nagle algorithm. This means that


### PR DESCRIPTION
### What does this PR do?

Adds the `TcpStream::nodelay` getter and changes `TcpStream::set_nodelay`'s signature to match [`std::net::TcpStream`](https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_nodelay).

### Motivation

Continue work on #243 

### Related issues

#243 

### Additional Notes

For 735251c, I included the standard library rationale for `set_nodelay` (and most other socket setters) taking an immutable reference, i.e. 
> RFC 1145: "This aspect mirrors the ability of the underlying system to deal with concurrent modification of socket options."

This PR changes the `set_nodelay` signature from `&mut` to `&`. The opposite change, moving from `&` to `&mut`, breaks semver since old code may fail to compile. On the other hand I am relatively sure `&mut` to `&` doesn't count as API breakage, since passing `&mut` to a method expecting `&` will still compile, although there might be new warnings about needless mutability: [playground example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=e4096a90e9fcf367875dcc680a580547).
 
### Checklist

[x] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
