### PR TITLE
Issue #229 has been fixed. 

### DIFF
--- a/glommio/src/multitask.rs
+++ b/glommio/src/multitask.rs
@@ -129,7 +129,7 @@ impl LocalExecutor {
     pub(crate) fn spawn<T>(
         &self,
         tq: Rc<RefCell<TaskQueue>>,
-        future: impl Future<Output=T>,
+        future: impl Future<Output = T>,
     ) -> Task<T> {
         let tq = Rc::downgrade(&tq);
 

--- a/glommio/src/multitask.rs
+++ b/glommio/src/multitask.rs
@@ -113,6 +113,7 @@ pub(crate) struct LocalExecutor {
 }
 
 impl UnwindSafe for LocalExecutor {}
+
 impl RefUnwindSafe for LocalExecutor {}
 
 impl LocalExecutor {
@@ -128,18 +129,21 @@ impl LocalExecutor {
     pub(crate) fn spawn<T>(
         &self,
         tq: Rc<RefCell<TaskQueue>>,
-        future: impl Future<Output = T>,
+        future: impl Future<Output=T>,
     ) -> Task<T> {
         let tq = Rc::downgrade(&tq);
 
         // The function that schedules a runnable task when it gets woken up.
         let schedule = move |runnable: Runnable| {
-            let tq = tq.upgrade().unwrap();
-            {
-                let queue = tq.borrow();
-                queue.ex.local_queue.push(runnable);
+            let tq = tq.upgrade();
+
+            if let Some(tq) = tq {
+                {
+                    let queue = tq.borrow();
+                    queue.ex.local_queue.push(runnable);
+                }
+                maybe_activate(tq);
             }
-            maybe_activate(tq);
         };
 
         // Create a task, push it into the queue by scheduling it, and return its `Task` handle.

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -138,10 +138,12 @@ impl Timers {
         self.timer_id
     }
 
-    fn remove(&mut self, id: u64) {
+    fn remove(&mut self, id: u64) -> Option<Waker> {
         if let Some(when) = self.timers_by_id.remove(&id) {
-            self.timers.remove(&(when, id));
+            return self.timers.remove(&(when, id));
         }
+
+        None
     }
 
     fn insert(&mut self, id: u64, when: Instant, waker: Waker) {
@@ -507,15 +509,15 @@ impl Reactor {
     /// Registers a timer in the reactor.
     ///
     /// Returns the inserted timer's ID.
-    pub(crate) fn insert_timer(&self, id: u64, when: Instant, waker: &Waker) {
+    pub(crate) fn insert_timer(&self, id: u64, when: Instant, waker: Waker) {
         let mut timers = self.timers.borrow_mut();
-        timers.insert(id, when, waker.clone());
+        timers.insert(id, when, waker);
     }
 
     /// Deregisters a timer from the reactor.
-    pub(crate) fn remove_timer(&self, id: u64) {
+    pub(crate) fn remove_timer(&self, id: u64) -> Option<Waker> {
         let mut timers = self.timers.borrow_mut();
-        timers.remove(id);
+        timers.remove(id)
     }
 
     /// Processes ready timers and extends the list of wakers to wake.

--- a/glommio/src/timer/timer_impl.rs
+++ b/glommio/src/timer/timer_impl.rs
@@ -693,9 +693,9 @@ impl TimerActionRepeat {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::LocalExecutorBuilder;
     use std::cell::RefCell;
     use std::rc::Rc;
-    use crate::LocalExecutorBuilder;
 
     #[test]
     fn basic_timer_works() {
@@ -1003,13 +1003,15 @@ mod test {
         // 2. Ensure correct clean up of resources in case of presence of unfinished tasks. Previous
         // versions of timer and executor caused abort of the program at some cases.
 
-        let handle = LocalExecutorBuilder::new().spawn(|| async move {
-            let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
-                println!("hello");
-            });
+        let handle = LocalExecutorBuilder::new()
+            .spawn(|| async move {
+                let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
+                    println!("hello");
+                });
 
-            action.rearm_in(Duration::from_millis(100));
-        }).unwrap();
+                action.rearm_in(Duration::from_millis(100));
+            })
+            .unwrap();
 
         handle.join().unwrap();
     }

--- a/glommio/src/timer/timer_impl.rs
+++ b/glommio/src/timer/timer_impl.rs
@@ -10,7 +10,7 @@ use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::{Rc, Weak};
-use std::task::{Context, Poll, Waker};
+use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 type Result<T> = crate::Result<T, ()>;
@@ -19,7 +19,7 @@ type Result<T> = crate::Result<T, ()>;
 struct Inner {
     id: u64,
 
-    waker: Option<Waker>,
+    is_charged: bool,
 
     /// When this timer fires.
     when: Instant,
@@ -29,15 +29,16 @@ struct Inner {
 
 impl Inner {
     fn reset(&mut self, dur: Duration) {
-        if self.waker.as_ref().is_some() {
+        let mut waker = None;
+        if self.is_charged {
             // Deregister the timer from the reactor.
-            self.reactor.upgrade().unwrap().remove_timer(self.id);
+            waker = self.reactor.upgrade().unwrap().remove_timer(self.id);
         }
 
         // Update the timeout.
         self.when = Instant::now() + dur;
 
-        if let Some(waker) = self.waker.as_mut() {
+        if let Some(waker) = waker {
             // Re-register the timer with the new timeout.
             self.reactor
                 .upgrade()
@@ -100,7 +101,7 @@ impl Timer {
         Timer {
             inner: Rc::new(RefCell::new(Inner {
                 id: reactor.register_timer(),
-                waker: None,
+                is_charged: false,
                 when: Instant::now() + dur,
                 reactor: Rc::downgrade(&reactor),
             })),
@@ -113,7 +114,7 @@ impl Timer {
         Timer {
             inner: Rc::new(RefCell::new(Inner {
                 id,
-                waker: None,
+                is_charged: false,
                 when: Instant::now() + dur,
                 reactor: Rc::downgrade(&Local::get_reactor()),
             })),
@@ -148,10 +149,14 @@ impl Timer {
 
 impl Drop for Timer {
     fn drop(&mut self) {
-        let mut inner = self.inner.borrow_mut();
-        if inner.waker.take().is_some() {
-            // Deregister the timer from the reactor.
-            inner.reactor.upgrade().unwrap().remove_timer(inner.id);
+        let inner = self.inner.borrow_mut();
+        if inner.is_charged {
+            // Deregister the timer from the reactor. Reactor can be dropped already
+            //if that is the case then reactor already removed the timer and we do not need
+            //to do anything
+            if let Some(reactor) = inner.reactor.upgrade() {
+                reactor.remove_timer(inner.id);
+            }
         }
     }
 }
@@ -172,8 +177,8 @@ impl Future for Timer {
                 .reactor
                 .upgrade()
                 .unwrap()
-                .insert_timer(inner.id, inner.when, cx.waker());
-            inner.waker = Some(cx.waker().clone());
+                .insert_timer(inner.id, inner.when, cx.waker().clone());
+            inner.is_charged = true;
             Poll::Pending
         }
     }
@@ -690,6 +695,7 @@ mod test {
     use super::*;
     use std::cell::RefCell;
     use std::rc::Rc;
+    use crate::LocalExecutorBuilder;
 
     #[test]
     fn basic_timer_works() {
@@ -985,5 +991,26 @@ mod test {
             let v = action.join().await;
             assert!(v.is_none());
         });
+    }
+
+    #[test]
+    fn test_memory_leak_unfinished_timer() {
+        //There are two targets of this test
+        // 1. To detect absence of memory leaks in case of unfinished
+        //timers. Right now we need to run tests with ASAN. There is a  crate https://github.com/lynnux/leak-detect-allocator
+        //which provides allocator with memory leak detection but it can not be used because it works
+        //only with nightly builds
+        // 2. Ensure correct clean up of resources in case of presence of unfinished tasks. Previous
+        // versions of timer and executor caused abort of the program at some cases.
+
+        let handle = LocalExecutorBuilder::new().spawn(|| async move {
+            let action = TimerActionOnce::do_in(Duration::from_millis(100), async move {
+                println!("hello");
+            });
+
+            action.rearm_in(Duration::from_millis(100));
+        }).unwrap();
+
+        handle.join().unwrap();
     }
 }


### PR DESCRIPTION
### What does this PR do?

An issue that caused program abort, in the presence of not finished timer in the executor,  has been fixed.

Issue #229 has been caused by the fact that the timer kept instance of Waker, which was not used to wake the future. That drove cyclic reference between the not finished timer and future itself through waker instance.

Program abort was caused by the drop of the future that triggered drop of the waker.  As a result, waker tries to reschedule the local executor task, which causes panic because the local executor is absent. The panic inside of local executor triggers drop of the timer, but the reactor is already absent at this moment which triggers panic inside panic and as a result triggers abort of the program.

### Motivation

Bug fixing.

### Related issues

Issue #229

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
