### PR TITLE
Add a benchmark for submitting nop events to the ring

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -41,6 +41,9 @@ futures = "0.3.5"
 fastrand = "1.4.0"
 tokio = { version = "0.3.5", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time"] }
 
+[features]
+bench = []
+
 [[bench]]
 name = "executor"
 harness = false
@@ -73,3 +76,6 @@ harness = false
 name = "udp"
 harness = false
 
+[[bench]]
+name = "nop"
+harness = false

--- a/glommio/benches/nop.rs
+++ b/glommio/benches/nop.rs
@@ -1,0 +1,99 @@
+//! Benchmark the noop performance of Glommio. This is a stress test for the executor/reactor
+//! infrastructure.
+
+use glommio::{LocalExecutorBuilder, Task};
+use std::fmt;
+use std::time::{Duration, Instant};
+
+struct Bench {
+    num_tasks: u64,
+    num_events: u64,
+}
+
+const BENCH_RUNS: &'static [Bench] = &[
+    Bench {
+        num_tasks: 100,
+        num_events: 10_000_000,
+    },
+    Bench {
+        num_tasks: 1_000,
+        num_events: 10_000_000,
+    },
+    Bench {
+        num_tasks: 10_000,
+        num_events: 10_000_000,
+    },
+    Bench {
+        num_tasks: 100_000,
+        num_events: 10_000_000,
+    },
+    Bench {
+        num_tasks: 1_000_000,
+        num_events: 10_000_000,
+    },
+];
+
+struct Measurement {
+    total_events: u64,
+    total_tasks: u64,
+    duration: Duration,
+}
+
+impl fmt::Display for Measurement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            r"completed submission of {} noop events across {} tasks, {} per task
+            duration: {:?}",
+            self.total_events,
+            self.total_tasks,
+            self.total_events / self.total_tasks,
+            self.duration
+        )
+    }
+}
+
+fn main() {
+    let mut measurements = vec![];
+    let num_bench_runs = 1;
+    for bench in BENCH_RUNS {
+        for _ in 0..num_bench_runs {
+            let ex = LocalExecutorBuilder::new().pin_to_cpu(0).make().unwrap();
+            let measurement = ex.run(run_bench_tasks(bench.num_tasks, bench.num_events));
+
+            println!("{}", measurement);
+            measurements.push(measurement);
+        }
+
+        let sum = measurements
+            .iter()
+            .fold(Duration::from_secs(0), |acc, v| acc + v.duration);
+        let average = sum / num_bench_runs;
+        println!("average bench duration: {:?}\n", average);
+        measurements.clear();
+    }
+}
+
+async fn run_bench_tasks(num_tasks: u64, num_events: u64) -> Measurement {
+    let num_ops_per_task = num_events / num_tasks;
+    let start_time = Instant::now();
+    let mut handles = vec![];
+    for _ in 0..num_tasks {
+        let handle = Task::local(async move {
+            let submitter = glommio::nop::NopSubmitter::new();
+            for _ in 0..num_ops_per_task {
+                submitter.run_nop().await.unwrap();
+            }
+        });
+        handles.push(handle)
+    }
+    for handle in handles {
+        handle.await;
+    }
+    let end_time = Instant::now();
+    Measurement {
+        total_events: num_events,
+        total_tasks: num_tasks,
+        duration: end_time - start_time,
+    }
+}

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -270,6 +270,9 @@ mod parking;
 mod sys;
 pub mod task;
 
+#[cfg(feature = "bench")]
+pub mod nop;
+
 // unwraps a Result to Poll<T>: if error returns right away.
 //
 // usage is similar to future_lite::ready!

--- a/glommio/src/nop.rs
+++ b/glommio/src/nop.rs
@@ -1,0 +1,31 @@
+//! Provides a [`NopSubmitter`] which can be used to submit nop operations to the ring. This is mainly useful for benchmarking Glommio.
+use std::io;
+use std::rc::{Rc, Weak};
+
+use crate::parking::Reactor;
+use crate::Local;
+
+/// Submit no-op operations to io_uring.
+///
+/// This is mainly useful for benchmarking Glommio.
+#[derive(Debug)]
+pub struct NopSubmitter {
+    reactor: Weak<Reactor>,
+}
+
+impl NopSubmitter {
+    /// Construct a new [`NopSubmitter`].
+    pub fn new() -> Self {
+        let reactor = Local::get_reactor();
+        let reactor = Rc::downgrade(&reactor);
+        Self { reactor }
+    }
+
+    /// Submit a no-op io_uring operation, and wait for completion.
+    pub async fn run_nop(&self) -> io::Result<()> {
+        let reactor = self.reactor.upgrade().unwrap();
+        let source = reactor.nop();
+        source.collect_rw().await?;
+        Ok(())
+    }
+}

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -503,6 +503,13 @@ impl Reactor {
         source
     }
 
+    #[cfg(feature = "bench")]
+    pub(crate) fn nop(&self) -> Source {
+        let source = self.new_source(-1, SourceType::Noop);
+        self.sys.nop(&source);
+        source
+    }
+
     /// Registers a timer in the reactor.
     ///
     /// Returns the registered timer's ID.

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -258,6 +258,8 @@ pub(crate) enum SourceType {
     Connect(SockAddr),
     Accept(SockAddrStorage),
     Invalid,
+    #[cfg(feature = "bench")]
+    Noop,
 }
 
 impl TryFrom<SourceType> for libc::statx {

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -60,6 +60,8 @@ enum UringOpDescriptor {
     SockSendMsg(*mut libc::msghdr, i32),
     SockRecv(usize, i32),
     SockRecvMsg(usize, i32),
+    #[cfg(feature = "bench")]
+    Nop,
 }
 
 #[derive(Debug)]
@@ -399,6 +401,8 @@ where
                     _ => unreachable!(),
                 };
             }
+            #[cfg(feature = "bench")]
+            UringOpDescriptor::Nop => sqe.prep_nop(),
         }
     }
 
@@ -1202,6 +1206,11 @@ impl Reactor {
         };
         let op = UringOpDescriptor::Open(pathptr as _, flags, mode as _);
         self.queue_standard_request(source, op);
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn nop(&self, source: &Source) {
+        self.queue_standard_request(source, UringOpDescriptor::Nop)
     }
 
     // We want to go to sleep but we can only go to sleep in one of the rings,


### PR DESCRIPTION
- Add a new feature for benchmark-related code, "bench".
- Add a new NopSubmitter type for submitting nop operations to the ring,
  gated behind the "bench" feature.
- Changes to Source and Source handling to support nop submissions.
- Add a new benchmark which measures nop submission rate for a variety of
  task counts.

### What does this PR do?

This PR adds a new `NopSubmitter` reactor handle which can submit nops to the ring. This is to support a new nop benchmark.

### Motivation

This benchmark was created to compare the current performance of submission/completion in Glommio against another set of proposed changes.

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
