### PR TITLE
unregister shared channels after they are dropped

### DIFF
--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -334,6 +334,9 @@ impl<T: Send + Sized + Copy> Drop for ConnectedReceiver<T> {
                 r.notify(fd);
             }
         }
+        if let Some(r) = self.reactor.upgrade() {
+            r.unregister_shared_channel(self.id)
+        }
     }
 }
 
@@ -344,6 +347,9 @@ impl<T: Send + Sized + Copy> Drop for ConnectedSender<T> {
             if let Some(r) = self.reactor.upgrade() {
                 r.notify(fd);
             }
+        }
+        if let Some(r) = self.reactor.upgrade() {
+            r.unregister_shared_channel(self.id)
         }
     }
 }

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -296,6 +296,11 @@ impl Reactor {
         id
     }
 
+    pub(crate) fn unregister_shared_channel(&self, id: u64) {
+        let mut channels = self.shared_channels.borrow_mut();
+        channels.check_map.remove(&id);
+    }
+
     pub(crate) fn add_shared_channel_waker(&self, id: u64, waker: Waker) {
         let mut channels = self.shared_channels.borrow_mut();
         let map = channels.wakers_map.entry(id).or_insert_with(VecDeque::new);


### PR DESCRIPTION
While searching for another issue (#261) I realized that we never unregister
channels on drop.

That has, unfortunately, nothing to do with the issue but that's a leak
so let's fix it.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
