### PR TITLE
Require the "bench" feature for the nop benchmark

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -80,3 +80,4 @@ harness = false
 [[bench]]
 name = "nop"
 harness = false
+required-features = ["bench"]


### PR DESCRIPTION
This add a `required-feature` to the nop benchmark, requiring the `"bench"` feature. 

This should fix `cargo build --all --all-targets` which was broken as part of #260 