### PR TITLE
allow users to inspect the path associated with the file

### DIFF
--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -206,8 +206,10 @@ impl BufferedFile {
         self.file.close().await.map_err(Into::into)
     }
 
-    pub(crate) fn path(&self) -> &Path {
-        self.file.path.as_ref().unwrap().as_path()
+    /// Returns an `Option` containing the path associated with this open
+    /// directory, or `None` if there isn't one.
+    pub fn path(&self) -> Option<&Path> {
+        self.file.path()
     }
 
     pub(crate) fn discard(self) -> (RawFd, Option<PathBuf>) {

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -478,7 +478,7 @@ macro_rules! do_seek {
                         .reactor
                         .upgrade()
                         .unwrap()
-                        .statx($fileobj.as_raw_fd(), $fileobj.path());
+                        .statx($fileobj.as_raw_fd(), $fileobj.path().unwrap());
                     source.add_waiter($cx.waker().clone());
                     $self.source = Some(source);
                     Poll::Pending

--- a/glommio/src/io/directory.rs
+++ b/glommio/src/io/directory.rs
@@ -146,6 +146,12 @@ impl Directory {
     pub async fn close(self) -> Result<()> {
         self.file.close().await
     }
+
+    /// Returns an `Option` containing the path associated with this open
+    /// directory, or `None` if there isn't one.
+    pub fn path(&self) -> Option<&Path> {
+        self.file.path()
+    }
 }
 
 fn contains_dir(path: &Path) -> bool {

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -332,6 +332,12 @@ impl DmaFile {
         self.file.close().await
     }
 
+    /// Returns an `Option` containing the path associated with this open
+    /// directory, or `None` if there isn't one.
+    pub fn path(&self) -> Option<&Path> {
+        self.file.path()
+    }
+
     pub(crate) async fn close_rc(self: Rc<DmaFile>) -> Result<()> {
         match Rc::try_unwrap(self) {
             Err(file) => Err(io::Error::new(
@@ -489,6 +495,15 @@ pub(crate) mod test {
             .await
             .expect_err("fallocate should fail with len == 0");
 
+        new_file.close().await.expect("failed to close file");
+    });
+
+    dma_file_test!(file_path, path, _k, {
+        let new_file = DmaFile::create(path.join("testfile"))
+            .await
+            .expect("failed to create file");
+
+        assert_eq!(new_file.path().unwrap(), path.join("testfile"));
         new_file.close().await.expect("failed to close file");
     });
 

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -143,6 +143,10 @@ impl GlommioFile {
             })
     }
 
+    pub(crate) fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
     pub(crate) async fn pre_allocate(&self, size: u64) -> Result<()> {
         let flags = libc::FALLOC_FL_ZERO_RANGE;
         let source = self


### PR DESCRIPTION
We associate paths with our file objects. Allow the user to inspect them.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
