### PR TITLE
File improvements

### DIFF
--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -1064,11 +1064,7 @@ impl AsyncWrite for DmaStreamWriter {
                     }
                 }
                 Some(mut buffer) => {
-                    let size = buf.len();
-                    let space = state.buffer_size - state.buffer_pos;
-                    let writesz = std::cmp::min(space, size - written);
-                    let end = written + writesz;
-                    buffer.write_at(state.buffer_pos, &buf[written..end]);
+                    let writesz = buffer.write_at(state.buffer_pos, &buf[written..]);
                     written += writesz;
                     state.buffer_pos += writesz;
                     if state.buffer_pos == state.buffer_size {


### PR DESCRIPTION
### What does this PR do?

Improves the performance of file streams, especially the reader, when we are dealing with very small reads.
This is a common pattern when processing a file that is filled with integers and floats: the stream will allow us to read a big buffer, but then we have to process the elements individually.

We could read large chunks outside the stream and process them, but that defeats the purpose of the abstraction.

### Motivation

CPU time is precious
