### PR TITLE
shared_channels: clear wakers and connection maps when unregistering

### DIFF
--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -305,6 +305,8 @@ impl Reactor {
 
     pub(crate) fn unregister_shared_channel(&self, id: u64) {
         let mut channels = self.shared_channels.borrow_mut();
+        channels.wakers_map.clear();
+        channels.connection_wakers.clear();
         channels.check_map.remove(&id);
     }
 


### PR DESCRIPTION
When shared channels are destroyed, it could be that there are still
pending wakers. If they are destroyed there isn't much we should do,
as there is nobody else to be awaken. We clear the collections to avoid
letting other parts of the code thinking there are still notifications
to be sent.

Fixes #269

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
