### PR TITLE
return a GlommioError for rename, remove

### DIFF
--- a/glommio/src/error.rs
+++ b/glommio/src/error.rs
@@ -267,6 +267,27 @@ impl<T> From<(io::Error, ResourceType<T>)> for GlommioError<T> {
 }
 
 impl<T> GlommioError<T> {
+    /// Returns the OS error that this error represents (if any).
+    ///
+    /// If this `Error` was constructed from an [`io::Error`] which encapsulates a
+    /// raw OS error, then this function will return [`Some`], otherwise it will return [`None`].
+    ///
+    /// [`io::Error`]: https://doc.rust-lang.org/std/io/struct.Error.html
+    /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    pub fn raw_os_error(&self) -> Option<i32> {
+        match self {
+            GlommioError::IoError(x) => x.raw_os_error(),
+            GlommioError::EnhancedIoError {
+                source,
+                op: _,
+                path: _,
+                fd: _,
+            } => source.raw_os_error(),
+            _ => None,
+        }
+    }
+
     pub(crate) fn queue_still_active(index: usize) -> GlommioError<T> {
         GlommioError::ExecutorError(ExecutorErrorKind::QueueError {
             index,

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -182,16 +182,7 @@ impl GlommioFile {
 
     pub(crate) async fn rename<P: AsRef<Path>>(&mut self, new_path: P) -> Result<()> {
         let old_path = self.path_required("rename")?;
-        crate::io::rename(old_path, &new_path)
-            .await
-            .map_err(|source| {
-                GlommioError::create_enhanced(
-                    source,
-                    "Renaming",
-                    self.path.as_ref(),
-                    Some(self.as_raw_fd()),
-                )
-            })?;
+        crate::io::rename(old_path, &new_path).await?;
         self.path = Some(new_path.as_ref().to_owned());
         Ok(())
     }

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -82,13 +82,12 @@ macro_rules! enhanced_try {
         match $expr {
             Ok(val) => Ok(val),
             Err(source) => {
-                let enhanced: std::io::Error = crate::error::GlommioError::<()>::EnhancedIoError {
+                let enhanced = crate::error::GlommioError::<()>::EnhancedIoError {
                     source,
                     op: $op,
                     path: $path.and_then(|x| Some(x.to_path_buf())),
                     fd: $fd,
-                }
-                .into();
+                };
                 Err(enhanced)
             }
         }
@@ -113,20 +112,22 @@ mod glommio_file;
 mod read_result;
 
 use crate::sys;
-use std::io;
 use std::path::Path;
+
+pub(super) type Result<T> = crate::Result<T, ()>;
 
 /// rename an existing file.
 ///
 /// Warning: synchronous operation, will block the reactor
-pub async fn rename<P: AsRef<Path>, Q: AsRef<Path>>(old_path: P, new_path: Q) -> io::Result<()> {
-    sys::rename_file(&old_path.as_ref(), &new_path.as_ref())
+pub async fn rename<P: AsRef<Path>, Q: AsRef<Path>>(old_path: P, new_path: Q) -> Result<()> {
+    sys::rename_file(&old_path.as_ref(), &new_path.as_ref())?;
+    Ok(())
 }
 
 /// remove an existing file given its name
 ///
 /// Warning: synchronous operation, will block the reactor
-pub async fn remove<P: AsRef<Path>>(path: P) -> io::Result<()> {
+pub async fn remove<P: AsRef<Path>>(path: P) -> Result<()> {
     enhanced_try!(
         sys::remove_file(path.as_ref()),
         "Removing",
@@ -147,3 +148,18 @@ pub use self::dma_file_stream::{
 pub use self::dma_open_options::DmaOpenOptions;
 pub use self::read_result::ReadResult;
 pub use crate::sys::DmaBuffer;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::LocalExecutor;
+
+    #[test]
+    fn remove_nonexistent() {
+        let local_ex = LocalExecutor::default();
+        local_ex.run(async {
+            let x = remove("/tmp/this_file_does_not_exist_and_if_you_created_just_to_mess_with_me_you_deserve_this_test_to_fail_and_I_am_not_even_sorry").await;
+            assert_eq!(x.unwrap_err().raw_os_error().unwrap(), libc::ENOENT);
+        });
+    }
+}


### PR DESCRIPTION
remove and rename are done through system calls, which are converted to
io::Errors. They are then converted through GlommioErrors through
enhance, then back to io::Error for the return value.

This has no other reason except for the fact that we forgot to convert
this to GlommioError.

Aside from the needless conversions, this causes the information about
which OS error generated this to be essentially lost. It is there, but
it is behind a Custom type, that needs a lot of downcast magic to be
fetched.

This patch returns a GlommioError, and adds a convenience method to
grab the OS error that generated it when it is available.

It also adds a test to make sure we won't break this in the future.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
