### PR TITLE
fix asynchronous close-on-drop

### DIFF
--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -40,7 +40,9 @@ That means that while the file is already out of scope, the file descriptor is s
 This is likely file, but in extreme situations can lead to resource exhaustion. An explicit asynchronous close is still preferred",
             self.path,
             file);
-            self.reactor.upgrade().map(|r| r.close(file));
+            if let Some(r) = self.reactor.upgrade() {
+                r.sys.async_close(file);
+            }
         }
     }
 }
@@ -236,5 +238,43 @@ impl GlommioFile {
     pub(crate) async fn file_size(&self) -> Result<u64> {
         let st = self.statx().await?;
         Ok(st.stx_size)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use super::*;
+    use crate::test_utils::*;
+    use crate::timer::sleep;
+    use std::time::Duration;
+
+    #[test]
+    fn drop_closes_the_file() {
+        test_executor!(async move {
+            let dir = make_tmp_test_directory("drop_closes_the_file");
+            let path = dir.path.clone();
+
+            let file = path.join("file");
+            let gf = GlommioFile::open_at(-1, &file, libc::O_CREAT, 0644)
+                .await
+                .unwrap();
+            let gf_fd = gf.path.as_ref().cloned().unwrap();
+
+            let file_list = || {
+                let mut files = vec![];
+                for f in std::fs::read_dir("/proc/self/fd").unwrap() {
+                    let f = f.unwrap().path();
+                    if let Ok(file) = std::fs::canonicalize(&f) {
+                        files.push(file);
+                    }
+                }
+                files
+            };
+
+            assert!(file_list().iter().find(|&x| *x == gf_fd).is_some()); // sanity check that file is open
+            let _ = { gf }; // moves scope and drops
+            sleep(Duration::from_millis(10)).await; // forces the reactor to run, which will drop the file
+            assert!(file_list().iter().find(|&x| *x == gf_fd).is_none()); // file is gone
+        });
     }
 }


### PR DESCRIPTION
Asynchronous close-on-drop is not working. Unfortunately this is not
easy to spot, until your long-running program runs out of disk space
as the files are not properly closed.

The reason is, we close through the normal Source path. But the Source
dies right after, which triggers a cancellation. What we need to do in
this case is have a special path where we don't depend on a Source.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
