### PR TITLE
Qingyang.wang/add cpu usage stats

### DIFF
--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -1704,7 +1704,8 @@ mod test {
         ex0.run(async {
             assert!(
                 Local::executor_stats().total_runtime() < Duration::from_nanos(10),
-                "expected runtime on LE0 is less than 10 ns"
+                "expected runtime on LE {:#?} is less than 10 ns",
+                Local::executor_stats().total_runtime()
             );
 
             let now = Instant::now();
@@ -1712,19 +1713,15 @@ mod test {
             Local::later().await;
             assert!(
                 Local::executor_stats().total_runtime() >= Duration::from_millis(200),
-                format!(
                     "expected runtime on LE0 {:#?} is greater than 200 ms",
                     Local::executor_stats().total_runtime()
-                )
             );
 
             timer::sleep(dur).await;
             assert!(
                 Local::executor_stats().total_runtime() < Duration::from_millis(220),
-                format!(
                     "expected runtime on LE0 {:#?} is not much greater than 200 ms",
                     Local::executor_stats().total_runtime()
-                )
             );
         });
 
@@ -1737,7 +1734,8 @@ mod test {
             Local::local(async move {
                 assert!(
                     Local::executor_stats().total_runtime() < Duration::from_nanos(10),
-                    "expected runtime on LE is less than 10 ns"
+                    "expected runtime on LE {:#?} is less than 10 ns",
+                    Local::executor_stats().total_runtime()
                 );
 
                 let now = Instant::now();
@@ -1745,18 +1743,14 @@ mod test {
                 Local::later().await;
                 assert!(
                     Local::executor_stats().total_runtime() >= Duration::from_millis(200),
-                    format!(
                         "expected runtime on LE {:#?} is greater than 200 ms",
                         Local::executor_stats().total_runtime()
-                    )
                 );
                 timer::sleep(dur).await;
                 assert!(
                     Local::executor_stats().total_runtime() < Duration::from_millis(220),
-                    format!(
                         "expected runtime on LE {:#?} is not much greater than 200 ms",
                         Local::executor_stats().total_runtime()
-                    )
                 );
             })
             .await;

--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -46,9 +46,15 @@ use futures_lite::pin;
 use scoped_tls::scoped_thread_local;
 
 use crate::{
-    multitask, parking, sys,
+    multitask,
+    parking,
+    sys,
     task::{self, waker_fn::waker_fn},
-    GlommioError, IoRequirements, Latency, Reactor, Shares,
+    GlommioError,
+    IoRequirements,
+    Latency,
+    Reactor,
+    Shares,
 };
 use ahash::AHashMap;
 
@@ -71,6 +77,13 @@ pub struct TaskQueueHandle {
 impl Default for TaskQueueHandle {
     fn default() -> Self {
         TaskQueueHandle { index: 0 }
+    }
+}
+
+impl TaskQueueHandle {
+    /// Returns a numeric ID that uniquely identifies this Task queue
+    pub fn index(&self) -> usize {
+        self.index
     }
 }
 
@@ -1353,7 +1366,8 @@ mod test {
     use crate::{
         enclose,
         timer::{self, Timer},
-        Local, SharesManager,
+        Local,
+        SharesManager,
     };
     use core::mem::MaybeUninit;
     use futures::join;

--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -195,6 +195,8 @@ fn bind_to_cpu(cpu: usize) -> Result<()> {
 /// Allows information about the current state of this executor to be consumed
 /// by applications.
 pub struct ExecutorStats {
+    executor_runtime: Duration,
+    // total_runtime include poll_io time, exclude spin loop time
     total_runtime: Duration,
     scheduler_runs: u64,
     tasks_executed: u64,
@@ -203,6 +205,7 @@ pub struct ExecutorStats {
 impl ExecutorStats {
     fn new() -> Self {
         Self {
+            executor_runtime: Duration::from_nanos(0),
             total_runtime: Duration::from_nanos(0),
             scheduler_runs: 0,
             tasks_executed: 0,
@@ -215,6 +218,11 @@ impl ExecutorStats {
     /// CPU time you will see in the operating system will be a far cry from
     /// the CPU time it actually spent executing. Sleeping or Spinning are
     /// not accounted here
+    pub fn executor_runtime(&self) -> Duration {
+        self.executor_runtime
+    }
+
+    /// The total amount of runtime in this executor, plus poll io time
     pub fn total_runtime(&self) -> Duration {
         self.total_runtime
     }
@@ -790,7 +798,7 @@ impl LocalExecutor {
 
                 let mut tq = self.queues.borrow_mut();
                 tq.active_executing = None;
-                tq.stats.total_runtime += runtime;
+                tq.stats.executor_runtime += runtime;
                 tq.stats.tasks_executed += tasks_executed_this_loop;
 
                 tq.last_vruntime = match last_vruntime {
@@ -841,6 +849,7 @@ impl LocalExecutor {
             let future = self.spawn(async move { future.await }).detach();
             pin!(future);
 
+            let mut pre_time = Instant::now();
             loop {
                 if let Poll::Ready(t) = future.as_mut().poll(cx) {
                     // can't be canceled, and join handle is None only upon
@@ -855,7 +864,11 @@ impl LocalExecutor {
                 // the opportunity to install the timer.
                 let duration = self.preempt_timer_duration();
                 self.parker.poll_io(duration);
-                if !self.run_task_queues() {
+                let run = self.run_task_queues();
+                let cur_time = Instant::now();
+                self.queues.borrow_mut().stats.total_runtime += cur_time - pre_time;
+                pre_time = cur_time;
+                if !run {
                     if let Poll::Ready(t) = future.as_mut().poll(cx) {
                         // It may be that we just became ready now that the task queue
                         // is exhausted. But if we sleep (park) we'll never know so we
@@ -863,13 +876,14 @@ impl LocalExecutor {
                         // future is probably the one setting up the task queues and etc.
                         break t.unwrap();
                     } else {
-                        let spin_start = Instant::now();
                         while !self.reactor.spin_poll_io().unwrap() {
-                            if spin_start.elapsed() > spin_before_park {
+                            if pre_time.elapsed() > spin_before_park {
                                 self.parker.park();
                                 break;
                             }
                         }
+                        // reset the timer for deduct spin loop time
+                        pre_time = Instant::now();
                     }
                 }
             }

--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -1699,7 +1699,7 @@ mod test {
 
     #[test]
     fn test_runtime_stats() {
-        let dur = Duration::from_secs(1);
+        let dur = Duration::from_secs(2);
         let ex0 = LocalExecutorBuilder::new().make().unwrap();
         ex0.run(async {
             assert!(
@@ -1713,21 +1713,22 @@ mod test {
             Local::later().await;
             assert!(
                 Local::executor_stats().total_runtime() >= Duration::from_millis(200),
-                    "expected runtime on LE0 {:#?} is greater than 200 ms",
-                    Local::executor_stats().total_runtime()
+                "expected runtime on LE0 {:#?} is greater than 200 ms",
+                Local::executor_stats().total_runtime()
             );
 
             timer::sleep(dur).await;
             assert!(
-                Local::executor_stats().total_runtime() < Duration::from_millis(220),
-                    "expected runtime on LE0 {:#?} is not much greater than 200 ms",
-                    Local::executor_stats().total_runtime()
+                Local::executor_stats().total_runtime() < Duration::from_millis(400),
+                "expected runtime on LE0 {:#?} is not greater than 400 ms",
+                Local::executor_stats().total_runtime()
             );
         });
 
         let ex = LocalExecutorBuilder::new()
             .pin_to_cpu(0)
-            .spin_before_park(Duration::from_millis(100))
+            // ensure entire sleep should spin
+            .spin_before_park(Duration::from_secs(5))
             .make()
             .unwrap();
         ex.run(async {
@@ -1743,14 +1744,14 @@ mod test {
                 Local::later().await;
                 assert!(
                     Local::executor_stats().total_runtime() >= Duration::from_millis(200),
-                        "expected runtime on LE {:#?} is greater than 200 ms",
-                        Local::executor_stats().total_runtime()
+                    "expected runtime on LE {:#?} is greater than 200 ms",
+                    Local::executor_stats().total_runtime()
                 );
                 timer::sleep(dur).await;
                 assert!(
-                    Local::executor_stats().total_runtime() < Duration::from_millis(220),
-                        "expected runtime on LE {:#?} is not much greater than 200 ms",
-                        Local::executor_stats().total_runtime()
+                    Local::executor_stats().total_runtime() < Duration::from_millis(400),
+                    "expected runtime on LE {:#?} is not greater than 400 ms",
+                    Local::executor_stats().total_runtime()
                 );
             })
             .await;


### PR DESCRIPTION
**What does this PR do?**
Expose executor_runtime which is the total amount of runtime for each executor so far, excluding poll io time.
in contrast the original total_runtime will be including poll io time.
The runtime spend in busy spin are not included in both cases.

**Motivation**
for easy monitoring cpu runtime

**Related issues**

**Checklist**
[x] I have added unit tests to the code I am submitting
[ ] My unit tests cover both failure and success scenarios
[ ] If applicable, I have discussed my architecture