### PR TITLE
Add rust/glommio version info to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,2 +1,7 @@
 name: Bug Report
 about: Something is not working as expected
+
+Environment:
+
+- Rust version:
+- Glommio version:


### PR DESCRIPTION
When triaging bug reports, it's extremely helpful to know both the Rust
version and the Glommio version.

This isn't a big deal now, but will be as the project matures and grows
in popularity.