### PR TITLE
Bump to `rust` `1.50.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   cargobuild:
     docker:
-      - image: circleci/rust:1.49.0
+      - image: cimg/rust:1.49.0
     steps:
       - checkout
       - run:
@@ -30,7 +30,7 @@ jobs:
 
   cargofmt:
     docker:
-      - image: circleci/rust:1.49.0
+      - image: cimg/rust:1.49.0
     steps:
       - checkout
       - run:
@@ -60,7 +60,7 @@ jobs:
 
   cargodoc:
     docker:
-      - image: circleci/rust:1.49.0
+      - image: cimg/rust:1.49.0
     steps:
       - checkout
       - run:
@@ -92,7 +92,7 @@ jobs:
 
   cargoclippy:
     docker:
-      - image: circleci/rust:1.49.0
+      - image: cimg/rust:1.49.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   cargobuild:
     docker:
-      - image: cimg/rust:1.49.0
+      - image: cimg/rust:1.50.0
     steps:
       - checkout
       - run:
@@ -30,7 +30,7 @@ jobs:
 
   cargofmt:
     docker:
-      - image: cimg/rust:1.49.0
+      - image: cimg/rust:1.50.0
     steps:
       - checkout
       - run:
@@ -60,7 +60,7 @@ jobs:
 
   cargodoc:
     docker:
-      - image: cimg/rust:1.49.0
+      - image: cimg/rust:1.50.0
     steps:
       - checkout
       - run:
@@ -92,7 +92,7 @@ jobs:
 
   cargoclippy:
     docker:
-      - image: cimg/rust:1.49.0
+      - image: cimg/rust:1.50.0
     steps:
       - checkout
       - run:
@@ -100,7 +100,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - run:
           name: Install clippy
-          command: rustup component add clippy --toolchain 1.49.0-x86_64-unknown-linux-gnu
+          command: rustup component add clippy --toolchain 1.50.0-x86_64-unknown-linux-gnu
       - run:
           name: Calculate dependencies
           command: cargo generate-lockfile


### PR DESCRIPTION
While `rust` `1.51.0` just landed, it's so new that [it's not yet
available in the `cimg/rust` registry](https://github.com/CircleCI-Public/cimg-rust/issues/52).
So for now I bumped to `1.50.0`.

Depends on https://github.com/DataDog/glommio/pull/307, that should be merged first and then this rebased.