### PR TITLE
Try re-enabling deadlinks checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,8 @@ jobs:
           rustup install nightly
           cargo +nightly doc --all
 
-    # temporarily disabled.
-    # - name: Validate links
-    #   run: cargo deadlinks --dir target/doc/glommio
+      - name: Validate links
+        run: cargo deadlinks --dir target/doc/glommio
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This was originally disabled back in https://github.com/DataDog/glommio/commit/7daa35a7a7d379c7a5259aa446d8385241bd453b.

That was four months ago, so perhaps the upstream issues have been fixed
and we can re-enable this now. Worth a shot... 😄 