### PR TITLE
allow for remote wakers: enable use side by side with tokio

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -33,6 +33,7 @@ smallvec = "1.4.2"
 buddy-alloc = "0.4.1"
 ahash = "0.5.7"
 intrusive-collections = "0.9.0"
+lockfree = "0.5"
 membarrier = "0.2.2"
 
 [dev-dependencies]

--- a/glommio/src/multitask.rs
+++ b/glommio/src/multitask.rs
@@ -135,6 +135,7 @@ impl LocalExecutor {
     /// Spawns a thread-local future onto this executor.
     pub(crate) fn spawn<T>(
         &self,
+        executor_id: usize,
         tq: Rc<RefCell<TaskQueue>>,
         future: impl Future<Output = T>,
     ) -> Task<T> {
@@ -155,7 +156,7 @@ impl LocalExecutor {
 
         // Create a task, push it into the queue by scheduling it, and return its `Task`
         // handle.
-        let (runnable, handle) = task_impl::spawn_local(future, schedule);
+        let (runnable, handle) = task_impl::spawn_local(executor_id, future, schedule);
         runnable.schedule();
         Task(Some(handle))
     }

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -1162,6 +1162,10 @@ impl Reactor {
         self.notifier.id()
     }
 
+    pub(crate) fn foreign_notifiers(&self) -> Option<core::task::Waker> {
+        self.notifier.get_foreign_notifier()
+    }
+
     pub(crate) fn alloc_dma_buffer(&self, size: usize) -> DmaBuffer {
         let mut poll_ring = self.poll_ring.borrow_mut();
         poll_ring.alloc_dma_buffer(size)

--- a/glommio/src/task/header.rs
+++ b/glommio/src/task/header.rs
@@ -63,9 +63,6 @@ impl Header {
         // Take the waker out.
         let waker = self.awaiter.take();
 
-        // Mark the state as not being notified anymore nor containing an awaiter.
-        self.state &= !AWAITER;
-
         if let Some(w) = waker {
             // We need a safeguard against panics because waking can panic.
             abort_on_panic(|| match current {
@@ -98,7 +95,6 @@ impl fmt::Debug for Header {
             .field("running", &(state & RUNNING != 0))
             .field("completed", &(state & COMPLETED != 0))
             .field("closed", &(state & CLOSED != 0))
-            .field("awaiter", &(state & AWAITER != 0))
             .field("handle", &(state & HANDLE != 0))
             .field("refcount", &refcount)
             .finish()

--- a/glommio/src/task/header.rs
+++ b/glommio/src/task/header.rs
@@ -6,7 +6,9 @@
 use core::{fmt, task::Waker};
 
 use crate::task::{raw::TaskVTable, state::*, utils::abort_on_panic};
-use std::thread::ThreadId;
+
+use crate::sys::SleepNotifier;
+use std::sync::Arc;
 
 /// The header of a task.
 ///
@@ -14,7 +16,8 @@ use std::thread::ThreadId;
 pub(crate) struct Header {
     /// ID of the executor to which task belongs to or in another words by which
     /// task was spawned by
-    pub(crate) thread_id: ThreadId,
+    pub(crate) notifier: Arc<SleepNotifier>,
+
     /// Current state of the task.
     ///
     /// Contains flags representing the current state and the reference count.
@@ -88,7 +91,7 @@ impl fmt::Debug for Header {
         let state = self.state;
 
         f.debug_struct("Header")
-            .field("thread_id", &self.thread_id)
+            .field("thread_id", &self.notifier.id())
             .field("scheduled", &(state & SCHEDULED != 0))
             .field("running", &(state & RUNNING != 0))
             .field("completed", &(state & COMPLETED != 0))

--- a/glommio/src/task/header.rs
+++ b/glommio/src/task/header.rs
@@ -10,7 +10,7 @@ use crate::task::{raw::TaskVTable, state::*, utils::abort_on_panic};
 use crate::sys::SleepNotifier;
 use std::sync::Arc;
 
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::atomic::{AtomicI16, Ordering};
 
 /// The header of a task.
 ///
@@ -24,7 +24,7 @@ pub(crate) struct Header {
     pub(crate) state: u8,
 
     /// Current reference count of the task.
-    pub(crate) references: AtomicU16,
+    pub(crate) references: AtomicI16,
 
     /// The task that is blocked on the `JoinHandle`.
     ///

--- a/glommio/src/task/join_handle.rs
+++ b/glommio/src/task/join_handle.rs
@@ -68,9 +68,7 @@ impl<R> JoinHandle<R> {
             }
 
             // Notify the awaiter that the task has been closed.
-            if state & AWAITER != 0 {
-                (*header).notify(None);
-            }
+            (*header).notify(None);
         }
     }
 }
@@ -174,9 +172,7 @@ impl<R> Future for JoinHandle<R> {
 
             // Notify the awaiter. Even though the awaiter is most likely the current
             // task, it could also be another task.
-            if state & AWAITER != 0 {
-                (*header).notify(Some(cx.waker()));
-            }
+            (*header).notify(Some(cx.waker()));
 
             // Take the output from the task.
             let output = ((*header).vtable.get_output)(ptr) as *mut R;

--- a/glommio/src/task/join_handle.rs
+++ b/glommio/src/task/join_handle.rs
@@ -13,6 +13,7 @@ use core::{
 };
 
 use crate::task::{header::Header, state::*};
+use std::sync::atomic::Ordering;
 
 /// A handle that awaits the result of a task.
 ///
@@ -51,7 +52,7 @@ impl<R> JoinHandle<R> {
 
             // If the task is not scheduled nor running, we'll need to schedule it.
             let new = if state & (SCHEDULED | RUNNING) == 0 {
-                (state | SCHEDULED | CLOSED) + REFERENCE
+                state | SCHEDULED | CLOSED
             } else {
                 state | CLOSED
             };
@@ -60,6 +61,9 @@ impl<R> JoinHandle<R> {
             (*header).state = new;
 
             if state & (SCHEDULED | RUNNING) == 0 {
+                // If we schedule it, need to bump the reference count, since after run() we
+                // decrement it.
+                (*header).references.fetch_add(1, Ordering::Relaxed);
                 ((*header).vtable.schedule)(ptr);
             }
 
@@ -81,14 +85,15 @@ impl<R> Drop for JoinHandle<R> {
 
         unsafe {
             // Optimistically assume the `JoinHandle` is being dropped just after creating
-            // the task. This is a common case so if the handle is not used, the
-            // overhead of it is only one compare-exchange operation.
-            if (*header).state == SCHEDULED | HANDLE | REFERENCE {
-                (*header).state = SCHEDULED | REFERENCE;
+            // the task. This is a common case, as often users don't wait on the task
+            if (*header).state == SCHEDULED | HANDLE {
+                (*header).state = SCHEDULED;
                 return;
             }
 
             let state = (*header).state;
+            let refs = (*header).references.load(Ordering::Relaxed);
+
             // If the task has been completed but not yet closed, that means its output
             // must be dropped.
             if state & COMPLETED != 0 && state & CLOSED == 0 {
@@ -100,15 +105,15 @@ impl<R> Drop for JoinHandle<R> {
                 (*header).state &= !HANDLE;
 
                 // If this is the last reference to the task, we need to destroy it.
-                if state & !(REFERENCE - 1) == 0 {
+                if refs == 0 {
                     ((*header).vtable.destroy)(ptr)
                 }
             } else {
                 // If this is the last reference to the task and it's not closed, then
                 // close it and schedule one more time so that its future gets dropped by
                 // the executor.
-                let new = if state & (!(REFERENCE - 1) | CLOSED) == 0 {
-                    SCHEDULED | CLOSED | REFERENCE
+                let new = if (refs == 0) | (state & CLOSED == 0) {
+                    SCHEDULED | CLOSED
                 } else {
                     state & !HANDLE
                 };
@@ -116,8 +121,9 @@ impl<R> Drop for JoinHandle<R> {
                 (*header).state = new;
                 // If this is the last reference to the task, we need to either
                 // schedule dropping its future or destroy it.
-                if state & !(REFERENCE - 1) == 0 {
+                if refs == 0 {
                     if state & CLOSED == 0 {
+                        (*header).references.fetch_add(1, Ordering::Relaxed);
                         ((*header).vtable.schedule)(ptr);
                     } else {
                         ((*header).vtable.destroy)(ptr);

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -257,13 +257,6 @@ where
             return;
         }
 
-        assert_eq!(
-            Self::thread_id(),
-            Some(raw.my_id()),
-            "Waker::wake_by_ref is called outside of working thread. Waker instances can not be \
-             moved to or work with multiple threads"
-        );
-
         let state = (*raw.header).state;
 
         // If the task is completed or closed, it can't be woken up.

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -474,9 +474,7 @@ where
             (*(raw.header as *mut Header)).state &= !SCHEDULED;
 
             // Notify the awaiter that the future has been dropped.
-            if state & AWAITER != 0 {
-                (*(raw.header as *mut Header)).notify(None);
-            }
+            (*(raw.header as *mut Header)).notify(None);
 
             // Drop the task reference.
             Self::drop_task(ptr);
@@ -527,9 +525,7 @@ where
                 }
 
                 // Notify the awaiter that the task has been completed.
-                if state & AWAITER != 0 {
-                    (*(raw.header as *mut Header)).notify(None);
-                }
+                (*(raw.header as *mut Header)).notify(None);
 
                 // Drop the task reference.
                 Self::drop_task(ptr);
@@ -558,9 +554,7 @@ where
                 // Otherwise, we just drop the task reference.
                 if state & CLOSED != 0 {
                     // Notify the awaiter that the future has been dropped.
-                    if state & AWAITER != 0 {
-                        (*(raw.header as *mut Header)).notify(None);
-                    }
+                    (*(raw.header as *mut Header)).notify(None);
                     // Drop the task reference.
                     Self::drop_task(ptr);
                 } else if state & SCHEDULED != 0 {
@@ -604,9 +598,7 @@ where
                     RawTask::<F, R, S>::drop_future(ptr);
 
                     // Notify the awaiter that the future has been dropped.
-                    if (*raw.header).state & AWAITER != 0 {
-                        (*(raw.header as *mut Header)).notify(None);
-                    }
+                    (*(raw.header as *mut Header)).notify(None);
 
                     // Drop the task reference.
                     RawTask::<F, R, S>::drop_task(ptr);

--- a/glommio/src/task/state.rs
+++ b/glommio/src/task/state.rs
@@ -48,4 +48,3 @@ pub(crate) const CLOSED: u8 = 1 << 3;
 /// while all other task references (`Task` and `Waker`s) are tracked by the
 /// reference count.
 pub(crate) const HANDLE: u8 = 1 << 4;
-pub(crate) const AWAITER: u8 = 1 << 5;

--- a/glommio/src/task/state.rs
+++ b/glommio/src/task/state.rs
@@ -11,7 +11,7 @@
 /// This flag can't be set when the task is completed. However, it can be set
 /// while the task is running, in which case it will be rescheduled as soon as
 /// polling finishes.
-pub(crate) const SCHEDULED: usize = 1 << 0;
+pub(crate) const SCHEDULED: u8 = 1 << 0;
 
 /// Set if the task is running.
 ///
@@ -20,7 +20,7 @@ pub(crate) const SCHEDULED: usize = 1 << 0;
 /// This flag can't be set when the task is completed. However, it can be in
 /// scheduled state while it is running, in which case it will be rescheduled as
 /// soon as polling finishes.
-pub(crate) const RUNNING: usize = 1 << 1;
+pub(crate) const RUNNING: u8 = 1 << 1;
 
 /// Set if the task has been completed.
 ///
@@ -29,7 +29,7 @@ pub(crate) const RUNNING: usize = 1 << 1;
 /// `JoinHandle` picks up the output by marking the task as closed.
 ///
 /// This flag can't be set when the task is scheduled or running.
-pub(crate) const COMPLETED: usize = 1 << 2;
+pub(crate) const COMPLETED: u8 = 1 << 2;
 
 /// Set if the task is closed.
 ///
@@ -40,29 +40,12 @@ pub(crate) const COMPLETED: usize = 1 << 2;
 /// `JoinHandle::cancel()`. 2. Its output gets awaited by the `JoinHandle`.
 /// 3. It panics while polling the future.
 /// 4. It is completed and the `JoinHandle` gets dropped.
-pub(crate) const CLOSED: usize = 1 << 3;
+pub(crate) const CLOSED: u8 = 1 << 3;
 
 /// Set if the `JoinHandle` still exists.
 ///
 /// The `JoinHandle` is a special case in that it is only tracked by this flag,
 /// while all other task references (`Task` and `Waker`s) are tracked by the
 /// reference count.
-pub(crate) const HANDLE: usize = 1 << 4;
-
-/// Set if the `JoinHandle` is awaiting the output.
-///
-/// This flag is set while there is a registered awaiter of type `Waker` inside
-/// the task. When the task gets closed or completed, we need to wake the
-/// awaiter. This flag can be used as a fast check that tells us if we need to
-/// wake anyone.
-pub(crate) const AWAITER: usize = 1 << 5;
-
-/// A single reference.
-///
-/// The lower bits in the state contain various flags representing the task
-/// state, while the upper bits contain the reference count. The value of
-/// `REFERENCE` represents a single reference in the total reference count.
-///
-/// Note that the reference counter only tracks the `Task` and `Waker`s. The
-/// `JoinHandle` is tracked separately by the `HANDLE` flag.
-pub(crate) const REFERENCE: usize = 1 << 6;
+pub(crate) const HANDLE: u8 = 1 << 4;
+pub(crate) const AWAITER: u8 = 1 << 5;

--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -17,7 +17,11 @@ use crate::task::{header::Header, raw::RawTask, state::*, JoinHandle};
 ///
 /// [`Task`]: struct.Task.html
 /// [`JoinHandle`]: struct.JoinHandle.html
-pub(crate) fn spawn_local<F, R, S>(future: F, schedule: S) -> (Task, JoinHandle<R>)
+pub(crate) fn spawn_local<F, R, S>(
+    executor_id: usize,
+    future: F,
+    schedule: S,
+) -> (Task, JoinHandle<R>)
 where
     F: Future<Output = R>,
     S: Fn(Task),
@@ -25,9 +29,9 @@ where
     // Allocate large futures on the heap.
     let raw_task = if mem::size_of::<F>() >= 2048 {
         let future = alloc::boxed::Box::pin(future);
-        RawTask::<_, R, S>::allocate(future, schedule)
+        RawTask::<_, R, S>::allocate(future, schedule, executor_id)
     } else {
-        RawTask::<_, R, S>::allocate(future, schedule)
+        RawTask::<_, R, S>::allocate(future, schedule, executor_id)
     };
 
     let task = Task { raw_task };

--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -129,13 +129,10 @@ impl Drop for Task {
             ((*header).vtable.drop_future)(ptr);
 
             // Mark the task as unscheduled.
-            let state = (*header).state;
             (*header).state &= !SCHEDULED;
 
             // Notify the awaiter that the future has been dropped.
-            if state & AWAITER != 0 {
-                (*header).notify(None);
-            }
+            (*header).notify(None);
 
             // Drop the task reference.
             ((*header).vtable.drop_task)(ptr);

--- a/glommio/src/task/utils.rs
+++ b/glommio/src/task/utils.rs
@@ -8,6 +8,7 @@ use core::{alloc::Layout, mem};
 /// Aborts the process.
 ///
 /// To abort, this function simply panics while panicking.
+#[track_caller]
 pub(crate) fn abort() -> ! {
     struct Panic;
 
@@ -25,6 +26,7 @@ pub(crate) fn abort() -> ! {
 ///
 /// This is useful in unsafe code where we can't recover from panics.
 #[inline]
+#[track_caller]
 pub(crate) fn abort_on_panic<T>(f: impl FnOnce() -> T) -> T {
     struct Bomb;
 


### PR DESCRIPTION
### What does this PR do?

Allows users to use glommio executors as well as tokio executors.
This was already technically possible, by connecting both executors with a channel. However because our wakers want to be woken in the same executor they were originated, this would crash on asserts.

This PR allows wakers to be manipulated in foreign executors, by reference counting them atomically (with the state machine still being local), and passing them back to their owners if a remote wake is triggered.

### Motivation

My dear friend @thirstycrow 


[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[x] If applicable, I have discussed my architecture
