### PR TITLE
Clarification of get_buffer_aligned docs

### DIFF
--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -524,15 +524,17 @@ impl DmaStreamReader {
 
     /// Allows access to the buffer that holds the current position with no
     /// extra copy
-    ///
-    /// In order to use this API, one must guarantee that reading the specified
-    /// length may cross into a different buffer.  Users of this API are
+    //_ In order to use this API, one must guarantee that reading the specified
+    /// length may not cross into a different buffer.  Users of this API are
     /// expected to be aware of their buffer size (selectable in the
     /// [`DmaStreamReaderBuilder`]) and act accordingly.
     ///
     /// The buffer is also not released until the returned [`ReadResult`] goes
     /// out of scope. So if you plan to keep this alive for a long time this
     /// is probably the wrong API.
+    ///
+    /// If EOF is hit while reading with this method, the number of bytes in the
+    /// returned buffer will be less than number requested.
     ///
     /// Let's say you want to open a file and check if its header is sane: this
     /// is a good API for that.


### PR DESCRIPTION
### What does this PR do?

This PR includes a small clarification to the docs for `get_buffer_aligned`.

### Motivation

I didn't understand how EOF was handled, or the working around reading across buffer bounds.

### Related issues

https://github.com/DataDog/glommio/issues/321

### Additional Notes

None

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[x] If applicable, I have discussed my architecture
