### PR TITLE
Wake directly without accumulating waker

### DIFF
--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -301,13 +301,23 @@ extern crate scopeguard;
 use crate::parking::Reactor;
 use std::{fmt::Debug, time::Duration};
 
+/// Call `Waker::wake()` and log to `error` if panicked.
+macro_rules! wake {
+    ($waker:expr $(,)?) => {
+        use log::error;
+
+        if let Err(x) = panic::catch_unwind(|| $waker.wake()) {
+            error!("Panic while calling waker! {:?}", x);
+        }
+    };
+}
+
 mod free_list;
 
 #[allow(clippy::redundant_slicing)]
 #[allow(dead_code)]
 #[allow(clippy::upper_case_acronyms)]
 mod iou;
-#[macro_use]
 mod parking;
 mod sys;
 pub mod task;

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -307,6 +307,7 @@ mod free_list;
 #[allow(dead_code)]
 #[allow(clippy::upper_case_acronyms)]
 mod iou;
+#[macro_use]
 mod parking;
 mod sys;
 pub mod task;

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -111,17 +111,6 @@ impl fmt::Debug for Reactor {
     }
 }
 
-/// Call `Waker::wake()` and log to `error` if panicked.
-macro_rules! wake {
-    ($waker:expr $(,)?) => {
-        use log::error;
-
-        if let Err(x) = panic::catch_unwind(|| $waker.wake()) {
-            error!("Panic while calling waker! {:?}", x);
-        }
-    };
-}
-
 struct Inner {}
 
 impl Inner {

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -165,7 +165,9 @@ impl Timers {
         self.timers.insert((when, id), waker);
     }
 
-    fn process_timers(&mut self, wakers: &mut Vec<Waker>) -> Option<Duration> {
+    /// Return the duration until next event and the number of
+    /// ready and woke timers.
+    fn process_timers(&mut self) -> (Option<Duration>, usize) {
         let now = Instant::now();
 
         // Split timers into ready and pending timers.
@@ -183,12 +185,13 @@ impl Timers {
             // Timers are about to fire right now.
             Some(Duration::from_secs(0))
         };
-        // Add wakers to the list.
+
+        let woke = ready.len();
         for (_, waker) in ready {
-            wakers.push(waker);
+            let _ = panic::catch_unwind(|| waker.wake());
         }
 
-        dur
+        (dur, woke)
     }
 }
 
@@ -209,23 +212,25 @@ impl SharedChannels {
         }
     }
 
-    fn process_shared_channels(&mut self, wakers: &mut Vec<Waker>) -> usize {
-        let mut added = self.connection_wakers.len();
-        wakers.append(&mut self.connection_wakers);
+    fn process_shared_channels(&mut self) -> usize {
+        let mut woke = self.connection_wakers.len();
+        for waker in self.connection_wakers.drain(..) {
+            let _ = panic::catch_unwind(|| waker.wake());
+        }
 
         let current_wakers = mem::take(&mut self.wakers_map);
         for (id, mut pending) in current_wakers.into_iter() {
             let room = self.check_map.get(&id).unwrap()();
             let room = std::cmp::min(room, pending.len());
             for w in pending.drain(0..room) {
-                added += 1;
-                wakers.push(w);
+                woke += 1;
+                let _ = panic::catch_unwind(|| w.wake());
             }
             if !pending.is_empty() {
                 self.wakers_map.insert(id, pending);
             }
         }
-        added
+        woke
     }
 }
 
@@ -247,8 +252,6 @@ pub(crate) struct Reactor {
 
     /// I/O Requirements of the task currently executing.
     current_io_requirements: Cell<IoRequirements>,
-
-    wakers: RefCell<Vec<Waker>>,
 
     /// Whether there are events in the latency ring.
     ///
@@ -274,7 +277,6 @@ impl Reactor {
             timers: RefCell::new(Timers::new()),
             shared_channels: RefCell::new(SharedChannels::new()),
             current_io_requirements: Cell::new(IoRequirements::default()),
-            wakers: RefCell::new(Vec::with_capacity(256)),
             preempt_ptr_head,
             preempt_ptr_tail: preempt_ptr_tail as _,
         }
@@ -592,30 +594,23 @@ impl Reactor {
     /// Processes ready timers and extends the list of wakers to wake.
     ///
     /// Returns the duration until the next timer before this method was called.
-    fn process_timers(&self, wakers: &mut Vec<Waker>) -> Option<Duration> {
+    fn process_timers(&self) -> (Option<Duration>, usize) {
         let mut timers = self.timers.borrow_mut();
-        timers.process_timers(wakers)
+        timers.process_timers()
     }
 
-    fn process_shared_channels(&self, wakers: &mut Vec<Waker>) -> usize {
+    fn process_shared_channels(&self) -> usize {
         let mut channels = self.shared_channels.borrow_mut();
-        let mut processed = channels.process_shared_channels(wakers);
+        let mut processed = channels.process_shared_channels();
         while let Some(w) = self.sys.foreign_notifiers() {
             processed += 1;
-            wakers.push(w)
+            let _ = panic::catch_unwind(|| w.wake());
         }
         processed
     }
 
     fn rush_dispatch(&self, source: &Source) -> io::Result<()> {
-        let mut wakers = self.wakers.borrow_mut();
-        self.sys
-            .rush_dispatch(Some(source.latency_req()), &mut wakers)?;
-        // Wake up ready tasks.
-        for waker in wakers.drain(..) {
-            // Don't let a panicking waker blow everything up.
-            let _ = panic::catch_unwind(|| waker.wake());
-        }
+        self.sys.rush_dispatch(Some(source.latency_req()), &mut 0)?;
         Ok(())
     }
 
@@ -623,47 +618,38 @@ impl Reactor {
     ///
     /// This doesn't ever sleep, and does not touch the preempt timer.
     pub(crate) fn spin_poll_io(&self) -> io::Result<bool> {
-        let mut wakers = self.wakers.borrow_mut();
+        let mut woke = 0;
         // any duration, just so we land in the latency ring
         self.sys
-            .rush_dispatch(Some(Latency::Matters(Duration::from_secs(1))), &mut wakers)?;
+            .rush_dispatch(Some(Latency::Matters(Duration::from_secs(1))), &mut woke)?;
         self.sys
-            .rush_dispatch(Some(Latency::NotImportant), &mut wakers)?;
-        self.sys.rush_dispatch(None, &mut wakers)?;
-        self.process_timers(&mut wakers);
-        self.process_shared_channels(&mut wakers);
+            .rush_dispatch(Some(Latency::NotImportant), &mut woke)?;
+        self.sys.rush_dispatch(None, &mut woke)?;
+        woke += self.process_timers().1;
+        woke += self.process_shared_channels();
 
-        let woke = wakers.len();
-        for waker in wakers.drain(..) {
-            // Don't let a panicking waker blow everything up.
-            let _ = panic::catch_unwind(|| waker.wake());
-        }
         Ok(woke > 0)
     }
 
-    fn process_external_events(&self, wakers: &mut Vec<Waker>) -> Option<Duration> {
-        let next_timer = self.process_timers(wakers);
-        self.process_shared_channels(wakers);
+    fn process_external_events(&self) -> Option<Duration> {
+        let next_timer = self.process_timers().0;
+        self.process_shared_channels();
         next_timer
     }
 
     /// Processes new events, blocking until the first event or the timeout.
     fn react(&self, timeout: Option<Duration>) -> io::Result<()> {
-        // FIXME: use shrink_to here to bring the capacity back to
-        // its normal level. It is not stable API yet and this is unlikely
-        // to be a problem in practice.
-        let mut wakers = self.wakers.borrow_mut();
-
         // Process ready timers.
-        let next_timer = self.process_external_events(&mut wakers);
+        let next_timer = self.process_external_events();
 
         // Block on I/O events.
-        let res = match self.sys.wait(&mut wakers, timeout, next_timer, |wakers| {
-            self.process_shared_channels(wakers)
-        }) {
+        match self
+            .sys
+            .wait(timeout, next_timer, || self.process_shared_channels())
+        {
             // Don't wait for the next loop to process timers or shared channels
             Ok(true) => {
-                self.process_external_events(&mut wakers);
+                self.process_external_events();
                 Ok(())
             }
 
@@ -674,17 +660,7 @@ impl Reactor {
 
             // An actual error occureed.
             Err(err) => Err(err),
-        };
-
-        // Wake up ready tasks.
-        for waker in wakers.drain(..) {
-            // Don't let a panicking waker blow everything up.
-            if let Err(x) = panic::catch_unwind(|| waker.wake()) {
-                error!("Panic while calling waker! {:?}", x);
-            }
         }
-
-        res
     }
 }
 

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -1397,6 +1397,7 @@ impl Reactor {
         &self,
         preempt_timer: Option<Duration>,
         user_timer: Option<Duration>,
+        mut woke: usize,
         process_remote_channels: F,
     ) -> io::Result<bool>
     where
@@ -1420,8 +1421,6 @@ impl Reactor {
                 false
             }
         };
-
-        let mut woke = 0;
 
         // this will only dispatch if we run out of sqes. Which means until
         // flush_rings! nothing is really send to the kernel...
@@ -1581,13 +1580,13 @@ mod tests {
         reactor.queue_standard_request(&lethargic, op);
 
         let start = Instant::now();
-        reactor.wait(None, None, || 0).unwrap();
+        reactor.wait(None, None, 0, || 0).unwrap();
         let elapsed_ms = start.elapsed().as_millis();
         assert!(50 <= elapsed_ms && elapsed_ms < 100);
 
         drop(slow); // Cancel this one.
 
-        reactor.wait(None, None, || 0).unwrap();
+        reactor.wait(None, None, 0, || 0).unwrap();
         let elapsed_ms = start.elapsed().as_millis();
         assert!(300 <= elapsed_ms && elapsed_ms < 350);
     }

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -475,7 +475,7 @@ where
             w.result = Some(transmute_error(result));
             if let Some(waiter) = w.waiter.take() {
                 woke = true;
-                let _ = panic::catch_unwind(|| waiter.wake());
+                wake!(waiter);
             }
         }
         return Some(woke);


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

### What does this PR do?

Wake directly without accumulating waker

### Related issues

#319 

### Additional Notes

The root change is removing `Reactor::wakers`. And call `Waker::wake()` instead of accumulating waker.

In the case of needing to count how many `wake()` are called, I accumulating the result in a mutable parameter rather than querying the vector's size.

But I think there might have some problems. In my environment, some test cases will hang *sometimes*. I pick one `producer_sleeps_before_consumer_consumes` to debug and find `submit_sqes_and_wait()` from `SleepableRing::sleep()` will not be wake up. So I mark this PR as draft for now. I'll continue on this and appreciate it if someone could help.

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
