### PR TITLE
reactor io stats collection

### DIFF
--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -52,6 +52,7 @@ use crate::{
     task::{self, waker_fn::waker_fn},
     GlommioError,
     IoRequirements,
+    IoStats,
     Latency,
     Reactor,
     Shares,
@@ -1599,6 +1600,28 @@ impl<T> Task<T> {
     /// [`ExecutorStats`]: struct.ExecutorStats.html
     pub fn executor_stats() -> ExecutorStats {
         LOCAL_EX.with(|local_ex| local_ex.queues.borrow().stats)
+    }
+
+    /// Returns an [`IoStats`] struct with information about IO performed by
+    /// this executor's reactor
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// use glommio::{Local, LocalExecutorBuilder};
+    ///
+    /// let ex = LocalExecutorBuilder::new()
+    ///     .spawn(|| async move {
+    ///         println!("Stats for executor: {:?}", Local::io_stats());
+    ///     })
+    ///     .unwrap();
+    ///
+    /// ex.join().unwrap();
+    /// ```
+    ///
+    /// [`IoStats`]: crate::IoStats
+    pub fn io_stats() -> IoStats {
+        LOCAL_EX.with(|local_ex| local_ex.get_reactor().io_stats())
     }
 
     /// Cancels the task and waits for it to stop running.

--- a/glommio/src/executor.rs
+++ b/glommio/src/executor.rs
@@ -1624,6 +1624,37 @@ impl<T> Task<T> {
         LOCAL_EX.with(|local_ex| local_ex.get_reactor().io_stats())
     }
 
+    /// Returns an [`IoStats`] struct with information about IO performed from
+    /// the provided TaskQueue by this executor's reactor
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// use glommio::{Latency, Local, LocalExecutorBuilder, Shares};
+    ///
+    /// let ex = LocalExecutorBuilder::new()
+    ///     .spawn(|| async move {
+    ///         let new_tq = Local::create_task_queue(Shares::default(), Latency::NotImportant, "test");
+    ///         println!(
+    ///             "Stats for executor: {:?}",
+    ///             Local::task_queue_io_stats(new_tq)
+    ///         );
+    ///     })
+    ///     .unwrap();
+    ///
+    /// ex.join().unwrap();
+    /// ```
+    ///
+    /// [`IoStats`]: crate::IoStats
+    pub fn task_queue_io_stats(handle: TaskQueueHandle) -> Result<IoStats> {
+        LOCAL_EX.with(
+            |local_ex| match local_ex.get_reactor().task_queue_io_stats(&handle) {
+                Some(x) => Ok(x),
+                None => Err(GlommioError::queue_not_found(handle.index)),
+            },
+        )
+    }
+
     /// Cancels the task and waits for it to stop running.
     ///
     /// Returns the task's output if it was completed just before it got

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -363,6 +363,7 @@ pub(crate) mod test {
     use super::*;
     use crate::{test_utils::*, ByteSliceMutExt, Latency, Local, Shares};
     use futures::join;
+    use std::time::Duration;
 
     #[cfg(test)]
     pub(crate) fn make_test_directories(test_name: &str) -> std::vec::Vec<TestDirectory> {
@@ -672,5 +673,71 @@ pub(crate) mod test {
         wfile.close().await.unwrap();
         wfile_other.close().await.unwrap();
         rfile.close().await.unwrap();
+    });
+
+    async fn read_write(path: std::path::PathBuf) {
+        let new_file = DmaFile::create(path.clone())
+            .await
+            .expect("failed to create file");
+
+        let mut buf = new_file.alloc_dma_buffer(4096);
+        buf.memset(42);
+        let res = new_file.write_at(buf, 0).await.expect("failed to write");
+        assert_eq!(res, 4096);
+
+        new_file.close().await.expect("failed to close file");
+
+        let new_file = DmaFile::open(path).await.expect("failed to create file");
+        let read_buf = new_file.read_at(0, 500).await.expect("failed to read");
+        std::assert_eq!(read_buf.len(), 500);
+        for i in 0..read_buf.len() {
+            std::assert_eq!(read_buf[i], 42);
+        }
+
+        let read_buf = new_file
+            .read_at_aligned(0, 4096)
+            .await
+            .expect("failed to read");
+        std::assert_eq!(read_buf.len(), 4096);
+        for i in 0..read_buf.len() {
+            std::assert_eq!(read_buf[i], 42);
+        }
+
+        new_file.close().await.expect("failed to close file");
+    }
+
+    dma_file_test!(per_queue_stats, path, _k, {
+        let q1 = Local::create_task_queue(Shares::default(), Latency::NotImportant, "q1");
+        let q2 = Local::create_task_queue(
+            Shares::default(),
+            Latency::Matters(Duration::from_millis(1)),
+            "q2",
+        );
+        let task1 =
+            Local::local_into(read_write(path.join("q1")), q1).expect("failed to spawn task");
+        let task2 =
+            Local::local_into(read_write(path.join("q2")), q2).expect("failed to spawn task");
+
+        join!(task1, task2);
+
+        let stats = Local::io_stats();
+        assert_eq!(stats.all_rings().files_opened(), 4);
+        assert_eq!(stats.all_rings().files_closed(), 4);
+        assert_eq!(stats.all_rings().file_reads(), (4, 9216));
+        assert_eq!(stats.all_rings().file_writes(), (2, 8192));
+
+        let stats = Local::task_queue_io_stats(q1).expect("failed to retrieve task queue io stats");
+        assert_eq!(stats.all_rings().files_opened(), 2);
+        assert_eq!(stats.all_rings().files_closed(), 2);
+        assert_eq!(stats.all_rings().file_reads(), (2, 4608));
+        assert_eq!(stats.all_rings().file_writes(), (1, 4096));
+
+        let stats = Local::task_queue_io_stats(q2).expect("failed to retrieve task queue io stats");
+        assert_eq!(stats.all_rings().files_opened(), 2);
+        assert_eq!(stats.latency_ring.files_opened(), 2);
+        assert_eq!(stats.all_rings().files_closed(), 2);
+        assert_eq!(stats.latency_ring.files_closed(), 2);
+        assert_eq!(stats.all_rings().file_reads(), (2, 4608));
+        assert_eq!(stats.all_rings().file_writes(), (1, 4096));
     });
 }

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -64,6 +64,7 @@ use crate::{
     IoStats,
     Latency,
     Local,
+    TaskQueueHandle,
 };
 
 /// Waits for a notification.
@@ -293,6 +294,10 @@ impl Reactor {
 
     pub(crate) fn io_stats(&self) -> IoStats {
         self.sys.io_stats()
+    }
+
+    pub(crate) fn task_queue_io_stats(&self, handle: &TaskQueueHandle) -> Option<IoStats> {
+        self.sys.task_queue_io_stats(handle)
     }
 
     #[inline(always)]

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -50,8 +50,18 @@ use futures_lite::*;
 
 use crate::{
     sys,
-    sys::{DirectIo, DmaBuffer, IoBuffer, PollableStatus, SleepNotifier, Source, SourceType},
+    sys::{
+        DirectIo,
+        DmaBuffer,
+        IoBuffer,
+        PollableStatus,
+        SleepNotifier,
+        Source,
+        SourceType,
+        StatsCollectionFn,
+    },
     IoRequirements,
+    IoStats,
     Latency,
     Local,
 };
@@ -281,6 +291,10 @@ impl Reactor {
         }
     }
 
+    pub(crate) fn io_stats(&self) -> IoStats {
+        self.sys.io_stats()
+    }
+
     #[inline(always)]
     pub(crate) fn need_preempt(&self) -> bool {
         unsafe { *self.preempt_ptr_head != (*self.preempt_ptr_tail).load(Ordering::Acquire) }
@@ -294,9 +308,20 @@ impl Reactor {
         sys::write_eventfd(remote);
     }
 
-    fn new_source(&self, raw: RawFd, stype: SourceType) -> Source {
+    fn new_source(
+        &self,
+        raw: RawFd,
+        stype: SourceType,
+        stats_collection_fn: Option<StatsCollectionFn>,
+    ) -> Source {
         let ioreq = self.current_io_requirements.get();
-        sys::Source::new(ioreq, raw, stype)
+        sys::Source::new(
+            ioreq,
+            raw,
+            stype,
+            stats_collection_fn,
+            Some(Local::current_task_queue()),
+        )
     }
 
     pub(crate) fn inform_io_requirements(&self, req: IoRequirements) {
@@ -343,7 +368,16 @@ impl Reactor {
         pos: u64,
         pollable: PollableStatus,
     ) -> Source {
-        let source = self.new_source(raw, SourceType::Write(pollable, IoBuffer::Dma(buf)));
+        let source = self.new_source(
+            raw,
+            SourceType::Write(pollable, IoBuffer::Dma(buf)),
+            Some(|result, stats| {
+                if let Ok(result) = result {
+                    stats.file_writes += 1;
+                    stats.file_bytes_written += *result as u64;
+                }
+            }),
+        );
         self.sys.write_dma(&source, pos);
         source
     }
@@ -355,19 +389,25 @@ impl Reactor {
                 PollableStatus::NonPollable(DirectIo::Disabled),
                 IoBuffer::Buffered(buf),
             ),
+            Some(|result, stats| {
+                if let Ok(result) = result {
+                    stats.file_buffered_writes += 1;
+                    stats.file_buffered_bytes_written += *result as u64;
+                }
+            }),
         );
         self.sys.write_buffered(&source, pos);
         source
     }
 
     pub(crate) fn connect(&self, raw: RawFd, addr: SockAddr) -> Source {
-        let source = self.new_source(raw, SourceType::Connect(addr));
+        let source = self.new_source(raw, SourceType::Connect(addr), None);
         self.sys.connect(&source);
         source
     }
 
     pub(crate) fn connect_timeout(&self, raw: RawFd, addr: SockAddr, d: Duration) -> Source {
-        let source = self.new_source(raw, SourceType::Connect(addr));
+        let source = self.new_source(raw, SourceType::Connect(addr), None);
         source.set_timeout(d);
         self.sys.connect(&source);
         source
@@ -375,7 +415,7 @@ impl Reactor {
 
     pub(crate) fn accept(&self, raw: RawFd) -> Source {
         let addr = SockAddrStorage::uninit();
-        let source = self.new_source(raw, SourceType::Accept(addr));
+        let source = self.new_source(raw, SourceType::Accept(addr), None);
         self.sys.accept(&source);
         source
     }
@@ -386,7 +426,7 @@ impl Reactor {
         buf: DmaBuffer,
         timeout: Option<Duration>,
     ) -> io::Result<Source> {
-        let source = self.new_source(fd, SourceType::SockSend(buf));
+        let source = self.new_source(fd, SourceType::SockSend(buf), None);
         if let Some(timeout) = timeout {
             source.set_timeout(timeout);
         }
@@ -418,7 +458,7 @@ impl Reactor {
             msg_flags: 0,
         };
 
-        let source = self.new_source(fd, SourceType::SockSendMsg(buf, iov, hdr, addr));
+        let source = self.new_source(fd, SourceType::SockSendMsg(buf, iov, hdr, addr), None);
         if let Some(timeout) = timeout {
             source.set_timeout(timeout);
         }
@@ -456,6 +496,7 @@ impl Reactor {
                 hdr,
                 std::mem::MaybeUninit::<nix::sys::socket::sockaddr_storage>::uninit(),
             ),
+            None,
         );
         if let Some(timeout) = timeout {
             source.set_timeout(timeout);
@@ -471,7 +512,7 @@ impl Reactor {
         size: usize,
         timeout: Option<Duration>,
     ) -> io::Result<Source> {
-        let source = self.new_source(fd, SourceType::SockRecv(None));
+        let source = self.new_source(fd, SourceType::SockRecv(None), None);
         if let Some(timeout) = timeout {
             source.set_timeout(timeout);
         }
@@ -481,7 +522,7 @@ impl Reactor {
     }
 
     pub(crate) fn recv(&self, fd: RawFd, size: usize, flags: MsgFlags) -> Source {
-        let source = self.new_source(fd, SourceType::SockRecv(None));
+        let source = self.new_source(fd, SourceType::SockRecv(None), None);
         self.sys.recv(&source, size, flags);
         source
     }
@@ -493,7 +534,16 @@ impl Reactor {
         size: usize,
         pollable: PollableStatus,
     ) -> Source {
-        let source = self.new_source(raw, SourceType::Read(pollable, None));
+        let source = self.new_source(
+            raw,
+            SourceType::Read(pollable, None),
+            Some(|result, stats| {
+                if let Ok(result) = result {
+                    stats.file_reads += 1;
+                    stats.file_bytes_read += *result as u64;
+                }
+            }),
+        );
         self.sys.read_dma(&source, pos, size);
         source
     }
@@ -502,13 +552,19 @@ impl Reactor {
         let source = self.new_source(
             raw,
             SourceType::Read(PollableStatus::NonPollable(DirectIo::Disabled), None),
+            Some(|result, stats| {
+                if let Ok(result) = result {
+                    stats.file_buffered_reads += 1;
+                    stats.file_buffered_bytes_read += *result as u64;
+                }
+            }),
         );
         self.sys.read_buffered(&source, pos, size);
         source
     }
 
     pub(crate) fn fdatasync(&self, raw: RawFd) -> Source {
-        let source = self.new_source(raw, SourceType::FdataSync);
+        let source = self.new_source(raw, SourceType::FdataSync, None);
         self.sys.fdatasync(&source);
         source
     }
@@ -520,13 +576,21 @@ impl Reactor {
         size: u64,
         flags: libc::c_int,
     ) -> Source {
-        let source = self.new_source(raw, SourceType::Fallocate);
+        let source = self.new_source(raw, SourceType::Fallocate, None);
         self.sys.fallocate(&source, position, size, flags);
         source
     }
 
     pub(crate) fn close(&self, raw: RawFd) -> Source {
-        let source = self.new_source(raw, SourceType::Close);
+        let source = self.new_source(
+            raw,
+            SourceType::Close,
+            Some(|result, stats| {
+                if result.is_ok() {
+                    stats.files_closed += 1
+                }
+            }),
+        );
         self.sys.close(&source);
         source
     }
@@ -542,6 +606,7 @@ impl Reactor {
         let source = self.new_source(
             raw,
             SourceType::Statx(path, Box::new(RefCell::new(statx_buf))),
+            None,
         );
         self.sys.statx(&source);
         source
@@ -556,14 +621,22 @@ impl Reactor {
     ) -> Source {
         let path = CString::new(path.as_os_str().as_bytes()).expect("path contained null!");
 
-        let source = self.new_source(dir, SourceType::Open(path));
+        let source = self.new_source(
+            dir,
+            SourceType::Open(path),
+            Some(|result, stats| {
+                if result.is_ok() {
+                    stats.files_opened += 1
+                }
+            }),
+        );
         self.sys.open_at(&source, flags, mode);
         source
     }
 
     #[cfg(feature = "bench")]
     pub(crate) fn nop(&self) -> Source {
-        let source = self.new_source(-1, SourceType::Noop);
+        let source = self.new_source(-1, SourceType::Noop, None);
         self.sys.nop(&source);
         source
     }

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -506,6 +506,8 @@ pub struct InnerSource {
     enqueued: Cell<Option<EnqueuedSource>>,
 
     stats_collection: Option<StatsCollectionFn>,
+
+    task_queue: Option<TaskQueueHandle>,
 }
 
 pub struct EnqueuedSource {
@@ -536,6 +538,7 @@ impl Source {
         raw: RawFd,
         source_type: SourceType,
         stats_collection_fn: Option<StatsCollectionFn>,
+        task_queue: Option<TaskQueueHandle>,
     ) -> Source {
         Source {
             inner: Rc::new(InnerSource {
@@ -546,6 +549,7 @@ impl Source {
                 enqueued: Cell::new(None),
                 timeout: RefCell::new(None),
                 stats_collection: stats_collection_fn,
+                task_queue,
             }),
         }
     }


### PR DESCRIPTION
### What does this PR do?

The reactor now records certain statistics from completed sources. We
currently records file basic counters:
* IO ops (reads/writes)
* bytes read/written;
* file open/close.

Applications may access these with `Local::io_stats()`. The plumbings
should make it easy for future additions.

This PR also records the same io stats we record in the reactor, but per
task queues, via `Local::task_queue_io_stats(handle)`. 
Since task queues are internally kept track of with a monotonic counter,
we don't delete stats when a task queue is removed. This means that an
application may retrieve io stats for queue even after they have
been removed from the executor.

### Checklist

- [x] I have added unit tests to the code I am submitting
- [x] My unit tests cover both failure and success scenarios
- [ ] If applicable, I have discussed my architecture
