### PR TITLE
don't treat timers separately

### DIFF
--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -989,7 +989,6 @@ impl UringCommon for SleepableRing {
             self.ring.peek_for_cqe(),
             |source| match &mut *source.source_type.borrow_mut() {
                 SourceType::LinkRings => Some(()),
-                SourceType::Timeout(_) => Some(()),
                 _ => None,
             },
             wakers,


### PR DESCRIPTION
This is ancient code, from a time in which we had to handle the preempt
timer in a special way. Our uring code is now more capable and more
generic, and the cancellation queue allow us to handle the preempt timer
like any other event.

I don't know for sure if this is the cause of Issue 326, but I suspect
it is: if a timer fires when we are processing the cancellations, and it
happens to be the only event that fires, it is theoretically possible
that we go to sleep, in which case we'll never wake up.

Although I am not sure this is the cause of the bug, it is one fewer
special case.

Ref #326

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
