### PR TITLE
Support getting peer_addr from AcceptedTcpStream

### DIFF
--- a/glommio/src/channels/sharding.rs
+++ b/glommio/src/channels/sharding.rs
@@ -80,6 +80,11 @@ impl<T: Send + 'static, H: Handler<T> + 'static> Sharded<T, H> {
         })
     }
 
+    /// Returns the total number of shards
+    pub fn nr_shards(&self) -> usize {
+        self.shard.nr_shards
+    }
+
     /// Returns the shard_id associated with ourselves
     pub fn shard_id(&self) -> usize {
         self.shard.shard_id


### PR DESCRIPTION
### What does this PR do?

This PR adds a method to get peer address from `AcceptedTcpStream`

### Motivation

It is necessary to implement something like scylla's shard awareness
