### PR TITLE
scoped task: a way to pass a future that is not 'static

### DIFF
--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -451,6 +451,7 @@ pub use crate::{
         LocalExecutorPoolBuilder,
         Placement,
         PoolThreadHandles,
+        ScopedTask,
         Task,
         TaskQueueHandle,
         TaskQueueStats,


### PR DESCRIPTION
Many of you have asked in the past for a way to spawn a task without
the 'static bound. Not only the 'static bound is hard to understand for
new users, it also forces us to resort to shared pointers in situations
where simple references would do.

As I have said before, the 'static bound comes from the fact that the
task may be detached. Even if it is not, the mere possibility of doing
so requires us to be strict abound that bound.

The solution for that is to create a new type of task: a ScopedTask.
The ScopedTask can never be detached, so we know it will live for as
long the variables it references. We can then just let the borrow
checker do its job.
