### PR TITLE
fix raii test

### DIFF
--- a/glommio/src/sync/semaphore.rs
+++ b/glommio/src/sync/semaphore.rs
@@ -681,7 +681,7 @@ mod test {
                 Local::local(async move {
                     let _g = g;
                     sleep(Duration::from_secs(1)).await;
-                }).detach();
+                }).await
             }});
 
             // Wait for all permits to try and acquire, then unleash the gates.


### PR DESCRIPTION
Test happens to work due to current scheduling order, but it is not
robust. We should wait for the sleep to finish, and only then we can
guarantee that the permit has been released
