### PR TITLE
fix join handle drop condition

### DIFF
--- a/glommio/src/task/join_handle.rs
+++ b/glommio/src/task/join_handle.rs
@@ -112,7 +112,7 @@ impl<R> Drop for JoinHandle<R> {
                 // If this is the last reference to the task and it's not closed, then
                 // close it and schedule one more time so that its future gets dropped by
                 // the executor.
-                let new = if (refs == 0) | (state & CLOSED == 0) {
+                let new = if (refs == 0) & (state & CLOSED == 0) {
                     SCHEDULED | CLOSED
                 } else {
                     state & !HANDLE


### PR DESCRIPTION
This is wrong: the comment says we should close if this is the last
reference *and* it is not closed. But we're testing with an or
statement.

It could obviously be that the comment is wrong, but:
1. logically it is not: why would we unconditionally close here if
   not closed?
2. while everything surprisingly works even with this condition, a
   couple of tests break if I change the FIFO order of execution, and
   this fixes it.

### What does this PR do?

A brief description of the change being made with this pull request.
