### PR TITLE
bulk (vectorized) IO dispatch and coalescing

### DIFF
--- a/examples/sharding.rs
+++ b/examples/sharding.rs
@@ -21,7 +21,7 @@ fn main() {
     #[derive(Clone)]
     struct RequestHandler {
         nr_shards: usize,
-    };
+    }
 
     impl Handler<i32> for RequestHandler {
         fn handle(&self, msg: Msg, _src_shard: usize, cur_shard: usize) -> HandlerResult {

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -35,6 +35,7 @@ ahash = "0.5.7"
 intrusive-collections = "0.9.0"
 lockfree = "0.5"
 membarrier = "0.2.2"
+itertools = "0.10.0"
 
 [dev-dependencies]
 futures = "0.3.5"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -41,6 +41,7 @@ itertools = "0.10.0"
 futures = "0.3.5"
 fastrand = "1.4.0"
 tokio = { version = "0.3.5", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time"] }
+rand = "0.8.0"
 
 [build-dependencies]
 cc = "1.0.47"

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -49,3 +49,52 @@ impl<U: Copy + Unpin> Stream for OrderedBulkIo<U> {
         (self.iovs.len(), Some(self.iovs.len()))
     }
 }
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct ReadManyArgs {
+    pub(crate) user_read: (u64, usize),
+    pub(crate) system_read: (u64, usize),
+}
+
+#[derive(Debug)]
+pub struct ReadManyResult {
+    pub(crate) inner: OrderedBulkIo<ReadManyArgs>,
+    pub(crate) current_result: ReadResult,
+}
+
+impl Stream for ReadManyResult {
+    type Item = super::Result<(u64, ReadResult)>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let next = match Pin::new(&mut self.inner).poll_next(cx) {
+            Poll::Ready(next) => next,
+            Poll::Pending => return Poll::Pending,
+        };
+
+        match next {
+            None => Poll::Ready(None),
+            Some((source, args)) => {
+                if let Some(mut source) = source {
+                    let read_size =
+                        enhanced_try!(source.take_result().unwrap(), "Reading", self.inner.file)?;
+                    let mut buffer = source.extract_dma_buffer();
+                    buffer.trim_to_size(std::cmp::min(read_size, args.system_read.1));
+                    self.current_result = ReadResult::from_whole_buffer(buffer);
+                }
+                Poll::Ready(Some(Ok((
+                    args.user_read.0,
+                    ReadResult::slice(
+                        &self.current_result,
+                        (args.user_read.0 - args.system_read.0) as usize,
+                        args.user_read.1,
+                    )
+                    .unwrap_or_default(),
+                ))))
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -1,0 +1,51 @@
+use crate::{
+    io::{DmaFile, ReadResult},
+    sys::Source,
+};
+use core::task::{Context, Poll};
+use futures_lite::Stream;
+use std::{collections::VecDeque, os::unix::io::AsRawFd, pin::Pin, rc::Rc};
+
+#[derive(Debug)]
+pub(crate) struct OrderedBulkIo<U> {
+    file: Rc<DmaFile>,
+    iovs: VecDeque<(Option<Source>, U)>,
+}
+
+impl<U: Copy + Unpin> OrderedBulkIo<U> {
+    pub(crate) fn new<S: Iterator<Item = (Option<Source>, U)>>(
+        file: Rc<DmaFile>,
+        iovs: S,
+    ) -> OrderedBulkIo<U> {
+        OrderedBulkIo {
+            file,
+            iovs: iovs.collect(),
+        }
+    }
+}
+
+impl<U: Copy + Unpin> Stream for OrderedBulkIo<U> {
+    type Item = (Option<Source>, U);
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.iovs.front() {
+            None => Poll::Ready(None),
+            Some((Some(source), _)) => {
+                let res = if source.has_result() {
+                    Poll::Ready(Some(self.iovs.pop_front().unwrap()))
+                } else {
+                    Poll::Pending
+                };
+                if let Some((Some(source), _)) = self.iovs.front() {
+                    source.add_waiter(cx.waker().clone());
+                }
+                res
+            }
+            Some((None, _)) => Poll::Ready(Some(self.iovs.pop_front().unwrap())),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.iovs.len(), Some(self.iovs.len()))
+    }
+}

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -346,7 +346,8 @@ impl DmaFile {
         self.file.path()
     }
 
-    pub(crate) async fn close_rc(self: Rc<DmaFile>) -> Result<()> {
+    /// Convenience method that closes a DmaFile wrapped inside an Rc
+    pub async fn close_rc(self: Rc<DmaFile>) -> Result<()> {
         match Rc::try_unwrap(self) {
             Err(file) => Err(io::Error::new(
                 io::ErrorKind::Other,

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -100,14 +100,7 @@ macro_rules! enhanced_try {
             }
         }
     }};
-    ($expr:expr, $op:expr, $obj:expr) => {{
-        enhanced_try!(
-            $expr,
-            $op,
-            $obj.path.as_ref().and_then(|x| Some(x.as_path())),
-            Some($obj.as_raw_fd())
-        )
-    }};
+    ($expr:expr, $op:expr, $obj:expr) => {{ enhanced_try!($expr, $op, $obj.path(), Some($obj.as_raw_fd())) }};
 }
 
 mod buffered_file;

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -147,7 +147,7 @@ pub use self::{
         StreamWriter,
         StreamWriterBuilder,
     },
-    bulk_io::ReadManyResult,
+    bulk_io::{IoVec, ReadManyResult},
     directory::Directory,
     dma_file::DmaFile,
     dma_file_stream::{

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -105,6 +105,7 @@ macro_rules! enhanced_try {
 
 mod buffered_file;
 mod buffered_file_stream;
+mod bulk_io;
 mod directory;
 mod dma_file;
 mod dma_file_stream;

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -147,6 +147,7 @@ pub use self::{
         StreamWriter,
         StreamWriterBuilder,
     },
+    bulk_io::ReadManyResult,
     directory::Directory,
     dma_file::DmaFile,
     dma_file_stream::{

--- a/glommio/src/io/read_result.rs
+++ b/glommio/src/io/read_result.rs
@@ -6,7 +6,7 @@ use crate::sys::DmaBuffer;
 use core::num::NonZeroUsize;
 use std::rc::Rc;
 
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Debug)]
 /// ReadResult encapsulates a buffer, returned by read operations like
 /// [`get_buffer_aligned`](super::DmaStreamReader::get_buffer_aligned) and
 /// [`read_at`](super::DmaFile::read_at)


### PR DESCRIPTION
### What does this PR do?

This PR adds a new method `DmaFile::read_many` that takes an
iterator of iovec and dispatch them in bulk. The function returns a
stream-like struct that yields `ReadResult`s that users may
asynchronously consume.

The benefit of this approach is that it makes it possible to submit an
arbitrary number of concurrent IO and wait for them from a single task,
reducing the CPU overhead. This effectively means that a Task is no
longer needed as a unit of parallelization when doing IO in glommio.

Using the glommio benchmark utility, I measure a 19% IOPS
improvement for random 4k reads. However, I believe my local disk
is the limiting factor at this point (the result I get matches the
manufacturer IOPS rate for random read at queue saturation).

In addition to reducing the scheduler overhead, this PR also adds
a IO request coalescing/merging utility. The iovec stream is
preprocessed such that many `ReadResult` may feed from the same
buffer. For instance:

```rust
let iovecs: Vec<(u64, usize)> = vec![(64, 256), (32, 4064), (4095, 10), (8192, 4096)];
let results = new_file.read_many(iovecs.into_iter(), 4096, None);
assert_eq!(results.count().await, 4);
assert_eq!(Local::io_stats().all_rings().file_reads().0, 2);
```

The above code requests 4 buffers and gets them back from the stream,
yet the reactor only performs two reads internally.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
