### PR TITLE
use clippy from the `stable` rust channel

### DIFF
--- a/examples/deadline_writer.rs
+++ b/examples/deadline_writer.rs
@@ -100,7 +100,7 @@ impl DeadlineSource for IntWriter {
     }
 
     fn action(self: Rc<Self>) -> Pin<Box<dyn Future<Output = Duration> + 'static>> {
-        Box::pin(self.clone().write_int())
+        Box::pin(self.write_int())
     }
 
     fn total_units(&self) -> u64 {

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -33,7 +33,7 @@ fn main() {
         let second = Local::local(|_left: Rc<RefCell<bool>>, right: Rc<RefCell<bool>>| -> _ {
             async move {
                 loop {
-                    if *(right.borrow()) == false {
+                    if !(*(right.borrow())) {
                         println!("right");
                         *(right.borrow_mut()) = true
                     }

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -325,7 +325,7 @@ fn main() {
 
     let file_size = matches
         .value_of("file_size")
-        .and_then(|s| Some(s.parse::<u64>().unwrap() << 30))
+        .map(|s| s.parse::<u64>().unwrap() << 30)
         .unwrap_or(total_memory * 2);
 
     let random = total_memory / 10;

--- a/glommio/benches/sharding.rs
+++ b/glommio/benches/sharding.rs
@@ -23,7 +23,7 @@ fn main() {
     #[derive(Clone)]
     struct RequestHandler {
         nr_shards: usize,
-    };
+    }
 
     impl Handler<i32> for RequestHandler {
         fn handle(&self, _msg: Msg, _src_shard: usize, _cur_shard: usize) -> HandlerResult {

--- a/glommio/benches/tcp.rs
+++ b/glommio/benches/tcp.rs
@@ -127,7 +127,7 @@ fn main() {
                 let wr = stream.write(&byte).await.unwrap();
                 total += wr as f64;
             }
-            total = total / 1_000_000_000.0;
+            total /= 1_000_000_000.0;
 
             println!(
                 "Bandwidth of sending through a single socket: {:.2} Gbps/s",

--- a/glommio/benches/tokio_tcp.rs
+++ b/glommio/benches/tokio_tcp.rs
@@ -85,7 +85,7 @@ async fn main() -> io::Result<()> {
         let wr = stream.write(&byte).await.unwrap();
         total += wr as f64;
     }
-    total = total / 1_000_000_000.0;
+    total /= 1_000_000_000.0;
 
     println!(
         "Bandwidth of sending through a single socket: {:.2} Gbps/s",

--- a/glommio/benches/udp.rs
+++ b/glommio/benches/udp.rs
@@ -27,7 +27,7 @@ fn main() {
                 if read == 0 {
                     break;
                 }
-                receiver.send(&mut buf).await.unwrap();
+                receiver.send(&buf).await.unwrap();
             }
 
             loop {
@@ -36,7 +36,7 @@ fn main() {
                 if read == 0 {
                     break;
                 }
-                receiver.send_to(&mut buf, client_addr).await.unwrap();
+                receiver.send_to(&buf, client_addr).await.unwrap();
             }
         })
         .unwrap();

--- a/glommio/src/channels/channel_mesh.rs
+++ b/glommio/src/channels/channel_mesh.rs
@@ -96,10 +96,8 @@ impl<T: Send> Senders<T> {
 
     /// Close the senders
     pub fn close(&self) {
-        for sender in self.senders.iter() {
-            if let Some(sender) = sender {
-                sender.close();
-            }
+        for sender in self.senders.iter().flatten() {
+            sender.close();
         }
     }
 }

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -181,8 +181,8 @@ impl<T: 'static + Send + Sized> SharedSender<T> {
         let peer = Connector::new(state.buffer.clone(), reactor.clone());
         let notifier = peer.await;
         ConnectedSender {
-            state,
             id,
+            state,
             reactor,
             notifier,
         }
@@ -338,8 +338,8 @@ impl<T: 'static + Send + Sized> SharedReceiver<T> {
         let peer = Connector::new(state.buffer.clone(), reactor.clone());
         let notifier = peer.await;
         ConnectedReceiver {
-            state,
             id,
+            state,
             reactor,
             notifier,
         }

--- a/glommio/src/channels/spsc_queue.rs
+++ b/glommio/src/channels/spsc_queue.rs
@@ -403,15 +403,15 @@ mod tests {
 
         for i in 0..10 {
             p.try_push(i);
-            assert!(p.capacity() == 10);
-            assert!(p.size() == i + 1);
+            assert_eq!(p.capacity(), 10);
+            assert_eq!(p.size(), i + 1);
         }
 
         match p.try_push(10) {
             Some(v) => {
-                assert!(v == 10);
+                assert_eq!(v, 10);
             }
-            None => assert!(false, "Queue should not have accepted another write!"),
+            None => unreachable!("Queue should not have accepted another write!"),
         }
     }
 
@@ -419,21 +419,19 @@ mod tests {
     fn test_try_poll() {
         let (p, c) = super::make(10);
 
-        match c.try_pop() {
-            Some(_) => assert!(false, "Queue was empty but a value was read!"),
-            None => {}
+        if c.try_pop().is_some() {
+            unreachable!("Queue was empty but a value was read!")
         }
 
         p.try_push(123);
 
         match c.try_pop() {
-            Some(v) => assert!(v == 123),
-            None => assert!(false, "Queue was not empty but poll() returned nothing!"),
+            Some(v) => assert_eq!(v, 123),
+            None => unreachable!("Queue was not empty but poll() returned nothing!"),
         }
 
-        match c.try_pop() {
-            Some(_) => assert!(false, "Queue was empty but a value was read!"),
-            None => {}
+        if c.try_pop().is_some() {
+            unreachable!("Queue was empty but a value was read!")
         }
     }
 
@@ -444,7 +442,7 @@ mod tests {
         thread::spawn(move || {
             for i in 0..100000 {
                 loop {
-                    if let None = p.try_push(i) {
+                    if p.try_push(i).is_none() {
                         break;
                     }
                 }

--- a/glommio/src/controllers/deadline_queue.rs
+++ b/glommio/src/controllers/deadline_queue.rs
@@ -612,14 +612,14 @@ mod test {
         test_executor!(async move {
             let queue = Rc::new(DeadlineQueue::new("example", Duration::from_millis(1)));
             let tq = Local::local(enclose! { (queue) async move {
-                let test = DeadlineSourceTest::new(Duration::from_secs(2 as u64), 1);
+                let test = DeadlineSourceTest::new(Duration::from_secs(2_u64), 1);
                 let res = queue.push_work(test).await.unwrap();
                 assert_eq!(res, 0);
             }})
             .detach();
 
             Timer::new(Duration::from_millis(1)).await;
-            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1);
+            let test = DeadlineSourceTest::new(Duration::from_secs(1_u64), 1);
             match queue.push_work(test).await {
                 Err(x) => assert_eq!(x.kind(), io::ErrorKind::InvalidInput),
                 Ok(_) => panic!("should have failed"),
@@ -635,7 +635,7 @@ mod test {
                 "example",
                 Duration::from_millis(1),
             ));
-            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 0);
+            let test = DeadlineSourceTest::new(Duration::from_secs(1_u64), 0);
             let res = queue.push_work(test).await.unwrap();
             assert_eq!(res, 0);
         });
@@ -648,7 +648,7 @@ mod test {
                 "example",
                 Duration::from_millis(1),
             ));
-            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 0);
+            let test = DeadlineSourceTest::new(Duration::from_secs(1_u64), 0);
             let drop_happens = test.drop_guarantee.clone();
             let res = queue.push_work(test).await.unwrap();
             assert_eq!(res, 0);
@@ -663,7 +663,7 @@ mod test {
                 "example",
                 Duration::from_millis(1),
             ));
-            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1000);
+            let test = DeadlineSourceTest::new(Duration::from_secs(1_u64), 1000);
             let tq = Local::local(enclose! { (queue, test) async move {
                 let res = queue.push_work(test).await.unwrap();
                 assert_eq!(res, 0);
@@ -685,7 +685,7 @@ mod test {
                 "example",
                 Duration::from_millis(1),
             ));
-            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1000);
+            let test = DeadlineSourceTest::new(Duration::from_secs(1_u64), 1000);
             let tq = Local::local(enclose! { (queue, test) async move {
                 let res = queue.push_work(test).await.unwrap();
                 assert_eq!(res, 0);
@@ -705,7 +705,7 @@ mod test {
                 "example",
                 Duration::from_millis(10),
             ));
-            let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1000);
+            let test = DeadlineSourceTest::new(Duration::from_secs(1_u64), 1000);
             let tq = Local::local(enclose! { (queue, test) async move {
                 let res = queue.push_work(test).await.unwrap();
                 assert_eq!(res, 0);
@@ -740,7 +740,7 @@ mod test {
         test_executor!(async move {
             let queue = Rc::new(DeadlineQueue::new("example", Duration::from_millis(1)));
             let tq = Local::local(enclose! { (queue) async move {
-                let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1);
+                let test = DeadlineSourceTest::new(Duration::from_secs(1_u64), 1);
                 let res = queue.push_work(test).await.unwrap();
                 assert_eq!(res, 0);
             }})
@@ -749,7 +749,7 @@ mod test {
             Timer::new(Duration::from_millis(2)).await;
             let shares_first = queue.queue.shares();
             let tq2 = Local::local(enclose! { (queue) async move {
-                let test = DeadlineSourceTest::new(Duration::from_secs(1 as u64), 1000);
+                let test = DeadlineSourceTest::new(Duration::from_secs(1_u64), 1000);
                 let res = queue.push_work(test).await.unwrap();
                 assert_eq!(res, 0);
             }})

--- a/glommio/src/error.rs
+++ b/glommio/src/error.rs
@@ -588,8 +588,7 @@ mod test {
             None,
             Some(32),
         );
-        Err(enhanced)?;
-        Ok(())
+        Err(enhanced.into())
     }
 
     #[test]

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -2008,8 +2008,12 @@ mod test {
     fn create_fail_to_bind() {
         // If you have a system with 4 billion CPUs let me know and I will
         // update this test.
-        if let Ok(_) = LocalExecutorBuilder::new().pin_to_cpu(usize::MAX).make() {
-            panic!("Should have failed");
+        if LocalExecutorBuilder::new()
+            .pin_to_cpu(usize::MAX)
+            .make()
+            .is_ok()
+        {
+            unreachable!("Should have failed");
         }
     }
 
@@ -2043,13 +2047,13 @@ mod test {
         local_ex.run(async {
             let task = Task::local_into(
                 async move {
-                    panic!("Should not have executed this");
+                    unreachable!("Should not have executed this");
                 },
                 TaskQueueHandle { index: 1 },
             );
 
-            if let Ok(_) = task {
-                panic!("Should have failed");
+            if task.is_ok() {
+                unreachable!("Should have failed");
             }
         });
     }
@@ -2128,7 +2132,7 @@ mod test {
                         async move {
                             // In case we are executed first, yield to the the other task
                             loop {
-                                if *(nolat_started.borrow()) == false {
+                                if !(*(nolat_started.borrow())) {
                                     Local::later().await;
                                 } else {
                                     break;
@@ -2216,7 +2220,7 @@ mod test {
                         async move {
                             // In case we are executed first, yield to the the other task
                             loop {
-                                if *(first_started.borrow()) == false {
+                                if !(*(first_started.borrow())) {
                                     Local::later().await;
                                 } else {
                                     break;

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -702,6 +702,7 @@ mod test {
                             .expect("failed to create file");
                         if $size > 0 {
                             let mut buf = Vec::new();
+                            #[allow(clippy::reversed_empty_ranges)]
                             for v in 0..$size {
                                 buf.push(v as u8);
                             }

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -457,7 +457,7 @@ pub(crate) mod test {
         };
 
         vec.push(make_tmp_test_directory(test_name));
-        return vec;
+        vec
     }
 
     macro_rules! dma_file_test {
@@ -681,7 +681,7 @@ pub(crate) mod test {
         for _ in 0..200 {
             let mut buf = file.alloc_dma_buffer(size);
             let bytes = buf.as_bytes_mut();
-            bytes[0] = 'x' as u8;
+            bytes[0] = b'x';
 
             let f = file.write_at(buf, 0);
             futs.push(f);
@@ -715,7 +715,7 @@ pub(crate) mod test {
 
                     let mut buf = file.alloc_dma_buffer(size);
                     let bytes = buf.as_bytes_mut();
-                    bytes[0] = 'x' as u8;
+                    bytes[0] = b'x';
                     file.write_at(buf, 0).await.unwrap();
                     file.close().await.unwrap();
                 })

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -1364,8 +1364,7 @@ mod test {
             .with_buffer_size(1 << 10)
             .build();
 
-        let mut buf = Vec::with_capacity(file_size);
-        buf.resize(file_size, 0);
+        let mut buf = vec![0; file_size];
         reader.read_exact(&mut buf).await.unwrap();
         check_contents!(buf, 0);
         reader.close().await.unwrap();

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -259,7 +259,7 @@ pub(crate) mod test {
             let path = dir.path.clone();
 
             let file = path.join("file");
-            let gf = GlommioFile::open_at(-1, &file, libc::O_CREAT, 0644)
+            let gf = GlommioFile::open_at(-1, &file, libc::O_CREAT, 644)
                 .await
                 .unwrap();
             let gf_fd = gf.path.as_ref().cloned().unwrap();
@@ -275,7 +275,7 @@ pub(crate) mod test {
                 files
             };
 
-            assert!(file_list().iter().find(|&x| *x == gf_fd).is_some()); // sanity check that file is open
+            assert!(file_list().iter().any(|x| *x == gf_fd)); // sanity check that file is open
             let _ = { gf }; // moves scope and drops
             sleep(Duration::from_millis(10)).await; // forces the reactor to run, which will drop the file
             assert!(file_list().iter().find(|&x| *x == gf_fd).is_none()); // file is gone

--- a/glommio/src/iou/mod.rs
+++ b/glommio/src/iou/mod.rs
@@ -364,31 +364,22 @@ mod tests {
     fn test_resultify() {
         let side_effect = |i, effect: &mut _| -> i32 {
             *effect += 1;
-            return i;
+            i
         };
 
         let mut calls = 0;
         let ret = resultify(side_effect(0, &mut calls));
-        assert!(match ret {
-            Ok(0) => true,
-            _ => false,
-        });
+        matches!(ret, Ok(0));
         assert_eq!(calls, 1);
 
         calls = 0;
         let ret = resultify(side_effect(1, &mut calls));
-        assert!(match ret {
-            Ok(1) => true,
-            _ => false,
-        });
+        matches!(ret, Ok(1));
         assert_eq!(calls, 1);
 
         calls = 0;
         let ret = resultify(side_effect(-1, &mut calls));
-        assert!(match ret {
-            Err(e) if e.raw_os_error() == Some(1) => true,
-            _ => false,
-        });
+        matches!(ret, Err(e) if e.raw_os_error() == Some(1));
         assert_eq!(calls, 1);
     }
 }

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -770,7 +770,7 @@ mod tests {
                 Task::local(enclose! { (coord) async move {
                     coord.set(1);
                     let stream = listener.accept().await?;
-                    Ok(stream.peer_addr()?)
+                    stream.peer_addr()
                 }});
 
             while coord.get() != 1 {

--- a/glommio/src/sync/rwlock.rs
+++ b/glommio/src/sync/rwlock.rs
@@ -936,6 +936,7 @@ mod test {
             let lock = RwLock::new(());
             drop(lock.read().await.unwrap());
             drop(lock.write().await.unwrap());
+            #[allow(clippy::eval_order_dependence)]
             drop((lock.read().await.unwrap(), lock.read().await.unwrap()));
             drop(lock.read().await.unwrap());
         });
@@ -1211,11 +1212,8 @@ mod test {
             let write_result = lock.try_write();
             match write_result {
                 Err(GlommioError::WouldBlock(ResourceType::RwLock)) => (),
-                Ok(_) => assert!(
-                    false,
-                    "try_write should not succeed while read_guard is in scope"
-                ),
-                Err(_) => assert!(false, "unexpected error"),
+                Ok(_) => unreachable!("try_write should not succeed while read_guard is in scope"),
+                Err(_) => unreachable!("unexpected error"),
             }
 
             drop(read_guard);
@@ -1231,11 +1229,8 @@ mod test {
             let write_result = lock.try_read();
             match write_result {
                 Err(GlommioError::WouldBlock(ResourceType::RwLock)) => (),
-                Ok(_) => assert!(
-                    false,
-                    "try_read should not succeed while read_guard is in scope"
-                ),
-                Err(_) => assert!(false, "unexpected error"),
+                Ok(_) => unreachable!("try_read should not succeed while read_guard is in scope"),
+                Err(_) => unreachable!("unexpected error"),
             }
 
             drop(read_guard);

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -1660,13 +1660,13 @@ mod tests {
         let start = Instant::now();
         reactor.wait(None, None, 0, || 0).unwrap();
         let elapsed_ms = start.elapsed().as_millis();
-        assert!(50 <= elapsed_ms && elapsed_ms < 100);
+        assert!((50..100).contains(&elapsed_ms));
 
         drop(slow); // Cancel this one.
 
         reactor.wait(None, None, 0, || 0).unwrap();
         let elapsed_ms = start.elapsed().as_millis();
-        assert!(300 <= elapsed_ms && elapsed_ms < 350);
+        assert!((300..350).contains(&elapsed_ms));
     }
 
     #[test]
@@ -1699,14 +1699,12 @@ mod tests {
         let x = al.new_buffer(4096).unwrap();
         let y = al.new_buffer(4096).unwrap();
 
-        match x.uring_buffer_id() {
-            Some(x) => assert_eq!(x, 1234),
-            None => panic!("Expected uring buffer"),
+        if y.uring_buffer_id().is_some() {
+            panic!("Expected non-uring buffer")
         }
 
-        match y.uring_buffer_id() {
-            Some(_) => panic!("Expected non-uring buffer"),
-            None => {}
+        if y.uring_buffer_id().is_some() {
+            unreachable!("Expected non-uring buffer")
         }
         drop(x);
         drop(y);
@@ -1715,14 +1713,13 @@ mod tests {
         let x = al.new_buffer(4096).unwrap();
         match x.uring_buffer_id() {
             Some(x) => assert_eq!(x, 1234),
-            None => panic!("Expected uring buffer"),
+            None => unreachable!("Expected uring buffer"),
         }
         drop(x);
         // Allocation for an object that is too big fails
         let x = al.new_buffer(40960).unwrap();
-        match x.uring_buffer_id() {
-            Some(_) => panic!("Expected non-uring buffer"),
-            None => {}
+        if x.uring_buffer_id().is_some() {
+            unreachable!("Expected non-uring buffer")
         }
     }
 

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -847,10 +847,7 @@ impl Source {
 
     pub(crate) fn take_result(&self) -> Option<io::Result<usize>> {
         let mut w = self.inner.wakers.borrow_mut();
-        match w.result.take() {
-            None => None,
-            Some(x) => Some(x.map(|x| x as usize)),
-        }
+        w.result.take().map(|x| x.map(|x| x as usize))
     }
 
     pub(crate) fn has_result(&self) -> bool {

--- a/glommio/src/task/mod.rs
+++ b/glommio/src/task/mod.rs
@@ -61,8 +61,6 @@
 //! [`Waker`]: https://doc.rust-lang.org/std/task/struct.Waker.html
 
 #![warn(missing_docs, missing_debug_implementations)]
-#![doc(test(attr(deny(rust_2018_idioms, warnings))))]
-#![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
 
 pub(crate) mod header;
 pub(crate) mod join_handle;

--- a/glommio/src/timer/timer_impl.rs
+++ b/glommio/src/timer/timer_impl.rs
@@ -1107,9 +1107,9 @@ mod test {
                 async move {
                     *(ex.borrow_mut()) += 1;
                     if (*ex.borrow()) == 10 {
-                        return None;
+                        None
                     } else {
-                        return Some(Duration::from_millis(5));
+                        Some(Duration::from_millis(5))
                     }
                 }
             });


### PR DESCRIPTION
### What does this PR do?

We currently use a specific version of clippy (1.51.0) because we wanted
some specific features not yet available in the `stable` channel. Rust
stable is now 1.52.0 so this commit makes all the necessary changes for
clippy to run without error under that version.

This PR also contains a second commit that is optional:

```
So far we don't run clippy on non-lib targets in CI. This commit applies
all clippy suggestions on those so we can start expecting clippied code
everywhere.

I left those changes in their own commit because I'm okay with dropping
them. There are pros and cons to doing this. Not running clippy
everywhere implicitly creates two languages for glommio: a clippy
version and a non-clippy one. This makes the sources harder to read and
harder to review, IMO.
```

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
