### PR TITLE
convert CI config to use VMs instead of containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,35 @@ jobs:
             - target/debug/deps
           key: v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
 
+  test:
+    machine:
+      image: ubuntu-2004:202104-01
+    steps:
+      - checkout
+      - rust/install
+      - run:
+          name: Version information
+          command: cat /proc/version; rustc --version; cargo --version; rustup --version
+      - run:
+          name: Calculate dependencies
+          command: cargo generate-lockfile
+      - run:
+          name: Set limits
+          command: ulimit -Sl 512; ulimit -Hl 512
+      - restore_cache:
+          keys:
+            - v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Test all targets
+          command: cargo test --all-features
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+
 workflows:
   unit_tests:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,12 @@
 # Glommio Circle-CI configuration file
 
-version: 5
+version: 2.1
+
+orbs:
+  rust: circleci/rust@1.5.0
 
 jobs:
-  cargobuild:
-    docker:
-      - image: cimg/rust:1.51.0
-    steps:
-      - checkout
-      - run:
-          name: Version information
-          command: rustc --version; cargo --version; rustup --version
-      - run:
-          name: Calculate dependencies
-          command: cargo generate-lockfile
-      - restore_cache:
-          keys:
-            - v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
-      - run:
-          name: Build all targets
-          command: cargo build --all --all-targets
-      - save_cache:
-          paths:
-            - /usr/local/cargo/registry
-            - target/debug/.fingerprint
-            - target/debug/build
-            - target/debug/deps
-          key: v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
-
-  cargofmt:
+  fmt:
     docker:
       - image: cimg/rust:1.51.0
     steps:
@@ -60,7 +38,7 @@ jobs:
             - target/debug/deps
           key: v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
 
-  cargodoc:
+  doc:
     docker:
       - image: cimg/rust:1.51.0
     steps:
@@ -92,7 +70,7 @@ jobs:
             - target/debug/deps
           key: v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
 
-  cargoclippy:
+  clippy:
     docker:
       - image: cimg/rust:1.51.0
     steps:
@@ -102,7 +80,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - run:
           name: Install clippy
-          command: rustup component add clippy --toolchain 1.51.0-x86_64-unknown-linux-gnu
+          command: rustup component add clippy
       - run:
           name: Calculate dependencies
           command: cargo generate-lockfile
@@ -120,11 +98,36 @@ jobs:
             - target/debug/deps
           key: v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
 
+  build:
+    machine:
+      image: ubuntu-2004:202104-01
+    steps:
+      - checkout
+      - rust/install
+      - run:
+          name: Version information
+          command: cat /proc/version; rustc --version; cargo --version; rustup --version
+      - run:
+          name: Calculate dependencies
+          command: cargo generate-lockfile
+      - restore_cache:
+          keys:
+            - v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Build all targets
+          command: cargo build --all --all-targets
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+
 workflows:
-  version: 2
   unit_tests:
     jobs:
-      - cargofmt
-      - cargoclippy
-      - cargobuild
-      - cargodoc
+      - fmt
+      - clippy
+      - doc
+      - build


### PR DESCRIPTION
### What does this PR do?

My disappointment is immeasurable, and my day is ruined.

I got excited earlier today when I saw [the announcement that
CircleCI was now providing VM images for `Ubuntu 21.04`](https://discuss.circleci.com/t/linux-machine-executor-images-2021-april-q2-update/39928). So,
I invested a couple of hours converting our CI configuration file
from using a container to using a VM.

Unfortunately, it seems like the announcement has a typo and the
new image is, in fact, just an updated version of Ubuntu 20.04.
(I am still waiting on a confirmation, we may get lucky).

Pretty disappointing but given that all this work will be eventually
needed, let's merge what we have so far.

> Note that this version of the configuration runs Clippy from `stable`
on all targets so this PR depends on #348.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
