### PR TITLE
simpler, faster reactor

### DIFF
--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -412,7 +412,7 @@ impl Reactor {
     }
 
     pub(crate) fn connect_timeout(&self, raw: RawFd, addr: SockAddr, d: Duration) -> Source {
-        let source = self.new_source(raw, SourceType::Connect(addr), None);
+        let mut source = self.new_source(raw, SourceType::Connect(addr), None);
         source.set_timeout(d);
         self.sys.connect(&source);
         source
@@ -431,7 +431,7 @@ impl Reactor {
         buf: DmaBuffer,
         timeout: Option<Duration>,
     ) -> io::Result<Source> {
-        let source = self.new_source(fd, SourceType::SockSend(buf), None);
+        let mut source = self.new_source(fd, SourceType::SockSend(buf), None);
         if let Some(timeout) = timeout {
             source.set_timeout(timeout);
         }
@@ -463,7 +463,7 @@ impl Reactor {
             msg_flags: 0,
         };
 
-        let source = self.new_source(fd, SourceType::SockSendMsg(buf, iov, hdr, addr), None);
+        let mut source = self.new_source(fd, SourceType::SockSendMsg(buf, iov, hdr, addr), None);
         if let Some(timeout) = timeout {
             source.set_timeout(timeout);
         }
@@ -493,7 +493,7 @@ impl Reactor {
             iov_base: std::ptr::null_mut(),
             iov_len: 0,
         };
-        let source = self.new_source(
+        let mut source = self.new_source(
             fd,
             SourceType::SockRecvMsg(
                 None,
@@ -517,7 +517,7 @@ impl Reactor {
         size: usize,
         timeout: Option<Duration>,
     ) -> io::Result<Source> {
-        let source = self.new_source(fd, SourceType::SockRecv(None), None);
+        let mut source = self.new_source(fd, SourceType::SockRecv(None), None);
         if let Some(timeout) = timeout {
             source.set_timeout(timeout);
         }

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -9,7 +9,7 @@ use lockfree::channel::mpsc;
 use log::debug;
 use nix::sys::socket::SockAddr;
 use std::{
-    cell::{Cell, RefCell},
+    cell::RefCell,
     convert::TryFrom,
     ffi::CString,
     fmt,
@@ -497,15 +497,15 @@ pub struct InnerSource {
     raw: RawFd,
 
     /// Tasks interested in events on this source.
-    wakers: RefCell<Wakers>,
+    wakers: Wakers,
 
-    source_type: RefCell<SourceType>,
+    source_type: SourceType,
 
     io_requirements: IoRequirements,
 
-    timeout: RefCell<Option<TimeSpec64>>,
+    timeout: Option<TimeSpec64>,
 
-    enqueued: Cell<Option<EnqueuedSource>>,
+    enqueued: Option<EnqueuedSource>,
 
     stats_collection: Option<StatsCollectionFn>,
 
@@ -530,7 +530,7 @@ impl fmt::Debug for InnerSource {
 
 #[derive(Debug)]
 pub struct Source {
-    pub(crate) inner: Rc<InnerSource>,
+    pub(crate) inner: Rc<RefCell<InnerSource>>,
 }
 
 impl Source {
@@ -543,16 +543,16 @@ impl Source {
         task_queue: Option<TaskQueueHandle>,
     ) -> Source {
         Source {
-            inner: Rc::new(InnerSource {
+            inner: Rc::new(RefCell::new(InnerSource {
                 raw,
-                wakers: RefCell::new(Wakers::new()),
-                source_type: RefCell::new(source_type),
+                wakers: Wakers::new(),
+                source_type,
                 io_requirements: ioreq,
-                enqueued: Cell::new(None),
-                timeout: RefCell::new(None),
+                enqueued: None,
+                timeout: None,
                 stats_collection: stats_collection_fn,
                 task_queue,
-            }),
+            })),
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

I've been doing some refactoring and performance improvements in the
reactor:
* `Source` wraps an `InnerSource` that contains fields wrapped in `RefCell`s
for interior mutability. This PR simplifies this by using a single `RefCell` for
the `InnerSource` altogether. This way all code inside the
`InnerSource` can use the compile-time borrow checker.
* Up to now, the source map existed as a static thread-local variable.
Thread-local entities are rather expensive in rust and so this commit
relocates the source map as a member of the `Reactor`. It is wrapped in
an `Rc` and shared in the different rings.
* We now avoid `Clone`ing sources when unnecessary in the reactor.

Some relevant IO benchmarks:

Before:
```
Buffered I/O: Wrote 1.07 GB in 352.827446ms, 3.04 GB/s
Buffered I/O: Closed in 55.866µs, Amortized total 3.04 GB/s
Direct I/O: Wrote 1.07 GB in 293.262222ms, 3.66 GB/s
Direct I/O: Closed in 121.008µs, Amortized total 3.66 GB/s
Direct I/O, write-behind: Wrote 1.07 GB in 222.827561ms, 4.82 GB/s
Direct I/O, write-behind: Closed in 1.030332ms, Amortized total 4.8 GB/s
Buffered I/O: Scanned 1.07 GB in 641.45869ms, 1.67 GB/s, 408670 IOPS
Direct I/O: Scanned 1.07 GB in 716.152568ms, 1.5 GB/s, 366046 IOPS
Direct I/O, read ahead: Scanned 1.07 GB in 270.486906ms, 3.97 GB/s, 969159 IOPS
Direct I/O, glommio API: Scanned 1.07 GB in 255.506772ms, 4.2 GB/s, 1025980 IOPS
Direct I/O, glommio API, large buffer: Scanned 1.07 GB in 110.936917ms, 9.68 GB/s, 18469 IOPS
```

After:
```
Buffered I/O: Wrote 1.07 GB in 244.095229ms, 4.4 GB/s
Buffered I/O: Closed in 58.921µs, Amortized total 4.4 GB/s
Direct I/O: Wrote 1.07 GB in 227.122739ms, 4.73 GB/s
Direct I/O: Closed in 110.318µs, Amortized total 4.73 GB/s
Direct I/O, write-behind: Wrote 1.07 GB in 171.369786ms, 6.27 GB/s
Direct I/O, write-behind: Closed in 782.615µs, Amortized total 6.24 GB/s
Buffered I/O: Scanned 1.07 GB in 623.257661ms, 1.72 GB/s, 420604 IOPS
Direct I/O: Scanned 1.07 GB in 704.036703ms, 1.53 GB/s, 372345 IOPS
Direct I/O, read ahead: Scanned 1.07 GB in 263.53527ms, 4.07 GB/s, 994724 IOPS
Direct I/O, glommio API: Scanned 1.07 GB in 249.565138ms, 4.3 GB/s, 1050407 IOPS
Direct I/O, glommio API, large buffer: Scanned 1.07 GB in 101.966746ms, 10.53 GB/s, 20094 IOPS
```

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
