### PR TITLE
fix UB in buffer allocation

### DIFF
--- a/glommio/src/sys/dma_buffer.rs
+++ b/glommio/src/sys/dma_buffer.rs
@@ -21,10 +21,14 @@ pub(crate) struct SysAlloc {
 
 impl SysAlloc {
     fn new(size: usize) -> Option<Self> {
-        let layout = Layout::from_size_align(size, 4096).unwrap();
-        let data = unsafe { alloc::alloc::alloc(layout) as *mut u8 };
-        let data = ptr::NonNull::new(data)?;
-        Some(SysAlloc { data, layout })
+        if size == 0 {
+            None
+        } else {
+            let layout = Layout::from_size_align(size, 4096).unwrap();
+            let data = unsafe { alloc::alloc::alloc(layout) as *mut u8 };
+            let data = ptr::NonNull::new(data)?;
+            Some(SysAlloc { data, layout })
+        }
     }
 
     fn as_ptr(&self) -> *const u8 {


### PR DESCRIPTION
https://doc.rust-lang.org/nightly/alloc/alloc/trait.GlobalAlloc.html#safety-1

It is UB to invoke a Layout with non-zero size, and we don't explicitly
test for it. We should.

Those are I/O buffers and a 0-sized I/O buffer makes no sense. So the
behavior here is to fail the allocation.

Thanks to user Nugine for spotting this.

Fixes #351

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
