### PR TITLE
Executor builders

### DIFF
--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -149,8 +149,18 @@ pub enum Placement {
     /// [`LocalExecutorPoolBuilder::on_all_shards`] will return `Result::
     /// Err`.
     MaxPack(Option<CpuSet>),
-    /* TODO:
-     * Custom, */
+    /// One [`LocalExecutor`] is bound to each of the [`CpuSet`]s specified by
+    /// `Custom`. The number of `CpuSet`s in the `Vec` should match the
+    /// number of shards requested from the pool builder.
+    ///
+    /// #### Errors
+    ///
+    /// [`LocalExecutorPoolBuilder::on_all_shards`] will return `Result::Err` if
+    /// either of the follow is true:
+    /// * The length of the vector does not match the number of shards requested
+    ///   in [`LocalExecutorPoolBuilder::new`].
+    /// * Any of the [`CpuSet`]s is empty.
+    Custom(Vec<CpuSet>),
 }
 
 /// The default is `Placement::Unbound`
@@ -274,6 +284,7 @@ pub(crate) enum CpuSetGenerator {
     Fenced(CpuSet),
     MaxSpread(MaxSpreader),
     MaxPack(MaxPacker),
+    Custom(Vec<CpuSet>),
 }
 
 impl CpuSetGenerator {
@@ -299,6 +310,18 @@ impl CpuSetGenerator {
                 };
                 Self::check_nr_cpus(nr_shards, &cpus)?;
                 Self::MaxPack(MaxPacker::from_cpu_set(cpus))
+            }
+            Placement::Custom(cpu_sets) => {
+                if cpu_sets.len() != nr_shards {
+                    return Err(GlommioError::BuilderError(BuilderErrorKind::NrShards {
+                        cpu_sets: cpu_sets.len(),
+                        shards: nr_shards,
+                    }));
+                }
+                for cpu_set in &cpu_sets {
+                    Self::check_nr_cpus(1, cpu_set)?;
+                }
+                Self::Custom(cpu_sets)
             }
         };
         Ok(this)
@@ -327,6 +350,9 @@ impl CpuSetGenerator {
             Self::Fenced(cpus) => CpuIter::from_vec(cpus.as_vec().clone()),
             Self::MaxSpread(it) => CpuIter::from_option(it.next()),
             Self::MaxPack(it) => CpuIter::from_option(it.next()),
+            Self::Custom(cpu_sets) => {
+                CpuIter::Multi(cpu_sets.pop().expect("insufficient cpu sets").take())
+            }
         }
     }
 }
@@ -751,5 +777,50 @@ mod test {
             counts[cpu_location.cpu] += 1;
         }
         assert_eq!(counts, [10, 10, 10, 10, 10, 10, 10]);
+    }
+
+    #[test]
+    fn custom_placement() {
+        let set1 = CpuSet(vec![
+            cpu_loc(0, 0, 0, 2),
+            cpu_loc(0, 0, 0, 0),
+            cpu_loc(0, 0, 0, 3),
+            cpu_loc(0, 0, 0, 1),
+        ]);
+        let set2 = CpuSet(vec![
+            cpu_loc(1, 1, 1, 5),
+            cpu_loc(0, 0, 0, 0),
+            cpu_loc(1, 1, 1, 4),
+            cpu_loc(0, 0, 0, 1),
+        ]);
+        let set3 = CpuSet(vec![]);
+
+        {
+            let p = Placement::Custom(vec![set1.clone(), set2.clone()]);
+            let mut gen = CpuSetGenerator::new(p, 2).unwrap();
+            let mut bindings = vec![];
+            for _ in 0..2 {
+                let v = gen
+                    .next()
+                    .cpu_binding()
+                    .unwrap()
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                bindings.push(v);
+            }
+            assert_eq!(bindings, vec![vec![1, 4, 0, 5], vec![1, 3, 0, 2]]);
+        }
+        {
+            let p = Placement::Custom(vec![set1.clone(), set2.clone()]);
+            assert!(CpuSetGenerator::new(p, 1).is_err());
+        }
+        {
+            let p = Placement::Custom(vec![set1.clone(), set2.clone()]);
+            assert!(CpuSetGenerator::new(p, 3).is_err());
+        }
+        {
+            let p = Placement::Custom(vec![set1, set2, set3]);
+            assert!(CpuSetGenerator::new(p, 3).is_err());
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Ties up a couple of loose ends relating to executor builders:
* Adds `Placement::Custom`
* Linux's default [NUMA memory policy](https://www.kernel.org/doc/html/latest/admin-guide/mm/numa_memory_policy.html) is "local allocation" which allocates memory on the NUMA node containing the CPU where the allocation takes place.  Hence, we bind to a CPU in the provided CPU set before allocating any memory for the `LocalExecutor`, thereby allowing any access to these data structures to occur on a local NUMA node.

### Motivation

Prior work

### Related issues

na

### Additional Notes

none

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[~] If applicable, I have discussed my architecture
