### PR TITLE
Remove `fasthash` from examples dependencies

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,6 @@ pretty-bytes = "0.2.2"
 clap = "2.33"
 sys-info = "0.7.0"
 fastrand = "1.4.0"
-fasthash = "0.3.2"
 
 # hyper and tokio for the hyper example. We just need the traits from Tokio
 hyper = { version = "0.13.9", default-features = false }


### PR DESCRIPTION
### What does this PR do?

Removes an unused dependency from the examples manifest to allow running said examples on ARM64 (https://github.com/flier/rust-fasthash/issues/13).

