### PR TITLE
docs.rs badge should point to glommio.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glommio
 
-[![docs.rs](https://docs.rs/mio/badge.svg)](https://docs.rs/glommio/latest/glommio/) [![CircleCI](https://circleci.com/gh/DataDog/glommio.svg?style=svg)](https://circleci.com/gh/DataDog/glommio)
+[![docs.rs](https://docs.rs/glommio/badge.svg)](https://docs.rs/glommio/latest/glommio/) [![CircleCI](https://circleci.com/gh/DataDog/glommio.svg?style=svg)](https://circleci.com/gh/DataDog/glommio)
 
 ## Join our Zulip community!
 


### PR DESCRIPTION
Previously, it would point to mio which has a different
version
