### PR TITLE
cross tasks io dedup

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.4.0"
 enclose = "1.1.8"
 scopeguard = "1.1.0"
 pin-project-lite = "0.1.10"
-smallvec = "1.4.2"
+smallvec = { version = "1.4.2", features = ["union"] }
 buddy-alloc = "0.4.1"
 ahash = "0.5.7"
 intrusive-collections = "0.9.0"

--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -166,7 +166,7 @@ impl BufferedFile {
             )
         })?;
         Ok(ReadResult::from_sliced_buffer(
-            source.extract_dma_buffer(),
+            source.extract_buffer(),
             0,
             read_size,
         ))

--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -165,9 +165,11 @@ impl BufferedFile {
                 Some(self.as_raw_fd()),
             )
         })?;
-        let mut buffer = source.extract_dma_buffer();
-        buffer.trim_to_size(read_size);
-        Ok(ReadResult::from_whole_buffer(buffer))
+        Ok(ReadResult::from_sliced_buffer(
+            source.extract_dma_buffer(),
+            0,
+            read_size,
+        ))
     }
 
     /// Issues `fdatasync` for the underlying file, instructing the OS to flush

--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -151,7 +151,7 @@ impl BufferedFile {
     /// [`DmaFile`]: struct.DmaFile.html
     /// Reads from a specific position in the file and returns the buffer.
     pub async fn read_at(&self, pos: u64, size: usize) -> Result<ReadResult> {
-        let mut source =
+        let source =
             self.file
                 .reactor
                 .upgrade()

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -366,7 +366,7 @@ impl StreamWriter {
         }
     }
 
-    fn consume_flush_result(&mut self, mut source: Source) -> io::Result<()> {
+    fn consume_flush_result(&mut self, source: Source) -> io::Result<()> {
         let res = source.take_result().unwrap();
         if res.is_ok() {
             let mut buffer = source.extract_buffer();
@@ -552,7 +552,7 @@ impl AsyncBufRead for StreamReader {
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<&'a [u8]>> {
         match self.source.take() {
-            Some(mut source) => {
+            Some(source) => {
                 let res = source.take_result().unwrap();
                 match res {
                     Err(x) => Poll::Ready(Err(x)),
@@ -645,7 +645,7 @@ impl AsyncBufRead for Stdin {
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<&'a [u8]>> {
         match self.source.take() {
-            Some(mut source) => {
+            Some(source) => {
                 let res = source.take_result().unwrap();
                 match res {
                     Err(x) => Poll::Ready(Err(x)),

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -167,7 +167,7 @@ impl Buffer {
         self.data = buf;
     }
 
-    fn replenish_buffer(&mut self, buf: IoBuffer, len: usize) {
+    fn replenish_buffer(&mut self, buf: &IoBuffer, len: usize) {
         use crate::ByteSliceExt;
         self.buffer_pos = 0;
         self.data.resize(len, 0u8);
@@ -367,7 +367,7 @@ impl StreamWriter {
     }
 
     fn consume_flush_result(&mut self, source: Source) -> io::Result<()> {
-        let res = source.take_result().unwrap();
+        let res = source.result().unwrap();
         if res.is_ok() {
             if let IoBuffer::Buffered(mut buffer) = source.extract_buffer() {
                 self.file_pos += buffer.len() as u64;
@@ -413,7 +413,7 @@ impl StreamWriter {
                     Poll::Pending
                 }
                 Some(source) => {
-                    let _ = source.take_result().unwrap();
+                    let _ = source.result().unwrap();
                     Poll::Ready(Ok(()))
                 }
             }
@@ -433,7 +433,7 @@ impl StreamWriter {
                 Poll::Pending
             }
             Some(source) => {
-                let _ = source.take_result().unwrap();
+                let _ = source.result().unwrap();
                 self.file.take().unwrap().discard();
                 Poll::Ready(Ok(()))
             }
@@ -556,7 +556,7 @@ impl AsyncBufRead for StreamReader {
     ) -> Poll<io::Result<&'a [u8]>> {
         match self.source.take() {
             Some(source) => {
-                let res = source.take_result().unwrap();
+                let res = source.result().unwrap();
                 match res {
                     Err(x) => Poll::Ready(Err(x)),
                     Ok(sz) => {
@@ -565,7 +565,7 @@ impl AsyncBufRead for StreamReader {
                         let added_size = new_pos - old_pos;
                         self.file_pos += added_size;
                         self.buffer
-                            .replenish_buffer(source.extract_buffer(), added_size as usize);
+                            .replenish_buffer(&source.buffer(), added_size as usize);
                         let this = self.project();
                         Poll::Ready(Ok(&this.buffer.unconsumed_bytes()))
                     }
@@ -647,11 +647,11 @@ impl AsyncBufRead for Stdin {
     ) -> Poll<io::Result<&'a [u8]>> {
         match self.source.take() {
             Some(source) => {
-                let res = source.take_result().unwrap();
+                let res = source.result().unwrap();
                 match res {
                     Err(x) => Poll::Ready(Err(x)),
                     Ok(sz) => {
-                        self.buffer.replenish_buffer(source.extract_buffer(), sz);
+                        self.buffer.replenish_buffer(&source.buffer(), sz);
                         let this = self.project();
                         Poll::Ready(Ok(&this.buffer.unconsumed_bytes()))
                     }

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -1,7 +1,4 @@
-use crate::{
-    io::{DmaFile, ReadResult},
-    sys::Source,
-};
+use crate::io::{DmaFile, ReadResult, ScheduledSource};
 use core::task::{Context, Poll};
 use futures_lite::{ready, Stream, StreamExt};
 use itertools::{Itertools, MultiPeek};
@@ -16,11 +13,11 @@ use std::{
 #[derive(Debug)]
 pub(crate) struct OrderedBulkIo<U> {
     file: Rc<DmaFile>,
-    iovs: VecDeque<(Option<Source>, U)>,
+    iovs: VecDeque<(Option<ScheduledSource>, U)>,
 }
 
 impl<U: Copy + Unpin> OrderedBulkIo<U> {
-    pub(crate) fn new<S: Iterator<Item = (Option<Source>, U)>>(
+    pub(crate) fn new<S: Iterator<Item = (Option<ScheduledSource>, U)>>(
         file: Rc<DmaFile>,
         iovs: S,
     ) -> OrderedBulkIo<U> {
@@ -32,10 +29,10 @@ impl<U: Copy + Unpin> OrderedBulkIo<U> {
 }
 
 impl<U: Copy + Unpin> Stream for OrderedBulkIo<U> {
-    type Item = (Option<Source>, U);
+    type Item = (Option<ScheduledSource>, U);
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.iovs.front() {
+        match self.iovs.front_mut() {
             None => Poll::Ready(None),
             Some((Some(source), _)) => {
                 let res = if source.result().is_some() {
@@ -43,7 +40,7 @@ impl<U: Copy + Unpin> Stream for OrderedBulkIo<U> {
                 } else {
                     Poll::Pending
                 };
-                if let Some((Some(source), _)) = self.iovs.front() {
+                if let Some((Some(source), _)) = self.iovs.front_mut() {
                     source.add_waiter(cx.waker().clone());
                 }
                 res
@@ -87,7 +84,7 @@ pub(crate) struct ReadManyArgs<V: IoVec> {
 #[derive(Debug)]
 pub struct ReadManyResult<V: IoVec> {
     pub(crate) inner: OrderedBulkIo<ReadManyArgs<V>>,
-    pub(crate) current_result: ReadResult,
+    pub(crate) current: Option<ScheduledSource>,
 }
 
 impl<V: IoVec> Stream for ReadManyResult<V> {
@@ -99,16 +96,15 @@ impl<V: IoVec> Stream for ReadManyResult<V> {
             Some((source, args)) => {
                 if let Some(source) = source {
                     enhanced_try!(source.result().unwrap(), "Reading", self.inner.file)?;
-                    self.current_result = ReadResult::from_whole_buffer(source.extract_buffer());
+                    self.current = Some(source);
                 }
                 Poll::Ready(Some(Ok((
                     args.user_read,
-                    ReadResult::slice(
-                        &self.current_result,
+                    ReadResult::from_sliced_buffer(
+                        self.current.as_ref().unwrap().clone(),
                         (args.user_read.pos() - args.system_read.pos()) as usize,
                         args.user_read.size(),
-                    )
-                    .unwrap_or_default(),
+                    ),
                 ))))
             }
         }

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -38,7 +38,7 @@ impl<U: Copy + Unpin> Stream for OrderedBulkIo<U> {
         match self.iovs.front() {
             None => Poll::Ready(None),
             Some((Some(source), _)) => {
-                let res = if source.has_result() {
+                let res = if source.result().is_some() {
                     Poll::Ready(Some(self.iovs.pop_front().unwrap()))
                 } else {
                     Poll::Pending
@@ -98,7 +98,7 @@ impl<V: IoVec> Stream for ReadManyResult<V> {
             None => Poll::Ready(None),
             Some((source, args)) => {
                 if let Some(source) = source {
-                    enhanced_try!(source.take_result().unwrap(), "Reading", self.inner.file)?;
+                    enhanced_try!(source.result().unwrap(), "Reading", self.inner.file)?;
                     self.current_result = ReadResult::from_whole_buffer(source.extract_buffer());
                 }
                 Poll::Ready(Some(Ok((

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -99,8 +99,7 @@ impl<V: IoVec> Stream for ReadManyResult<V> {
             Some((source, args)) => {
                 if let Some(source) = source {
                     enhanced_try!(source.take_result().unwrap(), "Reading", self.inner.file)?;
-                    self.current_result =
-                        ReadResult::from_whole_buffer(source.extract_dma_buffer());
+                    self.current_result = ReadResult::from_whole_buffer(source.extract_buffer());
                 }
                 Poll::Ready(Some(Ok((
                     args.user_read,

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -97,7 +97,7 @@ impl<V: IoVec> Stream for ReadManyResult<V> {
         match ready!(self.inner.poll_next(cx)) {
             None => Poll::Ready(None),
             Some((source, args)) => {
-                if let Some(mut source) = source {
+                if let Some(source) = source {
                     enhanced_try!(source.take_result().unwrap(), "Reading", self.inner.file)?;
                     self.current_result =
                         ReadResult::from_whole_buffer(source.extract_dma_buffer());

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -236,13 +236,10 @@ impl DmaFile {
             pos,
             size,
             self.pollable,
+            self.file.scheduler.borrow().as_ref(),
         );
         let read_size = enhanced_try!(source.collect_rw().await, "Reading", self.file)?;
-        Ok(ReadResult::from_sliced_buffer(
-            source.extract_buffer(),
-            0,
-            read_size,
-        ))
+        Ok(ReadResult::from_sliced_buffer(source, 0, read_size))
     }
 
     /// Reads into buffer in buf from a specific position in the file.
@@ -263,11 +260,12 @@ impl DmaFile {
             eff_pos,
             eff_size,
             self.pollable,
+            self.file.scheduler.borrow().as_ref(),
         );
 
         let read_size = enhanced_try!(source.collect_rw().await, "Reading", self.file)?;
         Ok(ReadResult::from_sliced_buffer(
-            source.extract_buffer(),
+            source,
             b,
             std::cmp::min(read_size, size),
         ))
@@ -322,13 +320,14 @@ impl DmaFile {
                     iov.1.0,
                     iov.1.1,
                     self.pollable,
+                    self.file.scheduler.borrow().as_ref(),
                 );
                 last = Some((iov.1.0, iov.1.1));
                 (Some(source), args)
             });
         ReadManyResult {
             inner: OrderedBulkIo::new(self.clone(), it),
-            current_result: Default::default(),
+            current: Default::default(),
         }
     }
 

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -234,9 +234,11 @@ impl DmaFile {
             self.pollable,
         );
         let read_size = enhanced_try!(source.collect_rw().await, "Reading", self.file)?;
-        let mut buffer = source.extract_dma_buffer();
-        buffer.trim_to_size(read_size);
-        Ok(ReadResult::from_whole_buffer(buffer))
+        Ok(ReadResult::from_sliced_buffer(
+            source.extract_dma_buffer(),
+            0,
+            read_size,
+        ))
     }
 
     /// Reads into buffer in buf from a specific position in the file.
@@ -260,10 +262,11 @@ impl DmaFile {
         );
 
         let read_size = enhanced_try!(source.collect_rw().await, "Reading", self.file)?;
-        let mut buffer = source.extract_dma_buffer();
-        buffer.trim_front(b);
-        buffer.trim_to_size(std::cmp::min(read_size, size));
-        Ok(ReadResult::from_whole_buffer(buffer))
+        Ok(ReadResult::from_sliced_buffer(
+            source.extract_dma_buffer(),
+            b,
+            std::cmp::min(read_size, size),
+        ))
     }
 
     /// Submit many reads and process the results in a stream-like fashion via a

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -6,8 +6,8 @@
 use crate::{
     io::{
         bulk_io::{CoalescedReads, IoVec, OrderedBulkIo, ReadManyArgs, ReadManyResult},
-        dma_open_options::DmaOpenOptions,
         glommio_file::GlommioFile,
+        open_options::OpenOptions,
         read_result::ReadResult,
     },
     sys::{self, sysfs, DirectIo, DmaBuffer, PollableStatus},
@@ -143,7 +143,7 @@ impl DmaFile {
         dir: RawFd,
         path: &'a Path,
         opdesc: &'static str,
-        opts: &'a DmaOpenOptions,
+        opts: &'a OpenOptions,
     ) -> Result<DmaFile> {
         let flags = libc::O_CLOEXEC
             | opts.get_access_mode()?
@@ -169,17 +169,17 @@ impl DmaFile {
 
     /// Similar to `create()` in the standard library, but returns a DMA file
     pub async fn create<P: AsRef<Path>>(path: P) -> Result<DmaFile> {
-        DmaOpenOptions::new()
+        OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
-            .open(path.as_ref())
+            .dma_open(path.as_ref())
             .await
     }
 
     /// Similar to `open()` in the standard library, but returns a DMA file
     pub async fn open<P: AsRef<Path>>(path: P) -> Result<DmaFile> {
-        DmaOpenOptions::new().read(true).open(path.as_ref()).await
+        OpenOptions::new().read(true).dma_open(path.as_ref()).await
     }
 
     /// Write the buffer in `buf` to a specific position in the file.
@@ -740,12 +740,12 @@ pub(crate) mod test {
     });
 
     async fn write_dma_file(path: PathBuf, bytes: usize) -> DmaFile {
-        let new_file = DmaOpenOptions::new()
+        let new_file = OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
             .read(true)
-            .open(path)
+            .dma_open(path)
             .await
             .expect("failed to create file");
 

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -235,7 +235,7 @@ impl DmaFile {
         );
         let read_size = enhanced_try!(source.collect_rw().await, "Reading", self.file)?;
         Ok(ReadResult::from_sliced_buffer(
-            source.extract_dma_buffer(),
+            source.extract_buffer(),
             0,
             read_size,
         ))
@@ -263,7 +263,7 @@ impl DmaFile {
 
         let read_size = enhanced_try!(source.collect_rw().await, "Reading", self.file)?;
         Ok(ReadResult::from_sliced_buffer(
-            source.extract_dma_buffer(),
+            source.extract_buffer(),
             b,
             std::cmp::min(read_size, size),
         ))

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -227,7 +227,7 @@ impl DmaFile {
     /// The position must be aligned to for Direct I/O. In most platforms
     /// that means 512 bytes.
     pub async fn read_at_aligned(&self, pos: u64, size: usize) -> Result<ReadResult> {
-        let mut source = self.file.reactor.upgrade().unwrap().read_dma(
+        let source = self.file.reactor.upgrade().unwrap().read_dma(
             self.as_raw_fd(),
             pos,
             size,
@@ -252,7 +252,7 @@ impl DmaFile {
         let b = (pos - eff_pos) as usize;
 
         let eff_size = self.align_up((size + b) as u64) as usize;
-        let mut source = self.file.reactor.upgrade().unwrap().read_dma(
+        let source = self.file.reactor.upgrade().unwrap().read_dma(
             self.as_raw_fd(),
             eff_pos,
             eff_size,

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -158,6 +158,10 @@ impl DmaFile {
         Ok(f)
     }
 
+    pub(super) fn attach_scheduler(&self) {
+        self.file.attach_scheduler()
+    }
+
     /// Allocates a buffer that is suitable for using to write to this file.
     pub fn alloc_dma_buffer(&self, size: usize) -> DmaBuffer {
         self.file.reactor.upgrade().unwrap().alloc_dma_buffer(size)

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -407,6 +407,9 @@ impl DmaStreamReader {
         let to_cancel = handles.len();
         let cancelled = stream::iter(handles).then(|f| f).count().await;
         assert_eq!(to_cancel, cancelled);
+
+        // the file may be used by other processes so failing to close it is not an
+        // issue.
         let _ = self.file.close_rc().await;
 
         let mut state = self.state.borrow_mut();

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -17,6 +17,10 @@ use std::{
 
 type Result<T> = crate::Result<T, ()>;
 
+pub(super) type Device = u64;
+pub(super) type Inode = u64;
+pub(super) type Identity = (Device, Inode);
+
 /// A wrapper over `std::fs::File` which carries a path (for better error
 /// messages) and prints a warning if closed synchronously.
 ///
@@ -108,10 +112,15 @@ impl GlommioFile {
         Ok(file)
     }
 
+    pub(crate) fn identity(&self) -> Identity {
+        (
+            (self.dev_major as u64) << 32 | self.dev_minor as u64,
+            self.inode,
+        )
+    }
+
     pub(crate) fn is_same(&self, other: &GlommioFile) -> bool {
-        self.inode == other.inode
-            && self.dev_major == other.dev_major
-            && self.dev_minor == other.dev_minor
+        self.identity() == other.identity()
     }
 
     pub(crate) fn discard(mut self) -> (RawFd, Option<PathBuf>) {

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -241,6 +241,7 @@ where
                 .open(self.path)
                 .await?,
         );
+        file.attach_scheduler();
         let size = file.file_size().await?;
         let stream_builder = DmaStreamReaderBuilder::from_rc(file)
             .with_buffer_size(self.buffer_size)
@@ -260,6 +261,8 @@ impl ImmutableFilePreSealSink {
     /// [`ImmutableFile`]
     pub async fn seal(mut self) -> Result<ImmutableFile> {
         let stream_builder = poll_fn(|cx| self.writer.poll_seal(cx)).await?;
+        stream_builder.file.attach_scheduler();
+
         let size = stream_builder.file.file_size().await?;
         Ok(ImmutableFile {
             stream_builder,

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -4,7 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
 use crate::io::{
-    dma_open_options::DmaOpenOptions,
+    open_options::OpenOptions,
     DmaStreamReaderBuilder,
     DmaStreamWriter,
     DmaStreamWriterBuilder,
@@ -191,11 +191,11 @@ where
     /// [`new`]: ImmutableFileBuilder::new
     /// [`seal`]: ImmutableFilePreSealSink::seal
     pub async fn build_sink(self) -> Result<ImmutableFilePreSealSink> {
-        let file = DmaOpenOptions::new()
+        let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create_new(true)
-            .open(self.path)
+            .dma_open(self.path)
             .await?;
 
         if let Some(size) = self.pre_allocate {
@@ -235,10 +235,10 @@ where
     /// [`new`]: ImmutableFileBuilder::new
     pub async fn build_existing(self) -> Result<ImmutableFile> {
         let file = Rc::new(
-            DmaOpenOptions::new()
+            OpenOptions::new()
                 .read(true)
                 .write(false)
-                .open(self.path)
+                .dma_open(self.path)
                 .await?,
         );
         file.attach_scheduler();

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -14,7 +14,6 @@ use crate::io::{
 };
 
 use futures_lite::{future::poll_fn, io::AsyncWrite};
-use log::warn;
 use std::{
     cell::Ref,
     io,
@@ -198,21 +197,12 @@ where
             .dma_open(self.path)
             .await?;
 
+        // these two syscall are hints and are allowed to fail.
         if let Some(size) = self.pre_allocate {
-            if let Err(err) = file.pre_allocate(size).await {
-                warn!(
-                    "Error: failed to run pre_allocate on ImmutableFile: {}",
-                    err
-                );
-            }
+            let _ = file.pre_allocate(size).await;
         }
         if let Some(size) = self.hint_extent_size {
-            if let Err(err) = file.hint_extent_size(size).await {
-                warn!(
-                    "Error: failed to run hint_extent_size on ImmutableFile: {}",
-                    err
-                );
-            }
+            let _ = file.hint_extent_size(size).await;
         }
 
         let writer = DmaStreamWriterBuilder::new(file)

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -129,6 +129,7 @@ mod dma_open_options;
 mod glommio_file;
 mod immutable_file;
 mod read_result;
+mod sched;
 
 use crate::sys;
 use std::path::Path;
@@ -155,6 +156,7 @@ pub async fn remove<P: AsRef<Path>>(path: P) -> Result<()> {
     )
 }
 
+pub(crate) use self::sched::{FileScheduler, IoScheduler, ScheduledSource};
 pub use self::{
     buffered_file::BufferedFile,
     buffered_file_stream::{

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -125,9 +125,9 @@ mod bulk_io;
 mod directory;
 mod dma_file;
 mod dma_file_stream;
-mod dma_open_options;
 mod glommio_file;
 mod immutable_file;
+mod open_options;
 mod read_result;
 mod sched;
 
@@ -175,8 +175,8 @@ pub use self::{
         DmaStreamWriter,
         DmaStreamWriterBuilder,
     },
-    dma_open_options::DmaOpenOptions,
     immutable_file::{ImmutableFile, ImmutableFileBuilder, ImmutableFilePreSealSink},
+    open_options::OpenOptions,
     read_result::ReadResult,
 };
 pub use crate::sys::DmaBuffer;

--- a/glommio/src/io/read_result.rs
+++ b/glommio/src/io/read_result.rs
@@ -2,7 +2,7 @@
 // under the mit/apache-2.0 license, at your convenience
 //
 // this product includes software developed at datadog (https://www.datadoghq.com/). copyright 2020 datadog, inc.
-use crate::sys::DmaBuffer;
+use crate::sys::IoBuffer;
 use core::num::NonZeroUsize;
 use std::rc::Rc;
 
@@ -23,7 +23,7 @@ impl core::ops::Deref for ReadResult {
 
 #[derive(Clone, Debug)]
 struct ReadResultInner {
-    buffer: Rc<DmaBuffer>,
+    buffer: Rc<IoBuffer>,
     offset: usize,
 
     // This (usage of `NonZeroUsize`) is probably needed to make sure that rustc
@@ -39,7 +39,10 @@ impl core::ops::Deref for ReadResultInner {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
-        &self.buffer.as_bytes()[self.offset..][..self.len.get()]
+        match &*self.buffer {
+            IoBuffer::Dma(buffer) => &buffer.as_bytes()[self.offset..][..self.len.get()],
+            IoBuffer::Buffered(buffer) => &buffer.as_slice()[self.offset..][..self.len.get()],
+        }
     }
 }
 
@@ -48,7 +51,7 @@ impl ReadResult {
         Self(None)
     }
 
-    pub(crate) fn from_whole_buffer(buffer: DmaBuffer) -> Self {
+    pub(crate) fn from_whole_buffer(buffer: IoBuffer) -> Self {
         Self(NonZeroUsize::new(buffer.len()).map(|len| ReadResultInner {
             buffer: Rc::new(buffer),
             offset: 0,
@@ -56,7 +59,7 @@ impl ReadResult {
         }))
     }
 
-    pub(crate) fn from_sliced_buffer(buffer: DmaBuffer, extra_offset: usize, len: usize) -> Self {
+    pub(crate) fn from_sliced_buffer(buffer: IoBuffer, extra_offset: usize, len: usize) -> Self {
         Self(NonZeroUsize::new(len).map(|len| {
             let ret = ReadResultInner {
                 buffer: Rc::new(buffer),

--- a/glommio/src/io/read_result.rs
+++ b/glommio/src/io/read_result.rs
@@ -56,6 +56,18 @@ impl ReadResult {
         }))
     }
 
+    pub(crate) fn from_sliced_buffer(buffer: DmaBuffer, extra_offset: usize, len: usize) -> Self {
+        Self(NonZeroUsize::new(len).map(|len| {
+            let ret = ReadResultInner {
+                buffer: Rc::new(buffer),
+                offset: extra_offset,
+                len,
+            };
+            ReadResultInner::check_invariants(&ret);
+            ret
+        }))
+    }
+
     /// Creates a slice of this ReadResult with the given offset and length.
     ///
     /// Returns `None` if either offset or offset + len would not fit in the

--- a/glommio/src/io/sched.rs
+++ b/glommio/src/io/sched.rs
@@ -1,0 +1,214 @@
+use crate::{io::glommio_file::Identity, sys::Source, IoRequirements};
+use intrusive_collections::{intrusive_adapter, Bound, KeyAdapter, RBTree, RBTreeLink};
+use std::{
+    cell::{Cell, RefCell},
+    ops::{Deref, Range},
+    rc::{Rc, Weak},
+};
+
+#[derive(Debug)]
+pub(crate) struct IoScheduler {
+    /// I/O Requirements of the task currently executing.
+    current_requirements: Cell<IoRequirements>,
+
+    file_schedulers: RefCell<RBTree<FileSchedulerAdapter>>,
+}
+
+impl IoScheduler {
+    pub(crate) fn new() -> IoScheduler {
+        IoScheduler {
+            current_requirements: Cell::new(Default::default()),
+            file_schedulers: RefCell::new(Default::default()),
+        }
+    }
+
+    pub(crate) fn requirements(&self) -> IoRequirements {
+        self.current_requirements.get()
+    }
+
+    pub(crate) fn inform_requirements(&self, req: IoRequirements) {
+        self.current_requirements.set(req);
+    }
+
+    pub(super) fn get_file_scheduler(self: &Rc<Self>, identity: Identity) -> FileScheduler {
+        let mut borrow = self.file_schedulers.borrow_mut();
+        let file = if let Some(file) = borrow.find(&identity).clone_pointer() {
+            file
+        } else {
+            let file_sched = Rc::new(FileSchedulerInner {
+                link: RBTreeLink::new(),
+                identity,
+                sources: RefCell::new(Default::default()),
+            });
+            borrow.insert(file_sched.clone());
+            file_sched
+        };
+
+        FileScheduler {
+            inner: file,
+            io_scheduler: Rc::downgrade(self),
+        }
+    }
+
+    fn remove_file(&self, file: &FileScheduler) {
+        unsafe {
+            self.file_schedulers
+                .borrow_mut()
+                .cursor_mut_from_ptr(file.inner.as_ref())
+                .remove()
+        };
+    }
+}
+
+#[derive(Debug)]
+struct FileSchedulerInner {
+    link: RBTreeLink,
+    identity: Identity,
+    sources: RefCell<RBTree<ScheduledSourceAdapter>>,
+}
+
+intrusive_adapter!(FileSchedulerAdapter = Rc<FileSchedulerInner>: FileSchedulerInner { link: RBTreeLink });
+impl<'a> KeyAdapter<'a> for FileSchedulerAdapter {
+    type Key = Identity;
+    fn get_key(&self, s: &'a FileSchedulerInner) -> Self::Key {
+        s.identity
+    }
+}
+
+impl FileSchedulerInner {
+    fn remove_source(&self, source: &ScheduledSource) {
+        unsafe {
+            self.sources
+                .borrow_mut()
+                .cursor_mut_from_ptr(source.inner.as_ref())
+                .remove()
+        };
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct FileScheduler {
+    inner: Rc<FileSchedulerInner>,
+    io_scheduler: Weak<IoScheduler>,
+}
+
+impl Drop for FileScheduler {
+    fn drop(&mut self) {
+        if Rc::strong_count(&self.inner) <= 2 {
+            if let Some(io_sched) = self.io_scheduler.upgrade() {
+                // the scheduler owns one Rc to this FileScheduler
+                // so if the count is two or less, then we can remove this file scheduler
+                io_sched.remove_file(self)
+            }
+        }
+    }
+}
+
+impl FileScheduler {
+    pub(crate) fn consume_scheduled(&self, data_range: Range<u64>) -> Option<ScheduledSource> {
+        let sources = self.inner.sources.borrow();
+        let mut candidates = sources.range(
+            Bound::Included(&data_range.start),
+            Bound::Excluded(&data_range.end),
+        );
+
+        if let Some(sched_source) = candidates.find(|&x| {
+            x.data_range.contains(&data_range.start) && x.data_range.contains(&(data_range.end - 1))
+        }) {
+            unsafe {
+                let offset_start = data_range.start - sched_source.data_range.start;
+                Some(ScheduledSource {
+                    inner: sources
+                        .cursor_from_ptr(sched_source)
+                        .clone_pointer()
+                        .unwrap(),
+                    file: Rc::downgrade(&self.inner),
+                    offseted_range: offset_start..offset_start + data_range.end,
+                })
+            }
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn schedule(&self, source: Source, data_range: Range<u64>) -> ScheduledSource {
+        let scheduled = Rc::new(ScheduledSourceInner {
+            source,
+            link: Default::default(),
+            data_range: data_range.clone(),
+        });
+        self.inner.sources.borrow_mut().insert(scheduled.clone());
+        ScheduledSource {
+            inner: scheduled,
+            file: Rc::downgrade(&self.inner),
+            offseted_range: 0..data_range.end - data_range.start,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ScheduledSourceInner {
+    source: Source,
+    link: RBTreeLink,
+    data_range: Range<u64>,
+}
+
+intrusive_adapter!(ScheduledSourceAdapter = Rc<ScheduledSourceInner>: ScheduledSourceInner { link: RBTreeLink });
+impl<'a> KeyAdapter<'a> for ScheduledSourceAdapter {
+    type Key = u64;
+    fn get_key(&self, s: &'a ScheduledSourceInner) -> Self::Key {
+        s.data_range.start
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ScheduledSource {
+    inner: Rc<ScheduledSourceInner>,
+    file: Weak<FileSchedulerInner>,
+    offseted_range: Range<u64>,
+}
+
+impl ScheduledSource {
+    pub(crate) fn new_raw(source: Source, data_range: Range<u64>) -> ScheduledSource {
+        ScheduledSource {
+            inner: Rc::new(ScheduledSourceInner {
+                source,
+                link: Default::default(),
+                data_range: data_range.clone(),
+            }),
+            file: Default::default(),
+            offseted_range: 0..data_range.end - data_range.start,
+        }
+    }
+
+    pub(crate) unsafe fn as_bytes(&self) -> &[u8] {
+        std::slice::from_raw_parts(
+            self.inner
+                .source
+                .buffer()
+                .as_ptr()
+                .add(self.offseted_range.start as usize),
+            (self.offseted_range.end - self.offseted_range.start) as usize,
+        )
+    }
+}
+
+impl Deref for ScheduledSource {
+    type Target = Source;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.source
+    }
+}
+
+impl Drop for ScheduledSource {
+    fn drop(&mut self) {
+        if Rc::strong_count(&self.inner) <= 2 {
+            if let Some(file) = self.file.upgrade() {
+                // the file scheduler owns one Rc to this ScheduledSource
+                // so if the count is two or less, then we can remove this source
+                file.remove_source(self)
+            }
+        }
+    }
+}

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -306,7 +306,7 @@ macro_rules! wake {
     ($waker:expr $(,)?) => {
         use log::error;
 
-        if let Err(x) = panic::catch_unwind(|| $waker.wake()) {
+        if let Err(x) = std::panic::catch_unwind(|| $waker.wake()) {
             error!("Panic while calling waker! {:?}", x);
         }
     };

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -555,6 +555,8 @@ pub struct RingIoStats {
     pub(crate) file_bytes_read: u64,
     pub(crate) file_buffered_reads: u64,
     pub(crate) file_buffered_bytes_read: u64,
+    pub(crate) file_deduped_reads: u64,
+    pub(crate) file_deduped_bytes_read: u64,
     pub(crate) file_writes: u64,
     pub(crate) file_bytes_written: u64,
     pub(crate) file_buffered_writes: u64,
@@ -593,6 +595,13 @@ impl RingIoStats {
         (self.file_reads, self.file_bytes_read)
     }
 
+    /// File read IO stats (deduplicated)
+    ///
+    /// Returns the number of reads that fed from another preexisting buffer
+    pub fn file_deduped_reads(&self) -> (u64, u64) {
+        (self.file_deduped_reads, self.file_deduped_bytes_read)
+    }
+
     /// Buffered file read IO stats
     ///
     /// Returns the number of individual buffered read ops as well as bytes read
@@ -625,6 +634,8 @@ impl Sum<RingIoStats> for RingIoStats {
             file_bytes_read: a.file_bytes_read + b.file_bytes_read,
             file_buffered_reads: a.file_buffered_reads + b.file_buffered_reads,
             file_buffered_bytes_read: a.file_buffered_bytes_read + b.file_buffered_bytes_read,
+            file_deduped_reads: a.file_deduped_reads + b.file_deduped_reads,
+            file_deduped_bytes_read: a.file_deduped_bytes_read + b.file_deduped_bytes_read,
             file_writes: a.file_writes + b.file_writes,
             file_bytes_written: a.file_bytes_written + b.file_bytes_written,
             file_buffered_writes: a.file_buffered_writes + b.file_buffered_writes,

--- a/glommio/src/net/datagram.rs
+++ b/glommio/src/net/datagram.rs
@@ -72,7 +72,7 @@ impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> FromRawFd for GlommioDatagr
 }
 
 impl<S: AsRawFd + FromRawFd + From<socket2::Socket>> GlommioDatagram<S> {
-    async fn consume_receive_buffer(&self, source: &Source, buf: &mut [u8]) -> io::Result<usize> {
+    async fn consume_receive_buffer(&self, source: Source, buf: &mut [u8]) -> io::Result<usize> {
         let sz = source.collect_rw().await?;
         let src = match source.extract_source_type() {
             SourceType::SockRecv(mut buf) => {
@@ -94,7 +94,7 @@ impl<S: AsRawFd + FromRawFd + From<socket2::Socket>> GlommioDatagram<S> {
             MsgFlags::MSG_PEEK,
         );
 
-        self.consume_receive_buffer(&source, buf).await
+        self.consume_receive_buffer(source, buf).await
     }
 
     pub(crate) async fn peek_from(
@@ -116,7 +116,7 @@ impl<S: AsRawFd + FromRawFd + From<socket2::Socket>> GlommioDatagram<S> {
                     buf.len(),
                     self.read_timeout.get(),
                 )?;
-                self.consume_receive_buffer(&source, buf).await
+                self.consume_receive_buffer(source, buf).await
             }
         }
     }

--- a/glommio/src/net/stream.rs
+++ b/glommio/src/net/stream.rs
@@ -32,9 +32,10 @@ impl TryFrom<Source> for RecvBuffer {
     type Error = io::Error;
 
     fn try_from(source: Source) -> io::Result<RecvBuffer> {
+        let res = source.result();
         match source.extract_source_type() {
             SourceType::SockRecv(mut buf) => {
-                let sz = source.take_result().unwrap()?;
+                let sz = res.unwrap()?;
                 let mut buf = buf.take().unwrap();
                 buf.trim_to_size(sz);
                 Ok(RecvBuffer { buf })
@@ -224,7 +225,7 @@ impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> GlommioStream<S> {
             )),
         };
 
-        if !source.has_result() {
+        if source.result().is_none() {
             source.add_waiter(cx.waker().clone());
             self.source_rx = Some(source);
             Poll::Pending
@@ -250,7 +251,7 @@ impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> GlommioStream<S> {
             )),
         };
 
-        match source.take_result() {
+        match source.result() {
             None => {
                 source.add_waiter(cx.waker().clone());
                 self.source_tx = Some(source);

--- a/glommio/src/net/stream.rs
+++ b/glommio/src/net/stream.rs
@@ -121,9 +121,7 @@ impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> GlommioStream<S> {
         let sz = source.collect_rw().await?;
         match source.extract_source_type() {
             SourceType::SockRecv(mut src) => {
-                let mut src = src.take().unwrap();
-                src.trim_to_size(sz);
-                buf[0..sz].copy_from_slice(&src.as_bytes()[0..sz]);
+                buf[0..sz].copy_from_slice(&src.take().unwrap().as_bytes()[0..sz]);
             }
             _ => unreachable!(),
         }

--- a/glommio/src/parking.rs
+++ b/glommio/src/parking.rs
@@ -35,7 +35,7 @@ use std::{
     io,
     mem,
     os::unix::{ffi::OsStrExt, io::RawFd},
-    panic::{self, RefUnwindSafe, UnwindSafe},
+    panic::{RefUnwindSafe, UnwindSafe},
     path::Path,
     rc::Rc,
     sync::{

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -225,6 +225,7 @@ mod uring;
 pub use self::dma_buffer::DmaBuffer;
 pub(crate) use self::{source::*, uring::*};
 use crate::error::{ExecutorErrorKind, GlommioError};
+use std::ops::Deref;
 
 #[derive(Debug, Default)]
 pub(crate) struct ReactorGlobalState {
@@ -363,6 +364,17 @@ impl Drop for SleepNotifier {
 pub(crate) enum IoBuffer {
     Dma(DmaBuffer),
     Buffered(Vec<u8>),
+}
+
+impl Deref for IoBuffer {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        match &self {
+            IoBuffer::Dma(buffer) => buffer.as_bytes(),
+            IoBuffer::Buffered(buffer) => buffer.as_slice(),
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -1,0 +1,236 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the MIT/Apache-2.0 License, at your convenience
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+//
+use crate::{
+    iou::sqe::{SockAddr, SockAddrStorage},
+    sys::{DmaBuffer, IoBuffer, PollableStatus, ReactorQueue, SourceId, TimeSpec64, Wakers},
+    GlommioError,
+    IoRequirements,
+    Latency,
+    ReactorErrorKind,
+    RingIoStats,
+    TaskQueueHandle,
+};
+use futures_lite::{future, io};
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    convert::TryFrom,
+    ffi::CString,
+    fmt,
+    mem::MaybeUninit,
+    os::unix::io::RawFd,
+    rc::Rc,
+    task::{Poll, Waker},
+    time::Duration,
+};
+
+#[derive(Debug)]
+pub(crate) enum SourceType {
+    Write(PollableStatus, IoBuffer),
+    Read(PollableStatus, Option<IoBuffer>),
+    SockSend(DmaBuffer),
+    SockRecv(Option<DmaBuffer>),
+    SockRecvMsg(
+        Option<DmaBuffer>,
+        libc::iovec,
+        libc::msghdr,
+        MaybeUninit<nix::sys::socket::sockaddr_storage>,
+    ),
+    SockSendMsg(
+        DmaBuffer,
+        libc::iovec,
+        libc::msghdr,
+        nix::sys::socket::SockAddr,
+    ),
+    Open(CString),
+    FdataSync,
+    Fallocate,
+    Close,
+    LinkRings,
+    Statx(CString, Box<RefCell<libc::statx>>),
+    Timeout(TimeSpec64),
+    Connect(SockAddr),
+    Accept(SockAddrStorage),
+    Invalid,
+    #[cfg(feature = "bench")]
+    Noop,
+}
+
+impl TryFrom<SourceType> for libc::statx {
+    type Error = GlommioError<()>;
+
+    fn try_from(value: SourceType) -> Result<Self, Self::Error> {
+        match value {
+            SourceType::Statx(_, buf) => Ok(buf.into_inner()),
+            _ => Err(GlommioError::ReactorError(
+                ReactorErrorKind::IncorrectSourceType,
+            )),
+        }
+    }
+}
+
+pub struct EnqueuedSource {
+    pub(crate) id: SourceId,
+    pub(crate) queue: ReactorQueue,
+}
+
+pub(crate) type StatsCollectionFn = fn(&io::Result<usize>, &mut RingIoStats) -> ();
+
+/// A registered source of I/O events.
+pub(crate) struct InnerSource {
+    /// Raw file descriptor on Unix platforms.
+    pub(crate) raw: RawFd,
+
+    /// Tasks interested in events on this source.
+    pub(crate) wakers: Wakers,
+
+    pub(crate) source_type: SourceType,
+
+    pub(crate) io_requirements: IoRequirements,
+
+    pub(crate) timeout: Option<TimeSpec64>,
+
+    pub(crate) enqueued: Option<EnqueuedSource>,
+
+    pub(crate) stats_collection: Option<StatsCollectionFn>,
+
+    pub(crate) task_queue: Option<TaskQueueHandle>,
+}
+
+impl InnerSource {
+    pub(crate) fn update_source_type(&mut self, source_type: SourceType) -> SourceType {
+        std::mem::replace(&mut self.source_type, source_type)
+    }
+}
+
+impl fmt::Debug for InnerSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InnerSource")
+            .field("raw", &self.raw)
+            .field("wakers", &self.wakers)
+            .field("source_type", &self.source_type)
+            .field("io_requirements", &self.io_requirements)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct Source {
+    pub(crate) inner: Rc<RefCell<InnerSource>>,
+}
+
+impl Source {
+    /// Registers an I/O source in the reactor.
+    pub(crate) fn new(
+        ioreq: IoRequirements,
+        raw: RawFd,
+        source_type: SourceType,
+        stats_collection_fn: Option<StatsCollectionFn>,
+        task_queue: Option<TaskQueueHandle>,
+    ) -> Source {
+        Source {
+            inner: Rc::new(RefCell::new(InnerSource {
+                raw,
+                wakers: Wakers::new(),
+                source_type,
+                io_requirements: ioreq,
+                enqueued: None,
+                timeout: None,
+                stats_collection: stats_collection_fn,
+                task_queue,
+            })),
+        }
+    }
+
+    pub(crate) fn set_timeout(&self, d: Duration) -> Option<Duration> {
+        let mut inner = self.inner.borrow_mut();
+        let t = &mut inner.timeout;
+        let old = *t;
+        *t = Some(TimeSpec64::from(d));
+        old.map(Duration::from)
+    }
+
+    pub(super) fn timeout_ref(&self) -> Ref<'_, Option<TimeSpec64>> {
+        Ref::map(self.inner.borrow(), |x| &x.timeout)
+    }
+
+    pub(crate) fn latency_req(&self) -> Latency {
+        self.inner.borrow().io_requirements.latency_req
+    }
+
+    pub(super) fn source_type(&self) -> Ref<'_, SourceType> {
+        Ref::map(self.inner.borrow(), |x| &x.source_type)
+    }
+
+    pub(crate) fn source_type_mut(&self) -> RefMut<'_, SourceType> {
+        RefMut::map(self.inner.borrow_mut(), |x| &mut x.source_type)
+    }
+
+    pub(crate) fn extract_source_type(&self) -> SourceType {
+        self.inner
+            .borrow_mut()
+            .update_source_type(SourceType::Invalid)
+    }
+
+    pub(crate) fn extract_dma_buffer(&self) -> DmaBuffer {
+        let stype = self.extract_source_type();
+        match stype {
+            SourceType::Read(_, Some(IoBuffer::Dma(buffer))) => buffer,
+            SourceType::Write(_, IoBuffer::Dma(buffer)) => buffer,
+            x => panic!("Could not extract buffer. Source: {:?}", x),
+        }
+    }
+
+    pub(crate) fn extract_buffer(&self) -> Vec<u8> {
+        let stype = self.extract_source_type();
+        match stype {
+            SourceType::Read(_, Some(IoBuffer::Buffered(buffer))) => buffer,
+            SourceType::Write(_, IoBuffer::Buffered(buffer)) => buffer,
+            x => panic!("Could not extract buffer. Source: {:?}", x),
+        }
+    }
+
+    pub(crate) fn take_result(&self) -> Option<io::Result<usize>> {
+        self.inner
+            .borrow_mut()
+            .wakers
+            .result
+            .take()
+            .map(|x| x.map(|x| x as usize))
+    }
+
+    pub(crate) fn has_result(&self) -> bool {
+        self.inner.borrow().wakers.result.is_some()
+    }
+
+    pub(crate) fn add_waiter(&self, waker: Waker) {
+        self.inner.borrow_mut().wakers.waiter.replace(waker);
+    }
+
+    pub(super) fn raw(&self) -> RawFd {
+        self.inner.borrow().raw
+    }
+
+    pub(crate) async fn collect_rw(&self) -> io::Result<usize> {
+        future::poll_fn(|cx| {
+            if let Some(result) = self.take_result() {
+                return Poll::Ready(result);
+            }
+
+            self.add_waiter(cx.waker().clone());
+            Poll::Pending
+        })
+        .await
+    }
+}
+
+impl Drop for Source {
+    fn drop(&mut self) {
+        let enqueued = self.inner.borrow_mut().enqueued.take();
+        if let Some(EnqueuedSource { id, queue }) = enqueued {
+            queue.borrow_mut().cancel_request(id);
+        }
+    }
+}

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -174,20 +174,11 @@ impl Source {
             .update_source_type(SourceType::Invalid)
     }
 
-    pub(crate) fn extract_dma_buffer(&self) -> DmaBuffer {
+    pub(crate) fn extract_buffer(&self) -> IoBuffer {
         let stype = self.extract_source_type();
         match stype {
-            SourceType::Read(_, Some(IoBuffer::Dma(buffer))) => buffer,
-            SourceType::Write(_, IoBuffer::Dma(buffer)) => buffer,
-            x => panic!("Could not extract buffer. Source: {:?}", x),
-        }
-    }
-
-    pub(crate) fn extract_buffer(&self) -> Vec<u8> {
-        let stype = self.extract_source_type();
-        match stype {
-            SourceType::Read(_, Some(IoBuffer::Buffered(buffer))) => buffer,
-            SourceType::Write(_, IoBuffer::Buffered(buffer)) => buffer,
+            SourceType::Read(_, Some(buffer)) => buffer,
+            SourceType::Write(_, buffer) => buffer,
             x => panic!("Could not extract buffer. Source: {:?}", x),
         }
     }

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -491,10 +491,7 @@ where
             let res = Some(post_process(src.borrow(), transmute_error(result)));
             let mut inner_source = src.borrow_mut();
             inner_source.wakers.result = res;
-            if let Some(waiter) = inner_source.wakers.waiter.take() {
-                woke = true;
-                wake!(waiter);
-            }
+            woke = inner_source.wakers.wake_waiters();
         }
         return Some(woke);
     }
@@ -948,7 +945,7 @@ impl SleepableRing {
             return self.ring.submit_sqes().map(|x| x as usize);
         }
 
-        let res = eventfd_src.take_result();
+        let res = eventfd_src.result();
         match res {
             None => {
                 // We already have the eventfd registered and nobody woke us up so far.


### PR DESCRIPTION
### What does this PR do?

**This is WIP.**

This PR adds a rudimentary IO scheduler on the read path such that tasks many consume IO performed by other tasks within an executor. 

Here is an example with 10 readers scanning the same file concurrently:
```
Direct I/O, glommio API, many readers:               Scanned 10.74 GB in 3.201660505s,  3.35 GB/s,  6399 IOPS
Direct I/O, glommio API, many readers, deduplicated: Scanned 10.74 GB in 517.044657ms, 20.77 GB/s, 39629 IOPS
```

Example code:
```
let first = read_some(new_file.clone(), 0..16384).await;
// we expect one IO to have been performed at this point
assert_eq!(Local::io_stats().all_rings().file_reads().0, 1);

// `first` holds a buffer and any further reads in this
// executor that falls inside 0..16384 will not trigger any IO
// but will instead feed from it, extending its lifetime.

let second = read_some(new_file.clone(), 67..578).await;
// should feed from the first buffer
assert_eq!(Local::io_stats().all_rings().file_reads().0, 1);
new_file.close_rc().await.expect("failed to close file");
```

This deduplication logic is guarded behind a file-level flag: `OpenOptions::immutable(bool)`. 

### Motivation

Imagine a read workload for a database. Depending on the exact read pattern, many independent readers may touch the same file. With this scheduler, they will benefit from each other and avoid performing duplicate IO, especially when read amplification is high (imagine a tree-like index structure).

### Related issues

#73 and #341 

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
