### PR TITLE
use Error::from to slightly improve performance

### DIFF
--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -198,9 +198,9 @@ macro_rules! to_io_error {
         match $error {
             Ok(x) => Ok(x),
             Err(nix::Error::Sys(_)) => Err(io::Error::last_os_error()),
-            Err(nix::Error::InvalidUtf8) => Err(io::Error::new(io::ErrorKind::InvalidInput, "")),
-            Err(nix::Error::InvalidPath) => Err(io::Error::new(io::ErrorKind::InvalidInput, "")),
-            Err(nix::Error::UnsupportedOperation) => Err(io::Error::new(io::ErrorKind::Other, "")),
+            Err(nix::Error::InvalidUtf8) => Err(io::Error::from(io::ErrorKind::InvalidInput)),
+            Err(nix::Error::InvalidPath) => Err(io::Error::from(io::ErrorKind::InvalidInput)),
+            Err(nix::Error::UnsupportedOperation) => Err(io::Error::from(io::ErrorKind::Other)),
         }
     }};
 }


### PR DESCRIPTION
### What does this PR do?

This PR slightly improves performance (though not on hotpath)
`std::io::Error::from(ErrorKind)` is faster than `std::io::Error::new()`