### PR TITLE
simplify waker_fn

### DIFF
--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -57,7 +57,7 @@ use crate::{
     error::BuilderErrorKind,
     parking,
     sys,
-    task::{self, waker_fn::waker_fn},
+    task::{self, waker_fn::dummy_waker},
     GlommioError,
     IoRequirements,
     IoStats,
@@ -1123,7 +1123,9 @@ impl LocalExecutor {
     /// assert_eq!(res, 6);
     /// ```
     pub fn run<T>(&self, future: impl Future<Output = T>) -> T {
-        let waker = waker_fn(|| {});
+        // this waker is never exposed in the public interface and is only used to check
+        // whether the task's `JoinHandle` is `Ready`
+        let waker = dummy_waker();
         let cx = &mut Context::from_waker(&waker);
 
         let spin_before_park = self.spin_before_park().unwrap_or_default();

--- a/glommio/src/task/mod.rs
+++ b/glommio/src/task/mod.rs
@@ -41,21 +41,7 @@
 //! The layout of a task is equivalent to 4 `usize`s followed by the schedule
 //! function, and then by a union of the future and its output.
 //!
-//! # Waking
-//!
-//! The handy [`waker_fn`] constructor converts any function into a [`Waker`].
-//! Every time it is woken, the function gets called:
-//!
-//! ```
-//! let waker = glommio::task::waker_fn(|| println!("Wake!"));
-//!
-//! // Prints "Wake!" twice.
-//! waker.wake_by_ref();
-//! waker.wake_by_ref();
-//! ```
-//!
 //! [`spawn_local`]: fn.spawn_local.html
-//! [`waker_fn`]: fn.waker_fn.html
 //! [`Task`]: struct.Task.html
 //! [`JoinHandle`]: struct.JoinHandle.html
 //! [`Waker`]: https://doc.rust-lang.org/std/task/struct.Waker.html
@@ -70,4 +56,4 @@ pub(crate) mod task_impl;
 pub(crate) mod utils;
 pub(crate) mod waker_fn;
 
-pub use crate::task::{join_handle::JoinHandle, task_impl::Task, waker_fn::waker_fn};
+pub use crate::task::{join_handle::JoinHandle, task_impl::Task};

--- a/glommio/src/task/waker_fn.rs
+++ b/glommio/src/task/waker_fn.rs
@@ -3,53 +3,21 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
-use core::{
-    mem::{self, ManuallyDrop},
-    task::{RawWaker, RawWakerVTable, Waker},
-};
-use std::rc::Rc;
+use core::task::{RawWaker, RawWakerVTable, Waker};
 
-/// Creates a waker from a wake function.
+/// Creates a waker that does nothing.
 ///
-/// The function gets called every time the waker is woken.
-pub fn waker_fn<F: Fn() + Send + Sync + 'static>(f: F) -> Waker {
-    let raw = Rc::into_raw(Rc::new(f)) as *const ();
-    let vtable = &Helper::<F>::VTABLE;
-    unsafe { Waker::from_raw(RawWaker::new(raw, vtable)) }
-}
-
-struct Helper<F>(F);
-
-impl<F: Fn() + Send + Sync + 'static> Helper<F> {
-    const VTABLE: RawWakerVTable = RawWakerVTable::new(
-        Self::clone_waker,
-        Self::wake,
-        Self::wake_by_ref,
-        Self::drop_waker,
-    );
-
-    #[allow(clippy::redundant_clone)]
-    // Clippy sees this rc.clone() call as redundant. However what we are doing here
-    // is making sure that the waker is alive until a later explicit call to
-    // drop_waker We need to leave this function with the reference count
-    // bumped.
-    unsafe fn clone_waker(ptr: *const ()) -> RawWaker {
-        let rc = ManuallyDrop::new(Rc::from_raw(ptr as *const F));
-        mem::forget(rc.clone());
-        RawWaker::new(ptr, &Self::VTABLE)
+/// This `Waker` is useful for polling a `Future` to check whether it is
+/// `Ready`, without doing any additional work.
+pub(crate) fn dummy_waker() -> Waker {
+    fn raw_waker() -> RawWaker {
+        // the pointer is never dereferenced, so null is ok
+        RawWaker::new(std::ptr::null::<()>(), vtable())
     }
 
-    unsafe fn wake(ptr: *const ()) {
-        let rc = Rc::from_raw(ptr as *const F);
-        (rc)();
+    fn vtable() -> &'static RawWakerVTable {
+        &RawWakerVTable::new(|_| raw_waker(), |_| {}, |_| {}, |_| {})
     }
 
-    unsafe fn wake_by_ref(ptr: *const ()) {
-        let rc = ManuallyDrop::new(Rc::from_raw(ptr as *const F));
-        (rc)();
-    }
-
-    unsafe fn drop_waker(ptr: *const ()) {
-        drop(Rc::from_raw(ptr as *const F));
-    }
+    unsafe { Waker::from_raw(raw_waker()) }
 }


### PR DESCRIPTION
### What does this PR do?

Ensures the `Waker` is `Send` and `Sync` and removes the need for
reference counting / heap allocation of the `Rc`.

### Motivation

simpler / safer

### Related issues

na

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[n] I have added unit tests to the code I am submitting
[n] My unit tests cover both failure and success scenarios
[~] If applicable, I have discussed my architecture
