### PR TITLE
add missing APIs to `ImmutableFile` and co.

### DIFF
--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -9,6 +9,7 @@ use crate::{
     GlommioError,
 };
 use std::{
+    cell::Ref,
     os::unix::io::{AsRawFd, FromRawFd, RawFd},
     path::{Path, PathBuf},
 };
@@ -134,7 +135,7 @@ impl BufferedFile {
             GlommioError::create_enhanced(
                 source,
                 "Writing",
-                self.file.path.as_ref(),
+                self.file.path.borrow().as_ref(),
                 Some(self.as_raw_fd()),
             )
         })
@@ -160,7 +161,7 @@ impl BufferedFile {
             GlommioError::create_enhanced(
                 source,
                 "Reading",
-                self.file.path.as_ref(),
+                self.file.path.borrow().as_ref(),
                 Some(self.as_raw_fd()),
             )
         })?;
@@ -219,7 +220,7 @@ impl BufferedFile {
 
     /// Returns an `Option` containing the path associated with this open
     /// directory, or `None` if there isn't one.
-    pub fn path(&self) -> Option<&Path> {
+    pub fn path(&self) -> Option<Ref<'_, Path>> {
         self.file.path()
     }
 

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -492,7 +492,7 @@ macro_rules! do_seek {
                         .reactor
                         .upgrade()
                         .unwrap()
-                        .statx($fileobj.as_raw_fd(), $fileobj.path().unwrap());
+                        .statx($fileobj.as_raw_fd(), &$fileobj.path().unwrap());
                     source.add_waiter($cx.waker().clone());
                     $self.source = Some(source);
                     Poll::Pending

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use nix::sys::statfs::*;
 use std::{
+    cell::Ref,
     io,
     os::unix::io::{AsRawFd, RawFd},
     path::Path,
@@ -368,7 +369,7 @@ impl DmaFile {
     /// rename this file.
     ///
     /// **Warning:** synchronous operation, will block the reactor
-    pub async fn rename<P: AsRef<Path>>(&mut self, new_path: P) -> Result<()> {
+    pub async fn rename<P: AsRef<Path>>(&self, new_path: P) -> Result<()> {
         self.file.rename(new_path).await
     }
 
@@ -395,7 +396,7 @@ impl DmaFile {
 
     /// Returns an `Option` containing the path associated with this open
     /// directory, or `None` if there isn't one.
-    pub fn path(&self) -> Option<&Path> {
+    pub fn path(&self) -> Option<Ref<'_, Path>> {
         self.file.path()
     }
 
@@ -491,7 +492,7 @@ pub(crate) mod test {
     });
 
     dma_file_test!(file_rename, path, _k, {
-        let mut new_file = DmaFile::create(path.join("testfile"))
+        let new_file = DmaFile::create(path.join("testfile"))
             .await
             .expect("failed to create file");
 
@@ -507,7 +508,7 @@ pub(crate) mod test {
     });
 
     dma_file_test!(file_rename_noop, path, _k, {
-        let mut new_file = DmaFile::create(path.join("testfile"))
+        let new_file = DmaFile::create(path.join("testfile"))
             .await
             .expect("failed to create file");
 
@@ -571,7 +572,7 @@ pub(crate) mod test {
             .await
             .expect("failed to create file");
 
-        assert_eq!(new_file.path().unwrap(), path.join("testfile"));
+        assert_eq!(*new_file.path().unwrap(), path.join("testfile"));
         new_file.close().await.expect("failed to close file");
     });
 

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -355,7 +355,7 @@ impl DmaFile {
     ///
     /// It is important not to set the extent size too big. Writes can fail
     /// otherwise if the extent can't be allocated.
-    pub async fn hint_extent_size(&self, size: usize) -> nix::Result<i32> {
+    pub async fn hint_extent_size(&self, size: usize) -> Result<i32> {
         self.file.hint_extent_size(size).await
     }
 

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -407,8 +407,7 @@ impl DmaStreamReader {
         let to_cancel = handles.len();
         let cancelled = stream::iter(handles).then(|f| f).count().await;
         assert_eq!(to_cancel, cancelled);
-        let res = self.file.close_rc().await;
-        collect_error!(self.state, res);
+        let _ = self.file.close_rc().await;
 
         let mut state = self.state.borrow_mut();
         match state.error.take() {

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -180,8 +180,11 @@ impl GlommioFile {
         Ok(())
     }
 
-    pub(crate) async fn hint_extent_size(&self, size: usize) -> nix::Result<i32> {
-        sys::fs_hint_extentsize(self.as_raw_fd(), size)
+    pub(crate) async fn hint_extent_size(&self, size: usize) -> Result<i32> {
+        match sys::fs_hint_extentsize(self.as_raw_fd(), size) {
+            Ok(hint) => Ok(hint),
+            Err(err) => Err(io::Error::from_raw_os_error(err.as_errno().unwrap() as i32).into()),
+        }
     }
 
     pub(crate) async fn truncate(&self, size: u64) -> Result<()> {

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -7,6 +7,7 @@
 use crate::{parking::Reactor, sys, GlommioError, Local};
 use log::debug;
 use std::{
+    cell::{Ref, RefCell},
     convert::TryInto,
     io,
     os::unix::io::{AsRawFd, FromRawFd, RawFd},
@@ -27,7 +28,7 @@ pub(crate) struct GlommioFile {
     // A file can appear in many paths, through renaming and linking.
     // If we do that, each path should have its own object. This is to
     // facilitate error displaying.
-    pub(crate) path: Option<PathBuf>,
+    pub(crate) path: RefCell<Option<PathBuf>>,
     pub(crate) inode: u64,
     pub(crate) dev_major: u32,
     pub(crate) dev_minor: u32,
@@ -43,7 +44,8 @@ That means that while the file is already out of scope, the file descriptor is s
                  until the next I/O cycle.
 This is likely file, but in extreme situations can lead to resource exhaustion. An explicit \
                  asynchronous close is still preferred",
-                self.path, file
+                self.path.borrow(),
+                file
             );
             if let Some(r) = self.reactor.upgrade() {
                 r.sys.async_close(file);
@@ -62,7 +64,7 @@ impl FromRawFd for GlommioFile {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         GlommioFile {
             file: Some(fd),
-            path: None,
+            path: RefCell::new(None),
             inode: 0,
             dev_major: 0,
             dev_minor: 0,
@@ -92,7 +94,7 @@ impl GlommioFile {
 
         let mut file = GlommioFile {
             file: Some(fd as _),
-            path: Some(path),
+            path: RefCell::new(Some(path)),
             inode: 0,
             dev_major: 0,
             dev_minor: 0,
@@ -131,15 +133,14 @@ impl GlommioFile {
         Ok(())
     }
 
-    pub(crate) fn with_path(mut self, path: Option<PathBuf>) -> GlommioFile {
-        self.path = path;
+    pub(crate) fn with_path(self, path: Option<PathBuf>) -> GlommioFile {
+        self.path.replace(path);
         self
     }
 
-    pub(crate) fn path_required(&self, op: &'static str) -> Result<&Path> {
-        self.path
-            .as_deref()
-            .ok_or_else(|| GlommioError::EnhancedIoError {
+    pub(crate) fn path_required(&self, op: &'static str) -> Result<Ref<'_, Path>> {
+        match *self.path.borrow() {
+            None => Err(GlommioError::EnhancedIoError {
                 op,
                 path: None,
                 fd: Some(self.as_raw_fd()),
@@ -147,11 +148,18 @@ impl GlommioFile {
                     std::io::ErrorKind::InvalidData,
                     "operation requires a valid path",
                 ),
-            })
+            }),
+            Some(_) => Ok(Ref::map(self.path.borrow(), |p| {
+                p.as_ref().unwrap().as_path()
+            })),
+        }
     }
 
-    pub(crate) fn path(&self) -> Option<&Path> {
-        self.path.as_deref()
+    pub(crate) fn path(&self) -> Option<Ref<'_, Path>> {
+        self.path
+            .borrow()
+            .as_deref()
+            .map(|_| Ref::map(self.path.borrow(), |p| p.as_ref().unwrap().as_path()))
     }
 
     pub(crate) async fn pre_allocate(&self, size: u64) -> Result<()> {
@@ -165,7 +173,7 @@ impl GlommioFile {
             GlommioError::create_enhanced(
                 source,
                 "Pre-allocate space",
-                self.path.as_ref(),
+                self.path.borrow().as_ref(),
                 Some(self.as_raw_fd()),
             )
         })?;
@@ -181,16 +189,16 @@ impl GlommioFile {
             GlommioError::create_enhanced(
                 source,
                 "Truncating",
-                self.path.as_ref(),
+                self.path.borrow().as_ref(),
                 Some(self.as_raw_fd()),
             )
         })
     }
 
-    pub(crate) async fn rename<P: AsRef<Path>>(&mut self, new_path: P) -> Result<()> {
-        let old_path = self.path_required("rename")?;
+    pub(crate) async fn rename<P: AsRef<Path>>(&self, new_path: P) -> Result<()> {
+        let old_path = self.path_required("rename")?.to_path_buf();
         crate::io::rename(old_path, &new_path).await?;
-        self.path = Some(new_path.as_ref().to_owned());
+        self.path.replace(Some(new_path.as_ref().to_owned()));
         Ok(())
     }
 
@@ -200,7 +208,7 @@ impl GlommioFile {
             GlommioError::create_enhanced(
                 source,
                 "Syncing",
-                self.path.as_ref(),
+                self.path.borrow().as_ref(),
                 Some(self.as_raw_fd()),
             )
         })?;
@@ -209,11 +217,11 @@ impl GlommioFile {
 
     pub(crate) async fn remove(&self) -> Result<()> {
         let path = self.path_required("remove")?;
-        sys::remove_file(path).map_err(|source| {
+        sys::remove_file(path.as_ref()).map_err(|source| {
             GlommioError::create_enhanced(
                 source,
                 "Removing",
-                self.path.as_ref(),
+                self.path.borrow().as_ref(),
                 Some(self.as_raw_fd()),
             )
         })
@@ -227,12 +235,12 @@ impl GlommioFile {
             .reactor
             .upgrade()
             .unwrap()
-            .statx(self.as_raw_fd(), path);
+            .statx(self.as_raw_fd(), path.as_ref());
         source.collect_rw().await.map_err(|source| {
             GlommioError::create_enhanced(
                 source,
                 "getting file metadata",
-                self.path.as_ref(),
+                self.path.borrow().as_ref(),
                 Some(self.as_raw_fd()),
             )
         })?;
@@ -262,7 +270,7 @@ pub(crate) mod test {
             let gf = GlommioFile::open_at(-1, &file, libc::O_CREAT, 644)
                 .await
                 .unwrap();
-            let gf_fd = gf.path.as_ref().cloned().unwrap();
+            let gf_fd = gf.path.borrow().as_ref().cloned().unwrap();
 
             let file_list = || {
                 let mut files = vec![];

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 
 use futures_lite::{future::poll_fn, io::AsyncWrite};
 use std::{
+    cell::Ref,
     io,
     pin::Pin,
     rc::Rc,
@@ -275,7 +276,7 @@ impl AsyncWrite for ImmutableFilePreSealSink {
 impl ImmutableFile {
     /// Returns an `Option` containing the path associated with this open
     /// directory, or `None` if there isn't one.
-    pub fn path(&self) -> Option<&Path> {
+    pub fn path(&self) -> Option<Ref<'_, Path>> {
         self.stream_builder.file.path()
     }
 


### PR DESCRIPTION
### What does this PR do?

@glommer recently introduced a new family of API in #359. However some useful methods are missing on those vs what is available on the standard `DmaFile` and `BufferedFile` structs.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
