### PR TITLE
Fix doctest, broken by 5dc9048bfffe3bac6d5997e3525df2e688008c6c

### DIFF
--- a/glommio/src/sync/semaphore.rs
+++ b/glommio/src/sync/semaphore.rs
@@ -547,7 +547,7 @@ impl Semaphore {
     ///  If semaphore is closed
     /// `Err(GlommioError::Closed(ResourceType::Semaphore { .. }))` will be
     /// returned.  If semaphore does not have sufficient amount of units
-    ///  ```
+    ///  ```ignore
     ///  Err(GlommioError::WouldBlock(ResourceType::Semaphore {
     ///      requested: u64,
     ///      available: u64
@@ -598,7 +598,7 @@ impl Semaphore {
     ///  If semaphore is closed
     /// `Err(GlommioError::Closed(ResourceType::Semaphore { .. }))` will be
     /// returned.  If semaphore does not have sufficient amount of units
-    ///  ```
+    ///  ```ignore
     ///  Err(GlommioError::WouldBlock(ResourceType::Semaphore {
     ///      requested: u64,
     ///      available: u64


### PR DESCRIPTION
`cargo test` currently fails because it is treating these blocks as doctests