### PR TITLE
support partial flushes from DmaStreamWriter

### DIFF
--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -1020,7 +1020,7 @@ impl Drop for DmaStreamWriterState {
 
 impl Drop for DmaStreamWriter {
     fn drop(&mut self) {
-        if let Some(mut state) = self.state.try_borrow_mut().ok() {
+        if let Ok(mut state) = self.state.try_borrow_mut() {
             for handle in state.current_pending(u64::MAX).drain(..) {
                 handle.cancel();
             }

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -1867,7 +1867,6 @@ mod test {
         assert_eq!(writer.sync().await.unwrap(), 5000);
         // write more
         writer.write_all(&buffer).await.unwrap();
-        assert_eq!(writer.sync().await.unwrap(), 10000);
         writer.close().await.unwrap();
 
         assert_eq!(writer.current_flushed_pos(), 10000);

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -989,12 +989,12 @@ impl DmaStreamWriterState {
     fn flush_padded(&mut self, state: Rc<RefCell<Self>>, file: Rc<DmaFile>) -> bool {
         if self.buffer_pos == 0 {
             return false;
+        } else {
+            assert!(
+                self.buffer_pos < self.buffer_size,
+                "full buffer should have already been flushed"
+            );
         }
-        assert!(
-            self.buffer_pos < self.buffer_size,
-            "full buffer should have already been flushed"
-        );
-
         let last_flush_pos = self.flush_state.last_flush_pos();
         let current_pos = self.current_pos();
         if last_flush_pos == current_pos {
@@ -1002,16 +1002,13 @@ impl DmaStreamWriterState {
         } else {
             assert!(last_flush_pos < current_pos);
         }
-
         let buffer = self.current_buffer.take().unwrap();
-
         if let FileStatus::Open = self.file_status {
             let mut buffer_copy = file.alloc_dma_buffer(self.buffer_size);
             buffer_copy.as_bytes_mut()[..self.buffer_pos]
                 .copy_from_slice(&buffer.as_bytes()[..self.buffer_pos]);
             self.current_buffer = Some(buffer_copy);
         }
-
         self.flush_one_buffer(buffer, state, file);
         true
     }

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -869,11 +869,13 @@ impl DmaStreamWriterState {
                 }
             }
 
-            if final_pos != state.aligned_pos {
+            if final_pos > state.aligned_pos {
                 let res = file.truncate(final_pos).await;
                 if collect_error!(state, res) {
                     return;
                 }
+            } else {
+                assert_eq!(final_pos, state.aligned_pos);
             }
 
             if do_close {

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -902,15 +902,13 @@ impl DmaStreamWriterState {
         self.flushed_pos
     }
 
-    fn synced_pos(&self) -> u64 {
-        self.synced_pos
-    }
-
     async fn sync(&mut self, file: &DmaFile) -> Result<u64> {
-        let flushed_pos = self.flushed_pos;
-        if self.synced_pos < flushed_pos {
+        let flushed_pos_at_sync = self.flushed_pos;
+        if self.synced_pos < flushed_pos_at_sync {
             file.fdatasync().await?;
-            self.synced_pos = flushed_pos;
+            self.synced_pos = flushed_pos_at_sync;
+        } else {
+            assert_eq!(self.synced_pos, flushed_pos_at_sync);
         }
         Ok(self.synced_pos)
     }
@@ -1156,11 +1154,6 @@ impl DmaStreamWriter {
     /// [`close`]: https://docs.rs/futures/0.3.5/futures/io/trait.AsyncWriteExt.html#method.close
     pub fn current_flushed_pos(&self) -> u64 {
         self.state.borrow().flushed_pos()
-    }
-
-    /// TODO document
-    pub fn current_synced_pos(&self) -> u64 {
-        self.state.borrow().synced_pos()
     }
 
     /// TODO document

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -1024,7 +1024,8 @@ impl Drop for DmaStreamWriter {
                 let file = self.file.take().unwrap();
                 if let Err(err) = sys::truncate_file(file.as_raw_fd(), state.flushed_pos) {
                     debug!(
-                        "DmaStreamWriter[{:?}] was not closed and drop-time truncation to {}b failed: {}",
+                        "DmaStreamWriter[{:?}] was not closed and drop-time truncation to {}b \
+                         failed: {}",
                         file.path(),
                         state.flushed_pos,
                         err

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -260,20 +260,40 @@ impl ImmutableFilePreSealSink {
         })
     }
 
-    /// TODO document
+    /// Waits for all currently in-flight buffers to be written to the
+    /// underlying storage.
+    ///
+    /// This does not include the current buffer if it is not full. If all data
+    /// must be flushed, use [`flush`].
+    ///
+    /// Returns the flushed position of the file.
+    ///
+    /// [`flush`]: https://docs.rs/futures/0.3.15/futures/io/trait.AsyncWriteExt.html#method.flush
     pub async fn flush_aligned(&self) -> Result<u64> {
         self.writer.flush_aligned().await
     }
 
-    /// TODO document
+    /// Waits for all currently in-flight buffers to be written to the
+    /// underlying storage, and ensures they are safely persisted.
+    ///
+    /// This does not include the current buffer if it is not full. If all data
+    /// must be synced, use [`Self::sync`].
+    ///
+    /// Returns the flushed position of the file at the time the sync started.
     pub async fn sync_aligned(&self) -> Result<u64> {
         self.writer.sync_aligned().await
     }
 
-    /// Waits for all currently in-flight buffers to return and be safely stored
-    /// in the underlying storage.
+    /// Waits for all buffers to be written to the underlying storage, and
+    /// ensures they are safely persisted.
+    ///
+    /// This includes the current buffer even if it is not full, by padding it.
+    /// The padding will get over-written by future writes, or truncated upon
+    /// [`Self::seal`] or [`close`].
     ///
     /// Returns the flushed position of the file at the time the sync started.
+    ///
+    /// [`close`]: https://docs.rs/futures/0.3.15/futures/io/trait.AsyncWriteExt.html#method.close
     pub async fn sync(&self) -> Result<u64> {
         self.writer.sync().await
     }

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -261,13 +261,13 @@ impl ImmutableFilePreSealSink {
     }
 
     /// TODO document
-    pub async fn flush_upto(&self, pos: u64) -> Result<u64> {
-        self.writer.flush_upto(pos).await
+    pub async fn flush_aligned(&self) -> Result<u64> {
+        self.writer.flush_aligned().await
     }
 
     /// TODO document
-    pub async fn sync_upto(&self, pos: u64) -> Result<u64> {
-        self.writer.sync_upto(pos).await
+    pub async fn sync_aligned(&self) -> Result<u64> {
+        self.writer.sync_aligned().await
     }
 
     /// Waits for all currently in-flight buffers to return and be safely stored

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -267,13 +267,18 @@ impl ImmutableFilePreSealSink {
         })
     }
 
+    /// TODO document
+    pub async fn flush_upto(&self, pos: u64) -> Result<u64> {
+        self.writer.flush_upto(pos).await
+    }
+
+    /// TODO document
+    pub async fn sync_upto(&self, pos: u64) -> Result<u64> {
+        self.writer.sync_upto(pos).await
+    }
+
     /// Waits for all currently in-flight buffers to return and be safely stored
-    /// in the underlying storage
-    ///
-    /// Note that the current buffer being written to is not flushed, as it may
-    /// not be properly aligned. Buffers that are currently in-flight will
-    /// be waited on, and a sync operation will be issued by the operating
-    /// system.
+    /// in the underlying storage.
     ///
     /// Returns the flushed position of the file at the time the sync started.
     pub async fn sync(&self) -> Result<u64> {

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -1534,6 +1534,13 @@ impl Reactor {
         (cq.khead, cq.ktail)
     }
 
+    /// RAII-truncate asynchronously files that required it, e.g. because of
+    /// padded writes, but were not closed explicitly.
+    pub(crate) fn async_truncate(&self, fd: RawFd, size: u64) {
+        // actually synchronous for now!
+        let _ = sys::truncate_file(fd, size);
+    }
+
     // RAII-close asynchronously files that were not closed explicitly.
     // We can't do this through a Source, because the Source will be dropped when
     // the file is dropped.


### PR DESCRIPTION
### What does this PR do?

**High-level**

Updated behavior for `DmaStreamWriter` `flush()` and `sync()` is to write and await the current buffer, even if it is not full. This means the file can contain some padding for the last write.

New APIs `flush_aligned()` and `sync_aligned()` are provided which maintain the previous behavior, when a full flush/sync is not required.

**Details**

In `flush_padded()`:
- No-op if there is nothing to flush, or a flush is already pending for the `current_pos`.
- The current buffer gets copied. The `aligned_pos` and `buffer_pos` are not updated. The `aligned_pos` in the file will subsequently get overwritten, if more data is written to the stream.

During `close()` or if close is not performed, in `drop()`, file truncation is done if `must_truncate()`.

Also added an internal `synced_pos` which is used to track the `flushed_pos` at the time the last sync was done, and syncing is elided based on that.

### Motivation

Make `DmaStreamWriter` more generally useful, since writes are not likely to be aligned. Getting confidence in data having made it to disk should not require a close and reopen. Currently, close is the only time the current buffer is written even if not full, and then the file is truncated.

### Related issues

https://github.com/DataDog/glommio/pull/375 laid some of the groundwork

### Checklist

- [x] I have added unit tests to the code I am submitting
- [x] My unit tests cover both failure and success scenarios
- [x] If applicable, I have discussed my architecture
