### PR TITLE
remove Unpin restriction from IoVec trait

### DIFF
--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -58,7 +58,7 @@ impl<U: Copy + Unpin> Stream for OrderedBulkIo<U> {
 }
 
 /// An interface to an IO vector.
-pub trait IoVec: Copy + Unpin {
+pub trait IoVec: Copy {
     /// The read position (the offset) in the file
     fn pos(&self) -> u64;
     /// The number of bytes to read at [`Self::pos`]
@@ -76,7 +76,7 @@ impl IoVec for (u64, usize) {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub(crate) struct ReadManyArgs<V: IoVec> {
+pub(crate) struct ReadManyArgs<V: IoVec + Unpin> {
     pub(crate) user_read: V,
     pub(crate) system_read: (u64, usize),
 }
@@ -85,12 +85,12 @@ pub(crate) struct ReadManyArgs<V: IoVec> {
 ///
 /// See [`DmaFile::read_many`] for more information
 #[derive(Debug)]
-pub struct ReadManyResult<V: IoVec> {
+pub struct ReadManyResult<V: IoVec + Unpin> {
     pub(crate) inner: OrderedBulkIo<ReadManyArgs<V>>,
     pub(crate) current_result: ReadResult,
 }
 
-impl<V: IoVec> Stream for ReadManyResult<V> {
+impl<V: IoVec + Unpin> Stream for ReadManyResult<V> {
     type Item = super::Result<(V, ReadResult)>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -285,7 +285,7 @@ impl DmaFile {
     ///
     /// It is not necessary to respect the `O_DIRECT` alignment of the file, and
     /// this API will internally convert the positions and sizes to match.
-    pub fn read_many<V: IoVec, S: Iterator<Item = V>>(
+    pub fn read_many<V: IoVec + Unpin, S: Iterator<Item = V>>(
         self: &Rc<DmaFile>,
         iovs: S,
         max_merged_buffer_size: usize,

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -376,14 +376,14 @@ impl ImmutableFile {
     ///
     /// It is not necessary to respect the `O_DIRECT` alignment of the file, and
     /// this API will internally convert the positions and sizes to match.
-    pub fn read_many<V: IoVec, S: Iterator<Item = V>>(
+    pub fn read_many<V, S: Iterator<Item = V>>(
         &self,
         iovs: S,
         max_merged_buffer_size: usize,
         max_read_amp: Option<usize>,
     ) -> ReadManyResult<V>
     where
-        V: IoVec,
+        V: IoVec + Unpin,
         S: Iterator<Item = V>,
     {
         self.stream_builder


### PR DESCRIPTION
An IoVec should just be a base+pos combination. Adding Unpin to it
makes it harder to consume.

The Unpin restriction should be attached to IoVec uses whenever needed,
instead of always bundled in the trait.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
