### PR TITLE
DmaStreamWriter flush state management improvements

### DIFF
--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -910,11 +910,9 @@ impl DmaStreamWriterState {
     fn on_flush_success(&mut self, flush_pos: u64) {
         let mut complete_prefix_len = 0usize;
         let mut complete_prefix_finalized = false;
-        let mut found_index = None;
-        for (i, (pos, status)) in self.flushes.iter_mut().enumerate() {
+        for (pos, status) in &mut self.flushes {
             if *pos == flush_pos {
                 *status = FlushStatus::Complete;
-                found_index = Some(i);
             }
             if !complete_prefix_finalized {
                 if let FlushStatus::Complete = status {
@@ -923,11 +921,10 @@ impl DmaStreamWriterState {
                     complete_prefix_finalized = true;
                 }
             }
-            if found_index.is_some() && complete_prefix_finalized {
+            if complete_prefix_finalized && *pos >= flush_pos {
                 break;
             }
         }
-        found_index.expect("missing flush");
         if complete_prefix_len > 0 {
             let (pos, _) = self.flushes.drain(..complete_prefix_len).last().unwrap();
             self.flushed_pos = pos;

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -839,20 +839,19 @@ impl DmaStreamWriterFlushState {
         // `flushed_pos` can be updated accordingly and we don't
         // need to track them anymore, so drain that range.
         let mut drainable_len = 0usize;
-        let mut found_pending = false;
+        let mut counting = true;
         for (pos, status) in &mut self.flushes {
             if *pos == flush_pos {
                 *status = FlushStatus::Complete;
             }
-            if !found_pending {
+            if counting {
                 if let FlushStatus::Complete = status {
                     drainable_len += 1;
                     self.flushed_pos = *pos;
                 } else {
-                    found_pending = true;
+                    counting = false;
                 }
-            }
-            if found_pending && *pos >= flush_pos {
+            } else if *pos >= flush_pos {
                 break;
             }
         }

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -862,15 +862,6 @@ impl DmaStreamWriterFlushState {
     }
 }
 
-impl Drop for DmaStreamWriterFlushState {
-    fn drop(&mut self) {
-        let mut pending = self.take_pending_handles();
-        for flush in pending.drain(..) {
-            flush.cancel();
-        }
-    }
-}
-
 #[derive(Debug)]
 struct DmaStreamWriterState {
     buffer_size: usize,
@@ -1008,6 +999,15 @@ impl DmaStreamWriterState {
         })
         .detach();
         self.flush_state.on_start(flush_pos, handle);
+    }
+}
+
+impl Drop for DmaStreamWriterState {
+    fn drop(&mut self) {
+        let mut pending = self.take_pending_handles();
+        for flush in pending.drain(..) {
+            flush.cancel();
+        }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

Public APIs are not affected.

* Use a ring buffer for `pending` flushes as well as `out_of_order_write_returns`.
* Instead of `flush_id`, the last position represented in the write (`flush_pos`, or what `state.flushed_pos` should be updated to on completion) is used to identify each write.
* Rely on the natural sorting as it is an append-only stream, no need to resort the out-of-order write returns.
* When there is a contiguous prefix of completed flushes, `state.flushed_pos` is updated.

Although intended as a simplification, the LOC unfortunately turns out to be a bit more.

### Motivation

Makes partial flushes (https://github.com/DataDog/glommio/pull/371/) easier. Current logic for updating `state.flushed_pos` is fairly tied to aligned positions.

### Related issues

Enabler for https://github.com/DataDog/glommio/pull/371

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture