### PR TITLE
Await Local executor handle in flaky test

### DIFF
--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -904,8 +904,7 @@ mod test {
                 let _resp = receiver.recv().await.unwrap();
             })
             .unwrap();
-
-        drop(ex2);
+        ex2.join().unwrap();
         ex1.join().unwrap();
 
         // make sure that our total is always 0, to ensure we have dropped all entries,


### PR DESCRIPTION
The original test's code did not await both JoinHandles, but that is not safe or
correct. Unless you await the JoinHandles of a local executor, you cannot be 100%
sure that every object owned by a future inside the executor will be dropped
correctly. This could be addressed in the future but is currently outside of the
scope of this.

### What does this PR do?
Added an await to fix a flaky test.

### Motivation
This fixes #377 

### Related issues
#377 

### Additional Notes
None

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
