### PR TITLE
make a stronger distinction between add_waiter use cases

### DIFF
--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -391,7 +391,7 @@ impl StreamWriter {
                 bytes,
                 self.file_pos,
             );
-            source.add_waiter(waker);
+            source.add_waiter_single(waker);
             self.source = Some(source);
             true
         } else {
@@ -410,7 +410,7 @@ impl StreamWriter {
                         .upgrade()
                         .unwrap()
                         .fdatasync(self.file.as_ref().unwrap().as_raw_fd());
-                    source.add_waiter(cx.waker().clone());
+                    source.add_waiter_single(cx.waker().clone());
                     self.source = Some(source);
                     Poll::Pending
                 }
@@ -430,7 +430,7 @@ impl StreamWriter {
                     .upgrade()
                     .unwrap()
                     .close(self.file.as_ref().unwrap().as_raw_fd());
-                source.add_waiter(cx.waker().clone());
+                source.add_waiter_single(cx.waker().clone());
                 self.source = Some(source);
                 Poll::Pending
             }
@@ -498,7 +498,7 @@ macro_rules! do_seek {
                         .upgrade()
                         .unwrap()
                         .statx($fileobj.as_raw_fd(), &$fileobj.path().unwrap());
-                    source.add_waiter($cx.waker().clone());
+                    source.add_waiter_single($cx.waker().clone());
                     $source = Some(source);
                     Poll::Pending
                 }
@@ -586,7 +586,7 @@ impl AsyncBufRead for StreamReader {
                         self.buffer.max_buffer_size,
                         self.file.file.scheduler.borrow().as_ref(),
                     );
-                    source.add_waiter(cx.waker().clone());
+                    source.add_waiter_single(cx.waker().clone());
                     self.io_source = Some(source);
                     Poll::Pending
                 }
@@ -671,7 +671,7 @@ impl AsyncBufRead for Stdin {
                         self.buffer.max_buffer_size,
                         None,
                     );
-                    source.add_waiter(cx.waker().clone());
+                    source.add_waiter_single(cx.waker().clone());
                     self.source = Some(source);
                     Poll::Pending
                 }

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -41,7 +41,7 @@ impl<U: Copy + Unpin> Stream for OrderedBulkIo<U> {
                     Poll::Pending
                 };
                 if let Some((Some(source), _)) = self.iovs.front_mut() {
-                    source.add_waiter(cx.waker().clone());
+                    source.add_waiter_many(cx.waker().clone());
                 }
                 res
             }

--- a/glommio/src/net/stream.rs
+++ b/glommio/src/net/stream.rs
@@ -226,7 +226,7 @@ impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> GlommioStream<S> {
         };
 
         if source.result().is_none() {
-            source.add_waiter(cx.waker().clone());
+            source.add_waiter_single(cx.waker().clone());
             self.source_rx = Some(source);
             Poll::Pending
         } else {
@@ -253,7 +253,7 @@ impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> GlommioStream<S> {
 
         match source.result() {
             None => {
-                source.add_waiter(cx.waker().clone());
+                source.add_waiter_single(cx.waker().clone());
                 self.source_tx = Some(source);
                 Poll::Pending
             }


### PR DESCRIPTION
It used to be the case where we would assume there was a single waiter
per source, but in the read_many work we moved that to many-waiters.

The function that manipulates the wakers was kept the same, so whether
or not we had many wakers was entirely up to the user.

However I just found a use case (issue #391) where there are many
waiters added to a source that only expects a single waiter. That's
a use case in which we reuse a source, and we keep calling the poll
function into a stream even though the stream is never ready.

It's not clear to me (yet) why this is the case. It is certainly
surprising. While I want to get to the bottom of this, it is not a bad
idea to require the user to ask for their intentions explicitly.

In the future, if we can indeed guarantee that a function with a single
waiter should be empty we can use this opportunity for a stronger
assert. For now, this reverts the old behavior in the original users
and at least gets rid of this particular regression

Fixes #391

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
