### PR TITLE
fix eventfd logic and prevent multiple registrations

### DIFF
--- a/glommio/src/sys/dma_buffer.rs
+++ b/glommio/src/sys/dma_buffer.rs
@@ -52,6 +52,7 @@ impl Drop for SysAlloc {
 pub(crate) enum BufferStorage {
     Sys(SysAlloc),
     Uring(UringBuffer),
+    EventFd(*mut u8),
 }
 
 impl BufferStorage {
@@ -59,6 +60,7 @@ impl BufferStorage {
         match self {
             BufferStorage::Sys(x) => x.as_ptr(),
             BufferStorage::Uring(x) => x.as_ptr(),
+            BufferStorage::EventFd(x) => *x as *const u8,
         }
     }
 
@@ -66,6 +68,7 @@ impl BufferStorage {
         match self {
             BufferStorage::Sys(x) => x.as_mut_ptr(),
             BufferStorage::Uring(x) => x.as_mut_ptr(),
+            BufferStorage::EventFd(x) => *x,
         }
     }
 }

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -232,6 +232,17 @@ impl Source {
         self.inner.borrow_mut().wakers.waiters.push(waker)
     }
 
+    // used for eventfd, and other internal sources that reuse the same source
+    // across many invocations
+    pub(super) fn take_result(&self) -> Option<io::Result<usize>> {
+        self.inner
+            .borrow_mut()
+            .wakers
+            .result
+            .take()
+            .map(|x| OsResult::from(x).into())
+    }
+
     pub(super) fn raw(&self) -> RawFd {
         self.inner.borrow().raw
     }


### PR DESCRIPTION
Commit 8874895 introduced a regression that manifests as a SIGSEGV.
The reason for that is that the patch introduced Source reuse, in order
to implement read coalescing. Calls to take_result() were transformed into
result(), leaving the original Result in place for other consumers to
peek.

This is all fine for user-visible Sources, but our eventfd manipulation
is a bit more intricate, and relied on the presence or absence of a
Result to decide whether or not to install a new eventfd.

As a result of the change, every time the reactor is invoked after the
eventfd fired for the first time, a new eventfd source is registered,
which is wrong.

But what makes this problem really nasty is the fact that the kernel
already knows about the previous address. When we register a new Source,
we also add a new buffer. The kernel, though, will write to the previous
buffer which was already freed when we installed the new one.

Aside from fixing the issue, this patch also does the following:
- adds more comments about eventfd, so people can more easily follow
  what's going on
- adds an assert on fill_sqe's read. I can't imagine anyone outside
  of eventfd having a legitimate excuse to reuse a Source like this.
- Adds a new buffer type, special for Eventfd. Not only this is good
  defensively, because even upon multiple registration the kernel would
  keep writing always to the same location, it also saves an allocation.

Fixes #396

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
