### PR TITLE
Fix RwLock doesn't work with multiple writers

### DIFF
--- a/glommio/src/sync/rwlock.rs
+++ b/glommio/src/sync/rwlock.rs
@@ -355,7 +355,7 @@ impl State {
 
         debug_assert!(!(self.readers > 0 && self.writers > 0));
 
-        if self.readers == 0 {
+        if self.readers == 0 && self.writers == 0 {
             self.writers += 1;
             return Ok(true);
         }
@@ -1338,5 +1338,15 @@ mod test {
             *cond.borrow_mut() = 2;
             let _ = lock.write().await.unwrap();
         })
+    }
+
+    #[test]
+    fn rwlock_reentrant() {
+        let ex = LocalExecutor::default();
+        ex.run(async {
+            let lock = RwLock::new(());
+            let _guard = lock.write().await.unwrap();
+            assert!(lock.try_write().is_err());
+        });
     }
 }


### PR DESCRIPTION
### What does this PR do?

Fix the `RwLock` that will panic when multiple writers want to get the write guard. 

It only checks the number of readers and will grant more than one write guard, which leads to `RefCell` panic due to two mutable borrows.

### Motivation
N/A

### Related issues
N/A

### Additional Notes

Anything else we should know when reviewing?

### Checklist

- [x] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
