### PR TITLE
Fix task memory leak

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -45,12 +45,14 @@ fastrand = "1.4.0"
 tokio = { version = "0.3.5", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time"] }
 rand = "0.8.0"
 tracing-subscriber = "0.2"
+pretty_env_logger = "0.4"
 
 [build-dependencies]
 cc = "1.0.47"
 
 [features]
 bench = []
+debugging = []
 
 [[bench]]
 name = "executor"

--- a/glommio/src/task/debugging.rs
+++ b/glommio/src/task/debugging.rs
@@ -1,0 +1,190 @@
+use crate::{dbg_context, executor::executor_id, task::header::Header};
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+thread_local! {
+    static DEBUGGER: RefCell<Option<TaskDebugger>> = RefCell::new(None);
+}
+
+/// Provide facilities to inspect the lifecycle of glommio tasks
+pub struct TaskDebugger {
+    label: Option<&'static str>,
+    registry: HashMap<*const (), TaskInfo>,
+    filter: fn(Option<&'static str>) -> bool,
+    task_count: usize,
+    current_task: Option<*const ()>,
+    context: Vec<&'static str>,
+}
+
+impl TaskDebugger {
+    /// Set label for the next glommio task to be spawned. Labels are
+    /// used for filtering tasks to inspect.
+    pub fn set_label(label: &'static str) {
+        Self::with(|dbg| {
+            dbg.label = Some(label);
+        });
+    }
+
+    /// Set the filter function
+    pub fn set_filter(filter: fn(Option<&str>) -> bool) {
+        Self::with(|dbg| {
+            dbg.filter = filter;
+        });
+    }
+
+    /// Print the list of tasks which are older than the specified duration.
+    pub fn debug_aged_tasks(older_than: Duration) {
+        Self::with(|dbg| {
+            let mut count = 0;
+            for (k, v) in dbg.registry.iter() {
+                let age = v.ts.elapsed();
+                if age > older_than {
+                    count += 1;
+                    dbg.debug_task_info(v, format!("age: {:?}", age).as_str());
+                }
+            }
+            if count > 0 {
+                log::debug!("found {} tasks older than {:?}", count, older_than);
+            }
+        })
+    }
+
+    /// Returns a count of tasks which are not destroyed yet.
+    pub fn task_count() -> usize {
+        Self::with(|dbg| dbg.task_count)
+    }
+}
+
+impl TaskDebugger {
+    fn with<F, R>(f: F) -> R
+    where
+        F: FnOnce(&mut TaskDebugger) -> R,
+    {
+        DEBUGGER.with(|dbg| {
+            let mut dbg = dbg.borrow_mut();
+            if dbg.is_none() {
+                *dbg = Some(TaskDebugger {
+                    label: None,
+                    registry: HashMap::new(),
+                    filter: has_label,
+                    task_count: 0,
+                    current_task: None,
+                    context: Vec::new(),
+                });
+            }
+            f(dbg.as_mut().unwrap())
+        })
+    }
+
+    pub(crate) fn register(ptr: *const ()) -> bool {
+        Self::with(|dbg| {
+            dbg.task_count += 1;
+            let label = dbg.label.take();
+            if (dbg.filter)(label) {
+                dbg.registry.insert(ptr, TaskInfo::new(ptr, label));
+                let header = unsafe { &*(ptr as *const Header) };
+                header.debugging.set(true);
+                true
+            } else {
+                false
+            }
+        })
+    }
+
+    pub(crate) fn unregister(ptr: *const ()) {
+        Self::with(|dbg| {
+            dbg.task_count -= 1;
+            dbg.registry.remove(&ptr).is_some()
+        });
+    }
+
+    pub(crate) fn update(ptr: *const ()) {
+        Self::with(|dbg| {
+            if let Some(info) = dbg.registry.get_mut(&ptr) {
+                if dbg.label.is_some() {
+                    info.label = dbg.label;
+                }
+            }
+        });
+    }
+
+    pub(crate) fn enter(ptr: *const (), ctx: &'static str) -> bool {
+        Self::with(|dbg| {
+            if let Some(info) = dbg.registry.get(&ptr) {
+                dbg.context.push(ctx);
+                dbg.debug_task(info, "");
+                return true;
+            }
+
+            let header = unsafe { &*(ptr as *const Header) };
+            if Some(header.notifier.id()) != executor_id() && header.debugging.get() {
+                dbg.context.push(ctx);
+                dbg.debug_foreign_task(ptr);
+                return true;
+            }
+            false
+        })
+    }
+
+    pub(crate) fn leave() {
+        Self::with(|dbg| {
+            dbg.context.pop();
+        });
+    }
+
+    fn debug_task(&self, info: &TaskInfo, msg: &str) {
+        self.debug_task_info(info, msg);
+    }
+
+    fn debug_task_info(&self, info: &TaskInfo, msg: &str) {
+        let header = unsafe { &*(info.ptr as *const Header) };
+        log::debug!(
+            "[{:?}] [{}] [label:{}] [{}] {}",
+            info.ptr,
+            header.to_compact_string(),
+            info.label.unwrap_or(""),
+            self.context.join("|"),
+            msg,
+        )
+    }
+
+    fn debug_foreign_task(&self, ptr: *const ()) {
+        let header = unsafe { &*(ptr as *const Header) };
+        log::debug!(
+            "[{:?}] [{}] [executor:{:?}] [{}]",
+            ptr,
+            header.to_compact_string(),
+            executor_id(),
+            self.context.join("|"),
+        )
+    }
+
+    pub(crate) fn set_current_task(ptr: *const ()) {
+        Self::with(|dbg| {
+            dbg.current_task = Some(ptr);
+        });
+    }
+}
+
+struct TaskInfo {
+    ptr: *const (),
+    label: Option<&'static str>,
+    ts: Instant,
+}
+
+impl TaskInfo {
+    fn new(ptr: *const (), label: Option<&'static str>) -> Self {
+        Self {
+            ptr,
+            label,
+            ts: Instant::now(),
+        }
+    }
+}
+
+fn has_label(label: Option<&'static str>) -> bool {
+    label.is_some()
+}

--- a/glommio/src/task/header.rs
+++ b/glommio/src/task/header.rs
@@ -4,12 +4,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
 use core::{fmt, task::Waker};
-use std::{
-    cell::Cell,
-    sync::{
-        atomic::{AtomicI16, Ordering},
-        Arc,
-    },
+#[cfg(feature = "debugging")]
+use std::cell::Cell;
+use std::sync::{
+    atomic::{AtomicI16, Ordering},
+    Arc,
 };
 
 use crate::{
@@ -91,6 +90,7 @@ impl Header {
         abort_on_panic(|| self.awaiter = Some(waker.clone()));
     }
 
+    #[cfg(feature = "debugging")]
     pub(crate) fn to_compact_string(&self) -> String {
         let state = self.state;
 

--- a/glommio/src/task/header.rs
+++ b/glommio/src/task/header.rs
@@ -4,13 +4,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
 use core::{fmt, task::Waker};
+use std::{
+    cell::Cell,
+    sync::{
+        atomic::{AtomicI16, Ordering},
+        Arc,
+    },
+};
 
-use crate::task::{raw::TaskVTable, state::*, utils::abort_on_panic};
-
-use crate::sys::SleepNotifier;
-use std::sync::Arc;
-
-use std::sync::atomic::{AtomicI16, Ordering};
+use crate::{
+    sys::SleepNotifier,
+    task::{raw::TaskVTable, state::*, utils::abort_on_panic},
+};
 
 /// The header of a task.
 ///
@@ -37,6 +42,9 @@ pub(crate) struct Header {
     /// to several other methods necessary for bookkeeping the
     /// heap-allocated task.
     pub(crate) vtable: &'static TaskVTable,
+
+    #[cfg(feature = "debugging")]
+    pub(crate) debugging: Cell<bool>,
 }
 
 impl Header {
@@ -81,6 +89,31 @@ impl Header {
     pub(crate) fn register(&mut self, waker: &Waker) {
         // Put the waker into the awaiter field.
         abort_on_panic(|| self.awaiter = Some(waker.clone()));
+    }
+
+    pub(crate) fn to_compact_string(&self) -> String {
+        let state = self.state;
+
+        macro_rules! test {
+            ($flag:tt) => {
+                if state & $flag != 0 {
+                    stringify!($flag)
+                } else {
+                    ""
+                }
+            };
+        }
+
+        format!(
+            "thread:{}|{:>9}|{:>7}|{:>9}|{:>6}|{:>6}|refs:{}",
+            self.notifier.id(),
+            test!(SCHEDULED),
+            test!(RUNNING),
+            test!(COMPLETED),
+            test!(CLOSED),
+            test!(HANDLE),
+            self.references.load(Ordering::Relaxed)
+        )
     }
 }
 

--- a/glommio/src/task/mod.rs
+++ b/glommio/src/task/mod.rs
@@ -48,12 +48,32 @@
 
 #![warn(missing_docs, missing_debug_implementations)]
 
+#[cfg(feature = "debugging")]
+pub mod debugging;
 pub(crate) mod header;
 pub(crate) mod join_handle;
 pub(crate) mod raw;
 pub(crate) mod state;
 pub(crate) mod task_impl;
+mod tests;
 pub(crate) mod utils;
 pub(crate) mod waker_fn;
 
 pub use crate::task::{join_handle::JoinHandle, task_impl::Task};
+
+#[macro_export]
+macro_rules! dbg_context {
+    ($ptr:expr, $name:tt, $($body:tt)*) => {{
+        #[cfg(feature = "debugging")]
+        let entered = TaskDebugger::enter($ptr, $name);
+
+        #[cfg(feature = "debugging")]
+        defer! {
+            if entered {
+                TaskDebugger::leave();
+            }
+        }
+
+        $($body)*
+    }};
+}

--- a/glommio/src/task/mod.rs
+++ b/glommio/src/task/mod.rs
@@ -61,6 +61,7 @@ pub(crate) mod waker_fn;
 
 pub use crate::task::{join_handle::JoinHandle, task_impl::Task};
 
+/// Mark context for task operations
 #[macro_export]
 macro_rules! dbg_context {
     ($ptr:expr, $name:tt, $($body:tt)*) => {{

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -11,10 +11,9 @@ use core::{
     ptr::NonNull,
     task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
 };
-use std::{
-    cell::Cell,
-    sync::atomic::{AtomicI16, Ordering},
-};
+#[cfg(feature = "debugging")]
+use std::cell::Cell;
+use std::sync::atomic::{AtomicI16, Ordering};
 
 #[cfg(feature = "debugging")]
 use crate::task::debugging::TaskDebugger;

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -122,7 +122,7 @@ where
             (raw.header as *mut Header).write(Header {
                 notifier: sys::get_sleep_notifier_for(executor_id).unwrap(),
                 state: SCHEDULED | HANDLE,
-                references: AtomicI16::new(1),
+                references: AtomicI16::new(0),
                 awaiter: None,
                 vtable: &TaskVTable {
                     schedule: Self::schedule,

--- a/glommio/src/task/tests.rs
+++ b/glommio/src/task/tests.rs
@@ -1,0 +1,263 @@
+#[cfg(all(test, feature = "debugging"))]
+mod ref_count {
+    use std::{
+        cell::RefCell,
+        pin::Pin,
+        rc::Rc,
+        task::{Context, Poll, Waker},
+    };
+
+    use futures_lite::future::{yield_now, Future};
+
+    use crate::{channels::shared_channel, prelude::*, task::debugging::TaskDebugger};
+    use std::ptr::null;
+
+    struct Inner {
+        n: usize,
+        waker: Option<Waker>,
+    }
+
+    #[derive(Clone)]
+    struct WakeN {
+        inner: Rc<RefCell<Inner>>,
+    }
+
+    impl WakeN {
+        fn new(n: usize) -> Self {
+            Self {
+                inner: Rc::new(RefCell::new(Inner { n, waker: None })),
+            }
+        }
+
+        fn take_waker(&self) -> Option<Waker> {
+            self.inner.borrow_mut().waker.take()
+        }
+    }
+
+    impl Future for WakeN {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<()> {
+            let mut inner = self.inner.borrow_mut();
+            if inner.n > 0 {
+                inner.n -= 1;
+                inner.waker = Some(ctx.waker().clone());
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        }
+    }
+
+    fn init_logger() {
+        pretty_env_logger::try_init().ok();
+    }
+
+    #[test]
+    fn root_task() {
+        init_logger();
+        let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
+            assert_eq!(1, TaskDebugger::task_count());
+        });
+        result.unwrap().join_all()[0].as_ref().unwrap();
+    }
+
+    #[test]
+    fn foreground_task() {
+        init_logger();
+        let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
+            TaskDebugger::set_label("foreground_task");
+            let task = Local::local(async {
+                assert_eq!(2, TaskDebugger::task_count());
+            });
+            assert_eq!(2, TaskDebugger::task_count());
+            task.await;
+            assert_eq!(1, TaskDebugger::task_count());
+        });
+        result.unwrap().join_all()[0].as_ref().unwrap();
+    }
+
+    #[test]
+    fn background_task() {
+        init_logger();
+        let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
+            TaskDebugger::set_label("background_task");
+            let handle = Local::local(async {
+                assert_eq!(2, TaskDebugger::task_count());
+            })
+            .detach();
+            assert_eq!(2, TaskDebugger::task_count());
+            handle.await.unwrap();
+            assert_eq!(1, TaskDebugger::task_count());
+        });
+        result.unwrap().join_all()[0].as_ref().unwrap();
+    }
+
+    #[test]
+    fn drop_join_handle_before_completion() {
+        init_logger();
+        let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
+            TaskDebugger::set_label("drop_join_handle_before_completion");
+            let handle = Local::local(async {}).detach();
+            assert_eq!(2, TaskDebugger::task_count());
+            drop(handle);
+            assert_eq!(2, TaskDebugger::task_count());
+            yield_now().await;
+            assert_eq!(1, TaskDebugger::task_count());
+        });
+        result.unwrap().join_all()[0].as_ref().unwrap();
+    }
+
+    #[test]
+    fn drop_join_handle_after_completion() {
+        init_logger();
+        let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
+            TaskDebugger::set_label("drop_join_handle_after_completion");
+            let handle = Local::local(async {}).detach();
+            assert_eq!(2, TaskDebugger::task_count());
+            yield_now().await;
+            assert_eq!(2, TaskDebugger::task_count());
+            drop(handle);
+            assert_eq!(1, TaskDebugger::task_count());
+        });
+        result.unwrap().join_all()[0].as_ref().unwrap();
+    }
+
+    #[test]
+    fn wake() {
+        init_logger();
+        let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
+            let mut task = WakeN::new(1);
+            TaskDebugger::set_label("wake");
+            let handle = Local::local(task.clone()).detach();
+            yield_now().await;
+            task.take_waker().unwrap().wake();
+            yield_now().await;
+            assert_eq!(2, TaskDebugger::task_count());
+            drop(handle);
+            assert_eq!(1, TaskDebugger::task_count());
+        });
+        result.unwrap().join_all()[0].as_ref().unwrap();
+    }
+
+    #[test]
+    fn wake_completed_task() {
+        init_logger();
+        let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
+            let mut task = WakeN::new(1);
+            TaskDebugger::set_label("wake");
+            let handle = Local::local(task.clone()).detach();
+            drop(handle);
+            yield_now().await;
+            let waker = task.take_waker().unwrap();
+            waker.clone().wake();
+            yield_now().await;
+            assert_eq!(2, TaskDebugger::task_count());
+            waker.wake();
+            assert_eq!(1, TaskDebugger::task_count());
+        });
+        result.unwrap().join_all()[0].as_ref().unwrap();
+    }
+
+    #[test]
+    fn drop_waker_of_completed_task() {
+        init_logger();
+        let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
+            let mut task = WakeN::new(1);
+            TaskDebugger::set_label("wake");
+            let handle = Local::local(task.clone()).detach();
+            drop(handle);
+            yield_now().await;
+            let waker = task.take_waker().unwrap();
+            waker.clone().wake();
+            yield_now().await;
+            assert_eq!(2, TaskDebugger::task_count());
+            drop(waker);
+            assert_eq!(1, TaskDebugger::task_count());
+        });
+        result.unwrap().join_all()[0].as_ref().unwrap();
+    }
+
+    #[test]
+    fn wake_by_ref() {
+        init_logger();
+        let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
+            let mut task = WakeN::new(1);
+            TaskDebugger::set_label("wake_by_ref");
+            let handle = Local::local(task.clone()).detach();
+            yield_now().await;
+            let waker = task.take_waker().unwrap();
+            waker.wake_by_ref();
+            yield_now().await;
+            assert_eq!(2, TaskDebugger::task_count());
+            drop(handle);
+            assert_eq!(2, TaskDebugger::task_count());
+            drop(waker);
+            assert_eq!(1, TaskDebugger::task_count());
+        });
+        result.unwrap().join_all()[0].as_ref().unwrap();
+    }
+
+    #[test]
+    fn foreign_wake() {
+        init_logger();
+        let (sender, receiver) = shared_channel::new_bounded(1);
+
+        let results = vec![
+            LocalExecutorBuilder::new().spawn(move || async move {
+                let sender = sender.connect().await;
+                let mut task = WakeN::new(1);
+                TaskDebugger::set_label("foreign_wake");
+                let handle = Local::local(task.clone()).detach();
+                yield_now().await;
+                let waker = task.take_waker().unwrap();
+                sender.send(waker).await.unwrap();
+                yield_now().await;
+                assert_eq!(2, TaskDebugger::task_count());
+                handle.await.unwrap();
+                assert_eq!(1, TaskDebugger::task_count());
+            }),
+            LocalExecutorBuilder::new().spawn(move || async move {
+                let receiver = receiver.connect().await;
+                let waker = receiver.recv().await.unwrap();
+                waker.wake();
+            }),
+        ];
+
+        for res in results {
+            res.unwrap().join().unwrap();
+        }
+    }
+
+    #[test]
+    fn foreign_wake_by_ref() {
+        init_logger();
+        let (sender, receiver) = shared_channel::new_bounded(1);
+
+        let results = vec![
+            LocalExecutorBuilder::new().spawn(move || async move {
+                let sender = sender.connect().await;
+                let mut task = WakeN::new(1);
+                TaskDebugger::set_label("foreign_wake_by_ref");
+                let handle = Local::local(task.clone()).detach();
+                yield_now().await;
+                let waker = task.take_waker().unwrap();
+                sender.send(waker).await.unwrap();
+                yield_now().await;
+                assert_eq!(2, TaskDebugger::task_count());
+                handle.await.unwrap();
+                assert_eq!(1, TaskDebugger::task_count());
+            }),
+            LocalExecutorBuilder::new().spawn(move || async move {
+                let receiver = receiver.connect().await;
+                let waker = receiver.recv().await.unwrap();
+                waker.wake_by_ref();
+                drop(waker);
+            }),
+        ];
+
+        for res in results {
+            res.unwrap().join().unwrap();
+        }
+    }
+}


### PR DESCRIPTION
Three issues that prevent completed tasks from destroy are fixed:
- The ref count was initialized to 1, incremented on schedule, and decremented after run, so it will never going to be 0
- ~~The ref count could be updated on a foreign executor, so the relax ordering is not enough~~
- There's a chance that a foreign waker is dropped when the task is already complete. An additional foreign wake is necessary in this case.

Related issue: #401 