### PR TITLE
Remove unnecessary Arc

### DIFF
--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -277,7 +277,7 @@ impl fmt::Debug for OsError {
 pub(crate) struct SleepNotifier {
     id: usize,
     eventfd: std::fs::File,
-    memory: Arc<AtomicUsize>,
+    memory: AtomicUsize,
     foreign_wakes: Mutex<mpsc::Receiver<Waker>>,
     waker_sender: mpsc::Sender<Waker>,
 }
@@ -310,7 +310,7 @@ impl SleepNotifier {
         Ok(Arc::new(Self {
             eventfd,
             id,
-            memory: Arc::new(AtomicUsize::new(0)),
+            memory: AtomicUsize::new(0),
             waker_sender,
             foreign_wakes: Mutex::new(foreign_wakes),
         }))


### PR DESCRIPTION
### What does this PR do?

Remove `Arc` on `Arc<AtomicUsize>`.

### Motivation

`Arc` is unnecessary, as `memory` is not shared outside of `SleepNotifier`.

### Related issues

N/A

### Additional Notes

N/A
