### PR TITLE
Run right away

### DIFF
--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -222,6 +222,8 @@ impl DmaStreamReaderState {
         }
 
         let pending = Local::local(async move {
+            futures_lite::future::yield_now().await;
+
             if read_state.borrow().error.is_some() {
                 return;
             }
@@ -931,6 +933,8 @@ impl DmaStreamWriterState {
         self.flush_padded(state.clone(), file.clone());
         let mut pending = self.take_pending_handles();
         Local::local(async move {
+            futures_lite::future::yield_now().await;
+
             defer! {
                 waker.wake();
             }

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -122,7 +122,7 @@ where
             (raw.header as *mut Header).write(Header {
                 notifier: sys::get_sleep_notifier_for(executor_id).unwrap(),
                 state: SCHEDULED | HANDLE,
-                references: AtomicI16::new(1),
+                references: AtomicI16::new(0),
                 awaiter: None,
                 vtable: &TaskVTable {
                     schedule: Self::schedule,


### PR DESCRIPTION
    try to run tasks right away

    The current behavior is that, when we create a task, we move it to the
    back of a queue. However, a better behavior is to try to execute it
    right away. Especially for short lived tasks, that means that we don't
    need to go back to the queue at all, which should yield better
    performance.

    In the task switching microbenchmark, performance of spawning tasks
    almost doubles with this change.