### PR TITLE
remove alpha wording from Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ or really just chat with friends
 
 ## What is Glommio?
 
-
 Glommio (pronounced glo-mee-jow or |glomjəʊ|) is a Cooperative Thread-per-Core crate for
 Rust & Linux based on `io_uring`. Like other rust asynchronous crates it allows
 one to write asynchronous code that takes advantage of rust `async`/`await`, but
@@ -34,63 +33,21 @@ $ vi /etc/security/limits.conf
 *    soft    memlock        512
 ```
 
- To make the new limits effective, you need to login to the machine again. You can verify that
- the limits are updated by running the following:
+To make the new limits effective, you need to login to the machine again. You can verify that
+the limits are updated by running the following:
 
 ```sh
 $ ulimit -l
 512
 ```
 
+Glommio also requires a kernel with a recent enough `io_uring` support, at least recent enough
+to run discovery probes. The minimum version at this time is 5.8
+
 For more details check out our [docs
 page](https://docs.rs/glommio/latest/glommio/) and an [introductory
 article](https://www.datadoghq.com/blog/engineering/introducing-glommio/)
 
-## Status
-
-Glommio is still considered an alpha release. The main reasons are:
-
-* The existing API is still evolving
-* There are still some uses of unsafe that can be avoided
-* There are features that are critical for a good thread per core system
-  that are not implemented yet. The top one being:
-  * per-shard memory allocator.
-
-Want to help bring us to production status sooner? PRs are welcome!
-
-## Current limitations
-
-Due to our immediate needs which are a lot narrower, we make the following design assumptions:
-
-- NVMe. While other storage types may work, the general assumptions made in
-  here are based on the characteristics of NVMe storage. This allows us to
-  use io uring's poll ring for reads and writes which are interrupt free.
-  This also assumes that one is running either `XFS` or `Ext4` (an
-  assumption that Seastar also makes).
-  
-- A corollary to the above is that the CPUs are likely to be the
-  bottleneck, so this crate has a CPU scheduler but lacks an I/O scheduler.
-  That, however, would be a welcome addition.
-  
-- A recent(at least 5.8) kernel is no impediment, as long as a fully functional I/O uring
-  is present. In fact, we require a kernel so recent that it doesn't even
-  exist: operations like `mkdir, ftruncate`, etc which are not present in
-  today's (5.8) `io_uring` are simply synchronous and we'll live with the
-  pain in the hopes that Linux will eventually add support for them. 
-  
-## Missing features
-
-There are many. In particular:
-
-* Memory allocator: memory allocation is a big source of contention for
-  thread per core systems. A shard-aware allocator would be crucial for
-  achieving good performance in allocation-heavy workloads.
-  
-* As mentioned, an I/O Scheduler.
-  
-* Visibility: the crate exposes no metrics on its internals, and that should
-  change ASAP.
-  
 ## License
 
 Licensed under either of


### PR DESCRIPTION
We are getting very close to a point in which I am comfortable moving
Glommio out of alpha.

In particular, the limitations mentioned are either things that we fixed
already (NVMe only, lack of async truncate) or we are unlikely to anyway
(like a memory allocator, which should frankly be a separate crate) and
I/O scheduler (we have something basic now for I/O dedup, but it is
unclear we need more than that).
