### PR TITLE
do not reallocate memory when processing shared channels

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -42,7 +42,7 @@ crossbeam = "0.8"
 [dev-dependencies]
 futures = "0.3.5"
 fastrand = "1.4.0"
-tokio = { version = "0.3.5", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time"] }
+tokio = { version = "0.3.5", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time", "sync"] }
 rand = "0.8.0"
 tracing-subscriber = "0.2"
 pretty_env_logger = "0.4"

--- a/glommio/src/task/header.rs
+++ b/glommio/src/task/header.rs
@@ -123,6 +123,11 @@ impl fmt::Debug for Header {
         let refcount = self.references.load(Ordering::Relaxed);
 
         f.debug_struct("Header")
+            .field("ptr", &(self as *const Self))
+            .field(
+                "current_thread_id",
+                &crate::executor::executor_id().unwrap_or(usize::MAX),
+            )
             .field("thread_id", &self.notifier.id())
             .field("scheduled", &(state & SCHEDULED != 0))
             .field("running", &(state & RUNNING != 0))


### PR DESCRIPTION
### What does this PR do?

The implementation used to iterate over the tree of wakers and would
recreate a new tree with the remaining ones. This is not efficient as it
leads to a high number of allocations. Instead, iterate over the
existing tree and reuse the memory in place.

Additionally:
* use the same tree to store wakers and checker functions to reduce
the number of lookups and simplify the lifecycle of both;
* use a `SmallVec` to store wakers and optimize for the case
where a single waker is consuming the shared channel.

I added some additional benchmarks to exercise this code path. This
is a small but measurable improvement, especially in the many-to-many
benchmark (which is really meant to be worst-case). See below.

Before:
```
cost of mesh message shared channel: 21.48µs, peers 8, capacity 1024
cost of mesh message shared channel: 32.648µs, peers 8, capacity 1
```

After:
```
cost of mesh message shared channel: 20.744µs, peers 8, capacity 1024
cost of mesh message shared channel: 25.872µs, peers 8, capacity 1
```

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
