### PR TITLE
update to rust 1.55 and apply Clippy suggestions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 jobs:
   fmt:
     docker:
-      - image: cimg/rust:1.53
+      - image: cimg/rust:1.55
     steps:
       - checkout
       - run:
@@ -40,7 +40,7 @@ jobs:
 
   doc:
     docker:
-      - image: cimg/rust:1.53
+      - image: cimg/rust:1.55
     steps:
       - checkout
       - run:
@@ -72,7 +72,7 @@ jobs:
 
   clippy:
     docker:
-      - image: cimg/rust:1.53
+      - image: cimg/rust:1.55
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
             - v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Run linters
-          command: cargo clippy -- -D warnings
+          command: cargo clippy --all-targets --all-features -- -D warnings
       - save_cache:
           paths:
             - /usr/local/cargo/registry
@@ -115,7 +115,7 @@ jobs:
             - v5-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: Build all targets
-          command: cargo build --all --all-targets
+          command: cargo build --all --all-targets --all-features
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/examples/hyper.rs
+++ b/examples/hyper.rs
@@ -47,8 +47,8 @@ mod hyper_compat {
             Pin::new(&mut self.0)
                 .poll_read(cx, buf.initialize_unfilled())
                 .map(|n| {
-                    if n.is_ok() {
-                        buf.advance(n.unwrap());
+                    if let Ok(n) = n {
+                        buf.advance(n);
                     }
                     Ok(())
                 })

--- a/glommio/benches/nop.rs
+++ b/glommio/benches/nop.rs
@@ -11,7 +11,7 @@ struct Bench {
     num_events: u32,
 }
 
-const BENCH_RUNS: &'static [Bench] = &[
+const BENCH_RUNS: &[Bench] = &[
     Bench {
         num_tasks: 100,
         num_events: 10_000_000,

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -2021,7 +2021,6 @@ mod test {
         },
         task::Waker,
     };
-    use tracing_subscriber::EnvFilter;
 
     #[test]
     fn create_and_destroy_executor() {

--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -97,7 +97,7 @@ use super::{LocalExecutor, LocalExecutorPoolBuilder};
 ///
 /// handles.join_all();
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Placement {
     /// For the `Unbound` variant, the [`LocalExecutor`]s created by a
     /// [`LocalExecutorPoolBuilder`] are not bound to any CPU.  This is the
@@ -177,7 +177,7 @@ impl Default for Placement {
 /// Please see the documentation for [`Placement`] variants to
 /// understand how `CpuSet` restrictions apply to each variant.  CPUs are
 /// identified via their [`CpuLocation`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CpuSet(Vec<CpuLocation>);
 
 impl CpuSet {
@@ -516,7 +516,7 @@ mod test {
         let set = CpuSet::online().unwrap();
         let placement = Placement::Fenced(set);
         let placement_clone = placement.clone();
-        assert!(matches!(placement_clone, placement));
+        assert_eq!(placement_clone, placement);
     }
 
     #[test]
@@ -524,10 +524,10 @@ mod test {
         let set = CpuSet::online().unwrap();
         let some_placement = Placement::MaxSpread(Some(set));
         let some_placement_clone = some_placement.clone();
-        assert!(matches!(some_placement_clone, some_placement));
+        assert_eq!(some_placement_clone, some_placement);
         let none_placement = Placement::MaxSpread(None);
         let none_placement_clone = none_placement.clone();
-        assert!(matches!(none_placement_clone, none_placement));
+        assert_eq!(none_placement_clone, none_placement);
     }
 
     #[test]
@@ -535,21 +535,21 @@ mod test {
         let set = CpuSet::online().unwrap();
         let some_placement = Placement::MaxPack(Some(set));
         let some_placement_clone = some_placement.clone();
-        assert!(matches!(some_placement_clone, some_placement));
+        assert_eq!(some_placement_clone, some_placement);
         let none_placement = Placement::MaxPack(None);
         let none_placement_clone = none_placement.clone();
-        assert!(matches!(none_placement_clone, none_placement));
+        assert_eq!(none_placement_clone, none_placement);
     }
 
     #[test]
     fn placement_custom_clone() {
         let set1 = CpuSet::online().unwrap();
         let set2 = CpuSet::online().unwrap();
-        assert!(set1.len() > 0);
-        assert!(set2.len() > 0);
+        assert!(set1.is_empty());
+        assert!(set2.is_empty());
         let vec_set = vec![set1, set2];
         let placement = Placement::Custom(vec_set);
-        assert!(matches!(placement.clone(), placement));
+        assert_eq!(placement.clone(), placement);
     }
 
     #[test]

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -1204,7 +1204,7 @@ mod tests {
                     let mut buf = [0u8; 64];
                     // try to overflow the amount of wakers possible
                     for _ in 0..64_000 {
-                        if let Poll::Ready(_) = Pin::new(&mut stream).poll_read(cx, &mut buf) {
+                        if Pin::new(&mut stream).poll_read(cx, &mut buf).is_ready() {
                             panic!("should be pending");
                         }
                     }

--- a/glommio/src/sys/hardware_topology.rs
+++ b/glommio/src/sys/hardware_topology.rs
@@ -14,7 +14,7 @@ use std::{
 use super::sysfs::ListIterator;
 
 /// A description of the CPU's location in the machine topology.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CpuLocation {
     /// Holds the CPU id.  This is the most granular field and will distinguish
     /// among [`hyper-threads`].

--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -54,7 +54,7 @@ macro_rules! block_property {
             let bdev = map.entry(key).or_insert_with(|| BlockDevice::new(key));
 
             bdev.$property.clone()
-        });
+        })
     };
 }
 

--- a/glommio/src/task/tests.rs
+++ b/glommio/src/task/tests.rs
@@ -10,7 +10,6 @@ mod ref_count {
     use futures_lite::future::{yield_now, Future};
 
     use crate::{channels::shared_channel, prelude::*, task::debugging::TaskDebugger};
-    use std::ptr::null;
 
     struct Inner {
         n: usize,
@@ -37,7 +36,7 @@ mod ref_count {
     impl Future for WakeN {
         type Output = ();
 
-        fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<()> {
+        fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<()> {
             let mut inner = self.inner.borrow_mut();
             if inner.n > 0 {
                 inner.n -= 1;
@@ -127,7 +126,7 @@ mod ref_count {
     fn wake() {
         init_logger();
         let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
-            let mut task = WakeN::new(1);
+            let task = WakeN::new(1);
             TaskDebugger::set_label("wake");
             let handle = Local::local(task.clone()).detach();
             yield_now().await;
@@ -144,7 +143,7 @@ mod ref_count {
     fn wake_completed_task() {
         init_logger();
         let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
-            let mut task = WakeN::new(1);
+            let task = WakeN::new(1);
             TaskDebugger::set_label("wake");
             let handle = Local::local(task.clone()).detach();
             drop(handle);
@@ -163,7 +162,7 @@ mod ref_count {
     fn drop_waker_of_completed_task() {
         init_logger();
         let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
-            let mut task = WakeN::new(1);
+            let task = WakeN::new(1);
             TaskDebugger::set_label("wake");
             let handle = Local::local(task.clone()).detach();
             drop(handle);
@@ -182,7 +181,7 @@ mod ref_count {
     fn wake_by_ref() {
         init_logger();
         let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
-            let mut task = WakeN::new(1);
+            let task = WakeN::new(1);
             TaskDebugger::set_label("wake_by_ref");
             let handle = Local::local(task.clone()).detach();
             yield_now().await;
@@ -206,7 +205,7 @@ mod ref_count {
         let results = vec![
             LocalExecutorBuilder::new().spawn(move || async move {
                 let sender = sender.connect().await;
-                let mut task = WakeN::new(1);
+                let task = WakeN::new(1);
                 TaskDebugger::set_label("foreign_wake");
                 let handle = Local::local(task.clone()).detach();
                 yield_now().await;
@@ -237,7 +236,7 @@ mod ref_count {
         let results = vec![
             LocalExecutorBuilder::new().spawn(move || async move {
                 let sender = sender.connect().await;
-                let mut task = WakeN::new(1);
+                let task = WakeN::new(1);
                 TaskDebugger::set_label("foreign_wake_by_ref");
                 let handle = Local::local(task.clone()).detach();
                 yield_now().await;


### PR DESCRIPTION
### What does this PR do?

Time flies, we ended up skipping 1.54 this time.

On a side node, we need to be more careful because some code was not
passing Clippy even in 1.53. We seem to have an issue whereby
contributors need to have a CircleCI account for it to detect their PR
and run their code.

This is problematic, and we should find a solution, otherwise we can
except more broken/unformatted/undocumented code to end up being merged.

Code that doesn't pass clippy isn't the end of the world as I can fix it
later on. Undocumented code though, that's another story!

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
