### PR TITLE
impl Default for RwLock

### DIFF
--- a/glommio/src/sync/rwlock.rs
+++ b/glommio/src/sync/rwlock.rs
@@ -911,6 +911,12 @@ impl<T> RwLock<T> {
     }
 }
 
+impl<T: Default> Default for RwLock<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
 impl<T> Drop for RwLock<T> {
     fn drop(&mut self) {
         self.close();


### PR DESCRIPTION
### What does this PR do?
```rust
impl Default for RwLock {}
```

### Motivation

Another small API change. A usual pattern for wrapper struct.

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
