### PR TITLE
refactor `read_many` to take a stream of iovecs as input

### DIFF
--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -167,7 +167,7 @@ impl Reader {
     ) {
         match &self {
             Reader::Direct(file) => {
-                file.read_many(iovs, max_buffer_size, None)
+                file.read_many(futures_lite::stream::iter(iovs), max_buffer_size, None)
                     .for_each(|_| {})
                     .await;
             }
@@ -318,7 +318,7 @@ fn main() {
     let mut dir = PathBuf::from(path);
     assert!(dir.exists());
     dir.push("benchfiles");
-    assert!(!dir.exists());
+    assert!(!dir.exists(), "{:?} already exists", dir);
     let dir = BenchDirectory::new(dir);
 
     let total_memory = sys_info::mem_info().unwrap().total << 10;

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -35,7 +35,6 @@ ahash = "0.5.7"
 intrusive-collections = "0.9.0"
 lockfree = "0.5"
 membarrier = "0.2.2"
-itertools = "0.10.0"
 tracing = "0.1"
 crossbeam = "0.8"
 

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -1,7 +1,11 @@
-use crate::io::{DmaFile, ReadResult, ScheduledSource};
+use crate::io::{
+    dma_file::{align_down, align_up},
+    DmaFile,
+    ReadResult,
+    ScheduledSource,
+};
 use core::task::{Context, Poll};
 use futures_lite::{ready, Stream, StreamExt};
-use itertools::{Itertools, MultiPeek};
 use std::{
     cmp::{max, min},
     collections::VecDeque,
@@ -10,52 +14,8 @@ use std::{
     rc::Rc,
 };
 
-#[derive(Debug)]
-pub(crate) struct OrderedBulkIo<U> {
-    file: Rc<DmaFile>,
-    iovs: VecDeque<(Option<ScheduledSource>, U)>,
-}
-
-impl<U: Copy + Unpin> OrderedBulkIo<U> {
-    pub(crate) fn new<S: Iterator<Item = (Option<ScheduledSource>, U)>>(
-        file: Rc<DmaFile>,
-        iovs: S,
-    ) -> OrderedBulkIo<U> {
-        OrderedBulkIo {
-            file,
-            iovs: iovs.collect(),
-        }
-    }
-}
-
-impl<U: Copy + Unpin> Stream for OrderedBulkIo<U> {
-    type Item = (Option<ScheduledSource>, U);
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.iovs.front_mut() {
-            None => Poll::Ready(None),
-            Some((Some(source), _)) => {
-                let res = if source.result().is_some() {
-                    Poll::Ready(Some(self.iovs.pop_front().unwrap()))
-                } else {
-                    Poll::Pending
-                };
-                if let Some((Some(source), _)) = self.iovs.front_mut() {
-                    source.add_waiter_many(cx.waker().clone());
-                }
-                res
-            }
-            Some((None, _)) => Poll::Ready(Some(self.iovs.pop_front().unwrap())),
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.iovs.len(), Some(self.iovs.len()))
-    }
-}
-
 /// An interface to an IO vector.
-pub trait IoVec: Copy {
+pub trait IoVec {
     /// The read position (the offset) in the file
     fn pos(&self) -> u64;
     /// The number of bytes to read at [`Self::pos`]
@@ -72,9 +32,212 @@ impl IoVec for (u64, usize) {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+pub(crate) struct MergedIOVecs<V: IoVec>(pub(crate) VecDeque<V>, pub(crate) (u64, usize));
+
+impl<V: IoVec> MergedIOVecs<V> {
+    fn combine(&mut self, mut other: Self) -> Option<Self> {
+        if self.1 == other.1 {
+            self.0.append(&mut other.0);
+            None
+        } else {
+            Some(std::mem::replace(self, other))
+        }
+    }
+}
+
+impl<V: IoVec> Iterator for MergedIOVecs<V> {
+    type Item = (V, (u64, usize));
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(io) = self.0.pop_front() {
+            Some((io, self.1))
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.0.len(), Some(self.0.len()))
+    }
+}
+
+struct IOVecMerger<V: IoVec> {
+    max_merged_buffer_size: usize,
+    max_read_amp: Option<usize>,
+
+    current: Option<(u64, usize)>,
+    merged: VecDeque<V>,
+}
+
+impl<V: IoVec> IOVecMerger<V> {
+    pub(super) fn merge(&mut self, io: V) -> Option<MergedIOVecs<V>> {
+        let (pos, size) = (io.pos(), io.size());
+        match self.current {
+            None => {
+                self.current = Some((pos, size));
+                self.merged.push_back(io);
+                None
+            }
+            Some(cur) => {
+                if let Some(gap) = self.max_read_amp {
+                    // if the read gap is > to the max configured, don't merge
+                    if u64::saturating_sub(cur.pos(), pos) > gap as u64
+                        || u64::saturating_sub(pos, cur.pos() + cur.size() as u64) > gap as u64
+                    {
+                        return Some(MergedIOVecs(
+                            std::mem::replace(&mut self.merged, VecDeque::from(vec![io])),
+                            self.current.replace((pos, size)).unwrap(),
+                        ));
+                    }
+                }
+                let merged: (u64, u64) = (
+                    min(cur.pos(), pos),
+                    max(cur.pos() + cur.size() as u64, pos + size as u64),
+                );
+                if merged.1 - merged.0 > self.max_merged_buffer_size as u64 {
+                    // if the merged buffer is too large, don't merge
+                    return Some(MergedIOVecs(
+                        std::mem::replace(&mut self.merged, VecDeque::from(vec![io])),
+                        self.current.replace((pos, size)).unwrap(),
+                    ));
+                }
+                self.merged.push_back(io);
+                self.current = Some((merged.0, (merged.1 - merged.0) as usize));
+                None
+            }
+        }
+    }
+
+    pub(super) fn flush(self) -> Option<MergedIOVecs<V>> {
+        self.current.map(|x| MergedIOVecs(self.merged, x))
+    }
+}
+
+pub(crate) struct CoalescedReads<V: IoVec, S: Iterator<Item = V>> {
+    iter: S,
+    merger: Option<IOVecMerger<V>>,
+    alignment: Option<u64>,
+
+    last: Option<MergedIOVecs<V>>,
+}
+
+impl<V: IoVec, S: Iterator<Item = V>> CoalescedReads<V, S> {
+    pub(crate) fn new(
+        iter: S,
+        max_merged_buffer_size: usize,
+        max_read_amp: Option<usize>,
+        alignment: Option<u64>,
+    ) -> CoalescedReads<V, S> {
+        CoalescedReads {
+            iter,
+            merger: Some(IOVecMerger {
+                max_merged_buffer_size,
+                max_read_amp,
+                current: None,
+                merged: Default::default(),
+            }),
+            alignment,
+            last: None,
+        }
+    }
+}
+
+impl<V: IoVec, S: Iterator<Item = V>> Iterator for CoalescedReads<V, S> {
+    // CoalescedReads returns the original (offset, size) and the (offset, size) it
+    // was merged in
+    type Item = MergedIOVecs<V>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let align = |mut merged_iovec: MergedIOVecs<V>, alignment: u64| {
+            let (pos, size) = (merged_iovec.1.0, merged_iovec.1.1);
+            let eff_pos = align_down(pos, alignment);
+            let b = (pos - eff_pos) as usize;
+            merged_iovec.1 = (eff_pos, align_up((size + b) as u64, alignment) as usize);
+            merged_iovec
+        };
+
+        let next_inner = |this: &mut Self| {
+            for io in &mut this.iter {
+                if let Some(merged) = this.merger.as_mut().unwrap().merge(io) {
+                    return Some(merged);
+                }
+            }
+
+            if let Some(merger) = this.merger.take() {
+                merger.flush()
+            } else {
+                None
+            }
+        };
+
+        while let Some(mut inner) = next_inner(self) {
+            if let Some(alignment) = self.alignment {
+                inner = align(inner, alignment);
+            }
+
+            if let Some(last) = &mut self.last {
+                if let Some(last) = last.combine(inner) {
+                    return Some(last);
+                }
+            } else {
+                self.last = Some(inner);
+            }
+        }
+        self.last.take()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct OrderedBulkIo<U> {
+    file: Rc<DmaFile>,
+    iovs: VecDeque<(ScheduledSource, U)>,
+}
+
+impl<U: Unpin> OrderedBulkIo<U> {
+    pub(crate) fn new<S: Iterator<Item = (ScheduledSource, U)>>(
+        file: Rc<DmaFile>,
+        iovs: S,
+    ) -> OrderedBulkIo<U> {
+        OrderedBulkIo {
+            file,
+            iovs: iovs.collect(),
+        }
+    }
+}
+
+impl<U: Unpin> Stream for OrderedBulkIo<U> {
+    type Item = (ScheduledSource, U);
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.iovs.front_mut() {
+            None => Poll::Ready(None),
+            Some((source, _)) => {
+                let res = if source.result().is_some() {
+                    Poll::Ready(Some(self.iovs.pop_front().unwrap()))
+                } else {
+                    Poll::Pending
+                };
+
+                if let Some((source, _)) = self.iovs.front_mut() {
+                    source.add_waiter_many(cx.waker().clone());
+                }
+                res
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.iovs.len(), Some(self.iovs.len()))
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct ReadManyArgs<V: IoVec + Unpin> {
-    pub(crate) user_read: V,
+    pub(crate) user_reads: VecDeque<V>,
     pub(crate) system_read: (u64, usize),
 }
 
@@ -84,114 +247,39 @@ pub(crate) struct ReadManyArgs<V: IoVec + Unpin> {
 #[derive(Debug)]
 pub struct ReadManyResult<V: IoVec + Unpin> {
     pub(crate) inner: OrderedBulkIo<ReadManyArgs<V>>,
-    pub(crate) current: Option<ScheduledSource>,
+    pub(crate) current: Option<(ScheduledSource, ReadManyArgs<V>)>,
 }
 
 impl<V: IoVec + Unpin> Stream for ReadManyResult<V> {
     type Item = super::Result<(V, ReadResult)>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Some((source, args)) = &mut self.current {
+            if let Some(io) = args.user_reads.pop_front() {
+                let (pos, size) = (io.pos(), io.size());
+                return Poll::Ready(Some(Ok((
+                    io,
+                    ReadResult::from_sliced_buffer(
+                        source.clone(),
+                        (pos - args.system_read.pos()) as usize,
+                        size,
+                    ),
+                ))));
+            }
+        }
+
         match ready!(self.inner.poll_next(cx)) {
             None => Poll::Ready(None),
             Some((source, args)) => {
-                if let Some(source) = source {
-                    enhanced_try!(source.result().unwrap(), "Reading", self.inner.file)?;
-                    self.current = Some(source);
-                }
-                Poll::Ready(Some(Ok((
-                    args.user_read,
-                    ReadResult::from_sliced_buffer(
-                        self.current.as_ref().unwrap().clone(),
-                        (args.user_read.pos() - args.system_read.pos()) as usize,
-                        args.user_read.size(),
-                    ),
-                ))))
+                enhanced_try!(source.result().unwrap(), "Reading", self.inner.file)?;
+                self.current = Some((source, args));
+                self.poll_next(cx)
             }
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-pub(crate) struct CoalescedReads<V: IoVec, S: Iterator<Item = V>> {
-    iter: MultiPeek<S>,
-    next_merged: Option<(usize, (u64, usize))>,
-    max_merged_buffer_size: usize,
-    max_read_amp: Option<usize>,
-}
-
-impl<V: IoVec, S: Iterator<Item = V>> CoalescedReads<V, S> {
-    pub(crate) fn new(
-        iter: S,
-        max_merged_buffer_size: usize,
-        max_read_amp: Option<usize>,
-    ) -> CoalescedReads<V, S> {
-        CoalescedReads {
-            iter: iter.multipeek(),
-            next_merged: None,
-            max_merged_buffer_size,
-            max_read_amp,
-        }
-    }
-}
-
-impl<V: IoVec, S: Iterator<Item = V>> Iterator for CoalescedReads<V, S> {
-    // CoalescedReads returns the original (offset, size) and the (offset, size) it
-    // was merged in
-    type Item = (V, (u64, usize));
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(next) = self.next_merged {
-            if next.0 == 1 {
-                self.next_merged = None;
-            } else {
-                self.next_merged = Some((next.0 - 1, next.1));
-            }
-            return Some((self.iter.next().unwrap(), next.1));
-        }
-
-        let mut current: Option<(u64, usize)> = None;
-        let mut taken = 0;
-        while let Some(x) = self.iter.peek() {
-            match current {
-                None => {
-                    current = Some((x.pos(), x.size()));
-                    taken = 1;
-                    continue;
-                }
-                Some(cur) => {
-                    if let Some(gap) = self.max_read_amp {
-                        // if the read gap is > to the max configured, don't merge
-                        if u64::saturating_sub(cur.pos(), x.pos()) > gap as u64 {
-                            break;
-                        }
-                        if u64::saturating_sub(x.pos(), cur.pos() + cur.size() as u64) > gap as u64
-                        {
-                            break;
-                        }
-                    }
-                    let merged: (u64, u64) = (
-                        min(cur.pos(), x.pos()),
-                        max(cur.pos() + cur.size() as u64, x.pos() + x.size() as u64),
-                    );
-                    if merged.1 - merged.0 > self.max_merged_buffer_size as u64 {
-                        // if the merged buffer is too large, don't merge
-                        break;
-                    }
-                    taken += 1;
-                    current = Some((merged.0, (merged.1 - merged.0) as usize));
-                }
-            }
-        }
-
-        if taken > 0 {
-            self.next_merged = Some((taken, current.unwrap()));
-            self.next()
-        } else {
-            None
-        }
     }
 }
 
@@ -204,7 +292,9 @@ mod tests {
         let reads: Vec<(u64, usize)> =
             vec![(0, 64), (0, 256), (32, 4064), (4095, 10), (8192, 4096)];
         let merged: Vec<((u64, usize), (u64, usize))> =
-            CoalescedReads::new(reads.iter().copied(), 4096, None).collect();
+            CoalescedReads::new(reads.iter().copied(), 4096, None, None)
+                .flatten()
+                .collect();
 
         assert_eq!(
             merged,
@@ -223,7 +313,9 @@ mod tests {
         let reads: Vec<(u64, usize)> =
             vec![(0, 64), (0, 256), (32, 4064), (4095, 10), (8192, 4096)];
         let merged: Vec<((u64, usize), (u64, usize))> =
-            CoalescedReads::new(reads.iter().copied(), 500, None).collect();
+            CoalescedReads::new(reads.iter().copied(), 500, None, None)
+                .flatten()
+                .collect();
 
         assert_eq!(
             merged,
@@ -237,7 +329,9 @@ mod tests {
         );
 
         let merged: Vec<((u64, usize), (u64, usize))> =
-            CoalescedReads::new(reads.iter().copied(), 0, None).collect();
+            CoalescedReads::new(reads.iter().copied(), 0, None, None)
+                .flatten()
+                .collect();
 
         assert_eq!(
             merged,
@@ -255,7 +349,9 @@ mod tests {
     fn nonmonotonic_iovec_merging() {
         let reads: Vec<(u64, usize)> = vec![(64, 256), (32, 4064), (4095, 10), (8192, 4096)];
         let merged: Vec<((u64, usize), (u64, usize))> =
-            CoalescedReads::new(reads.iter().copied(), 4096, None).collect();
+            CoalescedReads::new(reads.iter().copied(), 4096, None, None)
+                .flatten()
+                .collect();
 
         assert_eq!(
             merged,
@@ -279,7 +375,9 @@ mod tests {
             (0, 256),
         ];
         let merged: Vec<((u64, usize), (u64, usize))> =
-            CoalescedReads::new(reads.iter().copied(), 4096, Some(0)).collect();
+            CoalescedReads::new(reads.iter().copied(), 4096, Some(0), None)
+                .flatten()
+                .collect();
 
         assert_eq!(
             merged,
@@ -294,7 +392,9 @@ mod tests {
         );
 
         let merged: Vec<((u64, usize), (u64, usize))> =
-            CoalescedReads::new(reads.iter().copied(), 4096, Some(32)).collect();
+            CoalescedReads::new(reads.iter().copied(), 4096, Some(32), None)
+                .flatten()
+                .collect();
 
         assert_eq!(
             merged,
@@ -303,6 +403,34 @@ mod tests {
                 ((128, 1), (64, 192)),
                 ((160, 96), (64, 192)),
                 ((96, 160), (64, 192)),
+                ((64, 192), (64, 192)),
+                ((0, 256), (0, 256)),
+            ]
+        );
+    }
+
+    #[test]
+    fn read_no_coalescing() {
+        let reads: Vec<(u64, usize)> = vec![
+            (128, 128),
+            (128, 1),
+            (160, 96),
+            (96, 160),
+            (64, 192),
+            (0, 256),
+        ];
+        let merged: Vec<((u64, usize), (u64, usize))> =
+            CoalescedReads::new(reads.iter().copied(), 0, Some(0), None)
+                .flatten()
+                .collect();
+
+        assert_eq!(
+            merged,
+            [
+                ((128, 128), (128, 128)),
+                ((128, 1), (128, 1)),
+                ((160, 96), (160, 96)),
+                ((96, 160), (96, 160)),
                 ((64, 192), (64, 192)),
                 ((0, 256), (0, 256)),
             ]

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -11,7 +11,7 @@ use crate::{
         read_result::ReadResult,
         ScheduledSource,
     },
-    sys::{self, sysfs, DirectIo, DmaBuffer, PollableStatus},
+    sys::{self, sysfs, DirectIo, DmaBuffer, PollableStatus, RING_SUBMISSION_DEPTH},
 };
 use futures_lite::{Stream, StreamExt};
 use nix::sys::statfs::*;
@@ -323,7 +323,7 @@ impl DmaFile {
             )
         });
         ReadManyResult {
-            inner: OrderedBulkIo::new(self.clone(), 128, it),
+            inner: OrderedBulkIo::new(self.clone(), RING_SUBMISSION_DEPTH, it),
             current: Default::default(),
         }
     }

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -323,7 +323,7 @@ impl DmaFile {
             )
         });
         ReadManyResult {
-            inner: OrderedBulkIo::new(self.clone(), it),
+            inner: OrderedBulkIo::new(self.clone(), 128, it),
             current: Default::default(),
         }
     }

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -303,6 +303,7 @@ impl DmaFile {
         S: Stream<Item = V> + Unpin,
     {
         let file = self.clone();
+        let reactor = file.file.reactor.upgrade().unwrap();
         let it = CoalescedReads::new(
             max_merged_buffer_size,
             max_read_amp,
@@ -310,7 +311,6 @@ impl DmaFile {
             iovs,
         )
         .map(move |iov| {
-            let reactor = file.file.reactor.upgrade().unwrap();
             let fd = file.as_raw_fd();
             let pollable = file.pollable;
             let scheduler = file.file.scheduler.borrow();

--- a/glommio/src/io/sched.rs
+++ b/glommio/src/io/sched.rs
@@ -187,7 +187,7 @@ impl<'a> KeyAdapter<'a> for ScheduledSourceAdapter {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ScheduledSource {
+pub struct ScheduledSource {
     inner: Rc<ScheduledSourceInner>,
     file: Weak<FileSchedulerInner>,
     offseted_range: Range<u64>,


### PR DESCRIPTION
Instead of taking an iterator of (offsets, positions), make it a stream.

The reason behind doing this is that using an iterator forces us to
schedule all the IO synchronously at call-time (or keep them in memory
which isn't great either). While this is fine when dealing with a small
number of requests (and -marginally- more efficient) it becomes
problematic as the number of IO requests increases.

Specifically, doing this may starve other tasks performing IO in the same
task queue since the reactor submits IO requests to the device in FIFO
order. Therefore, if two concurrent tasks call `read_many` they will
race and all the IO submitted by the first task will be processed before
a single IO from the second reaches the IO ring. This is obviously wrong
as we want some amount of fairness even within a common task queue.

Another use case is when performing parallel calls to `read_many` with
the intention of zipping the resulting streams. For instance, if some
data is spread in many files we may want to fetch data in parallel and
combine the result asynchronously.

The `read_many` stream now eagerly consumes the input stream until
it yields or until we reach 128 in-flight sources. This allows a maximum
of 128 sources to run concurrently. After that, the stream will wait until
the first source is fulfilled.

128 is a constant for now and was chosen to match the depth of our
io_uring submission queues. Although this value is a constant right now,
a further improvement would be to make it dynamic to maximize
throughput and lower IO latency on the fly.

Baby steps! 