### PR TITLE
add a stall detector that logs stacktraces of unyielding tasks

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -17,6 +17,7 @@ readme = "../README.md"
 
 [dependencies]
 ahash = "~0.7"
+backtrace = { version = "0.3.61", optional = true }
 bitflags = "1.3"
 bitmaps = "3.1.0"
 buddy-alloc = "~0.4"
@@ -35,6 +36,7 @@ pin-project-lite = "~0.2"
 rlimit = "~0.6"
 scoped-tls = "1.0.0"
 scopeguard = "1.1"
+signal-hook = { version = "0.3.10", optional = true }
 sketches-ddsketch = "0.1"
 smallvec = { version = "1.7", features = ["union"] }
 socket2 = { version = "~0.3", features = ["unix", "reuseport"] }
@@ -45,6 +47,7 @@ typenum = "1.14"
 fastrand = "1.5"
 futures = "~0.3"
 hdrhistogram = "7.3.0"
+logtest = "2.0.0"
 pretty_env_logger = "~0.4"
 rand = "~0.8"
 tokio = { version = "1.12", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time", "sync"] }
@@ -56,7 +59,7 @@ cc = "1.0"
 [features]
 bench = []
 debugging = []
-stall-detection = []
+stall-detection = ["signal-hook", "backtrace"]
 
 [[bench]]
 name = "executor"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -56,6 +56,7 @@ cc = "1.0"
 [features]
 bench = []
 debugging = []
+stall-detection = []
 
 [[bench]]
 name = "executor"

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -35,6 +35,7 @@
 mod latch;
 mod multitask;
 mod placement;
+mod stall;
 
 use latch::{Latch, LatchState};
 pub use placement::{CpuSet, Placement, PoolPlacement};
@@ -59,6 +60,8 @@ use scoped_tls::scoped_thread_local;
 
 use log::warn;
 
+#[cfg(feature = "stall-detection")]
+use crate::executor::stall::StallDetector;
 use crate::{
     error::BuilderErrorKind,
     parking,
@@ -122,7 +125,7 @@ pub(crate) struct TaskQueue {
     shares: Shares,
     vruntime: u64,
     io_requirements: IoRequirements,
-    _name: String,
+    name: String,
     last_adjustment: Instant,
     // for dynamic shares classes
     yielded: bool,
@@ -167,7 +170,7 @@ impl TaskQueue {
             shares,
             vruntime: 0,
             io_requirements: ioreq,
-            _name: name.into(),
+            name: name.into(),
             last_adjustment: Instant::now(),
             yielded: false,
         }))
@@ -936,6 +939,9 @@ pub struct LocalExecutor {
     parker: parking::Parker,
     id: usize,
     reactor: Rc<reactor::Reactor>,
+
+    #[cfg(feature = "stall-detection")]
+    stall_detector: StallDetector,
 }
 
 impl LocalExecutor {
@@ -979,7 +985,8 @@ impl LocalExecutor {
         }
         let p = parking::Parker::new();
         let queues = ExecutorQueues::new(preempt_timer, spin_before_park);
-        trace!(id = notifier.id(), "Creating executor");
+        let exec_id = notifier.id();
+        trace!(id = exec_id, "Creating executor");
         Ok(LocalExecutor {
             queues: Rc::new(RefCell::new(queues)),
             parker: p,
@@ -990,6 +997,8 @@ impl LocalExecutor {
                 ring_depth,
                 record_io_latencies,
             )),
+            #[cfg(feature = "stall-detection")]
+            stall_detector: StallDetector::new(exec_id)?,
         })
     }
 
@@ -1147,43 +1156,38 @@ impl LocalExecutor {
                     now
                 };
 
-                let mut tasks_executed_this_loop = 0;
-                loop {
-                    let mut queue_ref = queue.borrow_mut();
-                    if self.need_preempt() || queue_ref.yielded() {
-                        break;
-                    }
+                let (runtime, tasks_executed_this_loop) = {
+                    #[cfg(feature = "stall-detection")]
+                    let _stall_detector_guard = self
+                        .stall_detector
+                        .enter_task_queue(
+                            queue.borrow_mut().name.clone(),
+                            time,
+                            self.preempt_timer_duration(),
+                        )
+                        .unwrap();
 
-                    if let Some(r) = queue_ref.get_task() {
-                        drop(queue_ref);
-                        r.run();
-                        tasks_executed_this_loop += 1;
-                    } else {
-                        break;
-                    }
-                }
+                    let mut tasks_executed_this_loop = 0;
+                    loop {
+                        let mut queue_ref = queue.borrow_mut();
+                        if self.need_preempt() || queue_ref.yielded() {
+                            break;
+                        }
 
-                let runtime = time.elapsed();
-
-                let (need_repush, last_vruntime) = {
-                    let mut state = queue.borrow_mut();
-
-                    if cfg!(feature = "stall-detection") {
-                        // we consider a queue to be stalling the system if it returned more than a
-                        // millisecond after it should have. i.e. a task queue has 1ms after
-                        // `need_preempt()`returns true to yield.
-                        let stall_threshold = self
-                            .preempt_timer_duration()
-                            .saturating_add(Duration::from_millis(1))
-                            .max(Duration::from_millis(5));
-                        if runtime > stall_threshold {
-                            warn!(
-                                "Reactor stall! {} : {} {:?} > {:?}",
-                                &self.id, &state.name, runtime, stall_threshold
-                            );
+                        if let Some(r) = queue_ref.get_task() {
+                            drop(queue_ref);
+                            r.run();
+                            tasks_executed_this_loop += 1;
+                        } else {
+                            break;
                         }
                     }
 
+                    (time.elapsed(), tasks_executed_this_loop)
+                };
+
+                let (need_repush, last_vruntime) = {
+                    let mut state = queue.borrow_mut();
                     let last_vruntime = state.account_vruntime(runtime);
                     (state.is_active(), last_vruntime)
                 };

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -57,6 +57,8 @@ use std::{
 use futures_lite::pin;
 use scoped_tls::scoped_thread_local;
 
+use log::warn;
+
 use crate::{
     error::BuilderErrorKind,
     parking,
@@ -1165,6 +1167,13 @@ impl LocalExecutor {
 
                 let (need_repush, last_vruntime) = {
                     let mut state = queue.borrow_mut();
+                    if runtime > Duration::from_millis(5) {
+                        warn!(
+                            "Reactor stall! {} : {} {:?}",
+                            &self.id, &state.name, runtime
+                        );
+                    }
+
                     let last_vruntime = state.account_vruntime(runtime);
                     (state.is_active(), last_vruntime)
                 };

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -1167,18 +1167,21 @@ impl LocalExecutor {
 
                 let (need_repush, last_vruntime) = {
                     let mut state = queue.borrow_mut();
-                    // we consider a queue to be stalling the system if it returned more than a
-                    // millisecond after it should have. i.e. a task queue has 1ms after
-                    // `need_preempt()`returns true to yield.
-                    let stall_threshold = self
-                        .preempt_timer_duration()
-                        .saturating_add(Duration::from_millis(1))
-                        .max(Duration::from_millis(5));
-                    if runtime > stall_threshold {
-                        warn!(
-                            "Reactor stall! {} : {} {:?} > {:?}",
-                            &self.id, &state.name, runtime, stall_threshold
-                        );
+
+                    if cfg!(feature = "stall-detection") {
+                        // we consider a queue to be stalling the system if it returned more than a
+                        // millisecond after it should have. i.e. a task queue has 1ms after
+                        // `need_preempt()`returns true to yield.
+                        let stall_threshold = self
+                            .preempt_timer_duration()
+                            .saturating_add(Duration::from_millis(1))
+                            .max(Duration::from_millis(5));
+                        if runtime > stall_threshold {
+                            warn!(
+                                "Reactor stall! {} : {} {:?} > {:?}",
+                                &self.id, &state.name, runtime, stall_threshold
+                            );
+                        }
                     }
 
                     let last_vruntime = state.account_vruntime(runtime);

--- a/glommio/src/executor/stall.rs
+++ b/glommio/src/executor/stall.rs
@@ -1,0 +1,283 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the MIT/Apache-2.0 License, at your convenience
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+//
+#![allow(dead_code)]
+
+use nix::sys;
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread::JoinHandle,
+    time::{Duration, Instant},
+};
+
+#[cfg(feature = "stall-detection")]
+thread_local! {
+    static STALL_STRACE_COLLECTOR: (
+        crossbeam::channel::Sender<backtrace::BacktraceFrame>,
+        crossbeam::channel::Receiver<backtrace::BacktraceFrame>
+    ) = crossbeam::channel::bounded(1 << 10);
+}
+
+#[cfg(feature = "stall-detection")]
+lazy_static! {
+    static ref STALL_SIG_HANDLER: signal_hook::SigId = unsafe {
+        signal_hook::low_level::register(signal_hook::consts::SIGUSR1, move || {
+            STALL_STRACE_COLLECTOR.with(|collector| {
+                if collector.0.is_full() {
+                    return;
+                }
+
+                backtrace::trace_unsynchronized(|frame| {
+                    collector
+                        .0
+                        .try_send(backtrace::BacktraceFrame::from(frame.clone()))
+                        .is_ok()
+                });
+            });
+        })
+    }
+    .unwrap();
+}
+
+#[derive(Debug)]
+pub(crate) struct StallDetector {
+    timer: Arc<sys::timerfd::TimerFd>,
+    handler: Option<JoinHandle<()>>,
+    id: usize,
+    terminated: Arc<AtomicBool>,
+}
+
+impl StallDetector {
+    #[cfg(feature = "stall-detection")]
+    pub(crate) fn new(executor_id: usize) -> std::io::Result<StallDetector> {
+        lazy_static::initialize(&STALL_SIG_HANDLER);
+
+        let timer = Arc::new(
+            sys::timerfd::TimerFd::new(
+                sys::timerfd::ClockId::CLOCK_MONOTONIC,
+                sys::timerfd::TimerFlags::empty(),
+            )
+            .map_err(std::io::Error::from)?,
+        );
+        let tid = unsafe { nix::libc::pthread_self() };
+        let terminated = Arc::new(AtomicBool::new(false));
+        let timer_handler = std::thread::spawn(enclose::enclose! { (terminated, timer) move || {
+            while timer.wait().is_ok() {
+                if terminated.load(Ordering::Acquire) {
+                    return
+                }
+                unsafe { nix::libc::pthread_kill(tid, nix::libc::SIGUSR1) };
+            }
+        }});
+
+        Ok(Self {
+            timer,
+            handler: Some(timer_handler),
+            id: executor_id,
+            terminated,
+        })
+    }
+
+    pub(crate) fn enter_task_queue(
+        &self,
+        queue_name: String,
+        start: Instant,
+        max_expected_runtime: Duration,
+    ) -> nix::Result<StallDetectorGuard<'_>> {
+        // We consider a queue to be stalling the system if it failed to yield in due
+        // time. For a given maximum expected runtime, we allow a margin of error f 10%
+        // (and an absolute minimum of 10ms) after which we record a stacktrace. i.e. a
+        // task queue has should return shortly after `need_preempt()` returns
+        // true or the stall detector triggers. For example::
+        // * If a task queue has a preempt timer of 100ms the the stall detector
+        // triggers if it doesn't yield after running for 110ms.
+        // * If a task queue has a preempt timer of 100ms the the stall detector
+        // triggers if it doesn't yield after running for 15ms.
+
+        let error_margin =
+            Duration::from_millis((max_expected_runtime.as_millis() as f64 * 0.1) as u64)
+                .max(Duration::from_millis(10));
+        StallDetectorGuard::new(
+            self,
+            queue_name,
+            start,
+            max_expected_runtime.saturating_add(error_margin),
+        )
+    }
+
+    fn arm(&self, threshold: Duration) -> nix::Result<()> {
+        self.timer.set(
+            sys::timerfd::Expiration::OneShot(sys::time::TimeSpec::from(threshold)),
+            sys::timerfd::TimerSetTimeFlags::empty(),
+        )
+    }
+
+    fn disarm(&self) -> nix::Result<()> {
+        self.timer.unset()
+    }
+}
+
+impl Drop for StallDetector {
+    fn drop(&mut self) {
+        let timer_handler = self.handler.take().unwrap();
+        self.terminated.store(true, Ordering::Release);
+
+        self.timer
+            .set(
+                sys::timerfd::Expiration::Interval(sys::time::TimeSpec::from(
+                    Duration::from_millis(1),
+                )),
+                sys::timerfd::TimerSetTimeFlags::empty(),
+            )
+            .expect("failed wake the timer for termination");
+
+        let _ = timer_handler.join();
+    }
+}
+
+pub(crate) struct StallDetectorGuard<'detector> {
+    detector: &'detector StallDetector,
+    queue_name: String,
+    start: Instant,
+    threshold: Duration,
+}
+
+impl<'detector> StallDetectorGuard<'detector> {
+    fn new(
+        detector: &'detector StallDetector,
+        queue_name: String,
+        start: Instant,
+        threshold: Duration,
+    ) -> nix::Result<Self> {
+        detector.disarm().unwrap();
+        detector.arm(threshold).unwrap();
+        Ok(Self {
+            detector,
+            queue_name,
+            start,
+            threshold,
+        })
+    }
+}
+
+#[cfg(feature = "stall-detection")]
+impl<'detector> Drop for StallDetectorGuard<'detector> {
+    fn drop(&mut self) {
+        let _ = self.detector.disarm();
+
+        let mut strace = STALL_STRACE_COLLECTOR.with(|collector| {
+            let mut frames = vec![];
+            while let Ok(frame) = collector.1.try_recv() {
+                frames.push(frame);
+            }
+            backtrace::Backtrace::from(frames)
+        });
+
+        if strace.frames().is_empty() {
+            return;
+        }
+
+        let elapsed = self.start.elapsed();
+        strace.resolve();
+        log::warn!(
+            "[stall-detector -- executor {}] task queue {} went over-budget: {:#?} (budget: \
+             {:#?}). Backtrace: {:#?}",
+            self.detector.id,
+            &self.queue_name,
+            elapsed,
+            self.threshold,
+            strace,
+        );
+    }
+}
+
+#[cfg(all(test, feature = "stall-detection"))]
+mod test {
+    use crate::{timer::sleep, LocalExecutorBuilder};
+    use logtest::Logger;
+    use std::time::{Duration, Instant};
+
+    enum ExpectedLog {
+        Expected(&'static str),
+        NotExpected(&'static str),
+    }
+
+    fn search_logs_for(logger: &mut Logger, expected: ExpectedLog) -> bool {
+        let mut found = false;
+        while let Some(event) = logger.pop() {
+            match expected {
+                ExpectedLog::Expected(str) => found |= event.args().contains(str),
+                ExpectedLog::NotExpected(str) => found |= event.args().contains(str),
+            }
+        }
+
+        match expected {
+            ExpectedLog::Expected(_) => found,
+            ExpectedLog::NotExpected(_) => !found,
+        }
+    }
+
+    #[test]
+    fn executor_stall_detector() {
+        LocalExecutorBuilder::default()
+            .preempt_timer(Duration::from_millis(50))
+            .make()
+            .unwrap()
+            .run(async {
+                let mut logger = Logger::start();
+                let now = Instant::now();
+
+                // will trigger the stall detector because we go over budget
+                while now.elapsed() < Duration::from_millis(100) {}
+
+                assert!(search_logs_for(
+                    &mut logger,
+                    ExpectedLog::NotExpected("task queue default went over-budget"),
+                ));
+
+                crate::executor().yield_task_queue_now().await; // yield the queue
+
+                assert!(search_logs_for(
+                    &mut logger,
+                    ExpectedLog::Expected("task queue default went over-budget")
+                ));
+
+                // no stall because < 50ms of un-cooperativeness
+                let now = Instant::now();
+                while now.elapsed() < Duration::from_millis(40) {}
+
+                assert!(search_logs_for(
+                    &mut logger,
+                    ExpectedLog::NotExpected("task queue default went over-budget"),
+                ));
+
+                crate::executor().yield_task_queue_now().await; // yield the queue
+
+                // no stall because a timer yields internally
+                sleep(Duration::from_millis(100)).await;
+
+                crate::executor().yield_task_queue_now().await; // yield the queue
+
+                assert!(search_logs_for(
+                    &mut logger,
+                    ExpectedLog::NotExpected("task queue default went over-budget"),
+                ));
+
+                // trigger one last time
+                let now = Instant::now();
+                while now.elapsed() < Duration::from_millis(100) {}
+
+                crate::executor().yield_task_queue_now().await; // yield the queue
+
+                assert!(search_logs_for(
+                    &mut logger,
+                    ExpectedLog::Expected("task queue default went over-budget")
+                ));
+            });
+    }
+}


### PR DESCRIPTION
This PR adds a rudimentary stall detection mechanism to Glommio.

It measures the runtime of task queues and logs if they don't yield when
they are due. 

Knowing if a queue is stalling the reactor is nice, but finding the 
exact code location where the stall occurs remains very hard. Especially
if a task queue hosts many concurrent fibers.

To help with that, this PR introduces a stall detection mechanism that
records stack traces of stalling tasks. It works as follows:
* When a task queue is scheduled for execution, we set up a timer that
triggers some time after the queue is expected to yield (we add a 10%
error margin to avoid false positives). A background thread collocated
with the local executor waits on the timer at all times.
* When the timer fires, the thread sends a signal (`SIGUSR1`) to the 
local executor thread. Upon receiving the signal, the local executor 
records a complete trace of the local stack. Here we take advantage of 
the fact that by default, the kernel invokes signal handlers on top of 
the existing stack. i.e. the frames we record are those of the 
problematic user code that was meant to yield. The recorded frames are 
pushed on a non-blocking communication channel that links the signal 
handler and the local executor.
* When a task queue yields, the local executor disarm the timer and
checks the communication channel for potential recorded frames, if there
are any then we can conclude that the queue stalled, so we log them.

This code works in practice but has two major drawbacks:
* The timer dance is expensive; expect a high number of syscalls. 
Because of this runtime overhead, the stall detector is disabled by 
default. To opt-in, the feature `stall-detection` must be enabled at 
compile-time.
* We log stalls only after the queue yield. Therefore, if there is a bug
in your code and your queue never yields, the stall detector will never
log the code location that's at fault (even though we probably have
recorded the trace by then). The reason for this is that logging from a
signal handler is illegal.