### PR TITLE
Add GH Actions workflow for CI

### DIFF
--- a/.github/actions/cache-setup/action.yml
+++ b/.github/actions/cache-setup/action.yml
@@ -1,0 +1,30 @@
+name: Cache setup
+
+description: Setups up the cache for Rust-based steps
+
+inputs: {}
+outputs: {}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Version information
+      run: rustc --version; cargo --version; rustup --version
+      shell: bash
+
+    - name: Calculate dependencies
+      run: cargo generate-lockfile
+      shell: bash
+
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/debug/.fingerprint
+          target/debug/build
+          target/debug/dep
+        key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+    types: ["opened", "synchronize"]
+  push:
+    branches: [master]
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache setup
+        uses: ./.github/actions/cache-setup
+
+      - name: Install nightly for rustfmt features
+        run: |
+          FMT_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustfmt)
+          rustup install nightly
+          rustup default "$FMT_NIGHTLY"
+          rustup component add rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  doc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache setup
+        uses: ./.github/actions/cache-setup
+
+      - name: Install cargo-deadlinks
+        run: cargo install cargo-deadlinks
+
+      - name: Generate documentation
+        run: cargo doc --all-features
+
+    # temporarily disabled.
+    # - name: Validate links
+    #   run: cargo deadlinks --dir target/doc/glommio
+
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache setup
+        uses: ./.github/actions/cache-setup
+
+      - name: Run linters
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache setup
+        uses: ./.github/actions/cache-setup
+
+      - name: Build all targets
+        run: cargo build --all --all-targets --all-features
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache setup
+        uses: ./.github/actions/cache-setup
+
+      - name: Set limits
+        run: ulimit -Sl 512; ulimit -Hl 512
+
+      - name: Test all targets
+        run: cargo test --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,5 @@ jobs:
       - name: Cache setup
         uses: ./.github/actions/cache-setup
 
-      - name: Set limits
-        run: ulimit -Sl 512; ulimit -Hl 512
-
       - name: Test all targets
-        run: cargo test --all-features
+        run: sudo bash -c "ulimit -Sl 512 && ulimit -Hl 512 && PATH=$PATH:/usr/share/rust/.cargo/bin && RUSTUP_TOOLCHAIN=stable cargo test --all-features"


### PR DESCRIPTION
### What does this PR do?

The goal is to replace CircleCI with Github Actions. This PR adds the
latter, so CircleCI can be removed in a follow-up.

### Motivation

Mainly not requiring contributors to sign up to CircleCI, but also the ability
to run unit tests on CI, and eventually move to self-hosted runners for more
beefy machines.

### Related issues

### Additional Notes

The repo will need to be configured to require the Github Actions checks instead
of the CircleCI ones.

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
