### PR TITLE
Fix drop_join_handle_before_completion test

### DIFF
--- a/glommio/src/task/tests.rs
+++ b/glommio/src/task/tests.rs
@@ -97,7 +97,11 @@ mod ref_count {
         init_logger();
         let result = LocalExecutorPoolBuilder::new(1).on_all_shards(|| async move {
             TaskDebugger::set_label("drop_join_handle_before_completion");
-            let handle = Local::local(async {}).detach();
+            assert_eq!(1, TaskDebugger::task_count());
+            let handle = Local::local(async {
+                yield_now().await;
+            })
+            .detach();
             assert_eq!(2, TaskDebugger::task_count());
             drop(handle);
             assert_eq!(2, TaskDebugger::task_count());


### PR DESCRIPTION
### What does this PR do?

Now that tasks are run right away, it becomes completed and is dropped
when dropping the join handle. Add a yield to make the task remain
active.

### Motivation

Fixing a failing test.

### Related issues

### Additional Notes

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
