### PR TITLE
Make CpuSet an actual set interface

### DIFF
--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -189,17 +189,7 @@ pub struct CpuSet(HashSet<CpuLocation>);
 impl FromIterator<CpuLocation> for CpuSet
 {
     fn from_iter<I: IntoIterator<Item = CpuLocation>>(cpus: I) -> Self {
-        let iter = cpus.into_iter();
-        let (_, size) = iter.size_hint();
-        let mut set = if let Some(size) = size {
-            HashSet::with_capacity(size)
-        } else {
-            HashSet::new()
-        };
-        for cpu in iter {
-            set.insert(cpu);
-        }
-        Self(set)
+        Self(HashSet::<CpuLocation>::from_iter(cpus.into_iter()))
     }
 }
 

--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -938,10 +938,16 @@ mod test {
                     .cpu_binding()
                     .unwrap()
                     .into_iter()
-                    .collect::<Vec<_>>();
+                    .collect::<HashSet<_>>();
                 bindings.push(v);
             }
-            assert_eq!(bindings, vec![vec![1, 4, 0, 5], vec![1, 3, 0, 2]]);
+            assert_eq!(
+                bindings,
+                vec![
+                    HashSet::from_iter(vec![1, 4, 0, 5]),
+                    HashSet::from_iter(vec![1, 3, 0, 2])
+                ]
+            );
         }
         {
             let p = Placement::Custom(vec![set1.clone(), set2.clone()]);

--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -55,9 +55,11 @@ use pq_tree::{
     Node,
 };
 use std::{
-    collections::hash_map::RandomState,
-    collections::hash_set::{Difference, Intersection, IntoIter, Iter, SymmetricDifference, Union},
-    collections::HashSet,
+    collections::{
+        hash_map::RandomState,
+        hash_set::{Difference, Intersection, IntoIter, Iter, SymmetricDifference, Union},
+        HashSet,
+    },
     convert::TryInto,
     iter::FromIterator,
 };
@@ -186,8 +188,7 @@ impl Default for Placement {
 #[derive(Clone, Debug, PartialEq)]
 pub struct CpuSet(HashSet<CpuLocation>);
 
-impl FromIterator<CpuLocation> for CpuSet
-{
+impl FromIterator<CpuLocation> for CpuSet {
     fn from_iter<I: IntoIterator<Item = CpuLocation>>(cpus: I) -> Self {
         Self(HashSet::<CpuLocation>::from_iter(cpus.into_iter()))
     }
@@ -251,7 +252,8 @@ impl CpuSet {
         self.0.is_empty()
     }
 
-    /// An iterator visiting all [`CpuLocation`]s in this CpuSet in arbitrary order.
+    /// An iterator visiting all [`CpuLocation`]s in this CpuSet in arbitrary
+    /// order.
     pub fn iter(&self) -> Iter<'_, CpuLocation> {
         self.0.iter()
     }
@@ -267,44 +269,50 @@ impl CpuSet {
         self.0.contains(value)
     }
 
-    /// Visits the [`CpuLocation`]s representing the difference, i.e., the values that are in self but not in
-    /// other.
+    /// Visits the [`CpuLocation`]s representing the difference, i.e., the
+    /// values that are in self but not in other.
     pub fn difference<'a>(&'a self, other: &'a Self) -> Difference<'a, CpuLocation, RandomState> {
         self.0.difference(&other.0)
     }
 
-    /// Visits the [`CpuLocation`]s representing the intersection, i.e., the values that are both in self and
-    /// other.
-    pub fn intersection<'a>(&'a self, other: &'a Self) -> Intersection<'a, CpuLocation, RandomState> {
+    /// Visits the [`CpuLocation`]s representing the intersection, i.e., the
+    /// values that are both in self and other.
+    pub fn intersection<'a>(
+        &'a self,
+        other: &'a Self,
+    ) -> Intersection<'a, CpuLocation, RandomState> {
         self.0.intersection(&other.0)
     }
 
-    /// Returns true if self has no [`CpuLocation`]s in common with other. This is equivalent to checking
-    /// for an empty intersection.
+    /// Returns true if self has no [`CpuLocation`]s in common with other. This
+    /// is equivalent to checking for an empty intersection.
     pub fn is_disjoint(&self, other: &Self) -> bool {
         self.0.is_disjoint(&other.0)
     }
 
-    /// Returns true if this `CpuSet` is a subset of another, i.e., other contains at least all the
-    /// values in self.
+    /// Returns true if this `CpuSet` is a subset of another, i.e., other
+    /// contains at least all the values in self.
     pub fn is_subset(&self, other: &Self) -> bool {
         self.0.is_subset(&other.0)
     }
 
-    /// Returns true if this `CpuSet` is a superset of another, i.e., self contains at least all the
-    /// values in other.
+    /// Returns true if this `CpuSet` is a superset of another, i.e., self
+    /// contains at least all the values in other.
     pub fn is_superset(&self, other: &Self) -> bool {
         self.0.is_superset(&other.0)
     }
 
-    /// Visits the [`CpuLocation`]s representing the symmetric difference, i.e., the values that are in self
-    /// or in other but not in both.
-    pub fn symmetric_difference<'a>(&'a self, other: &'a Self) -> SymmetricDifference<'a, CpuLocation, RandomState> {
+    /// Visits the [`CpuLocation`]s representing the symmetric difference, i.e.,
+    /// the values that are in self or in other but not in both.
+    pub fn symmetric_difference<'a>(
+        &'a self,
+        other: &'a Self,
+    ) -> SymmetricDifference<'a, CpuLocation, RandomState> {
         self.0.symmetric_difference(&other.0)
     }
 
-    /// Visits the [`CpuLocation`]s representing the union, i.e., all the values in self or other, without
-    /// duplicates.
+    /// Visits the [`CpuLocation`]s representing the union, i.e., all the values
+    /// in self or other, without duplicates.
     pub fn union<'a>(&'a self, other: &'a Self) -> Union<'a, CpuLocation, RandomState> {
         self.0.union(&other.0)
     }
@@ -958,12 +966,8 @@ mod test {
         assert!(xs.is_disjoint(&ys));
         assert!(ys.is_disjoint(&xs));
 
-        let xs = CpuSet::from_iter(vec![
-            cpu_loc(0, 0, 0, 2),
-        ]);
-        let ys = CpuSet::from_iter(vec![
-            cpu_loc(1, 1, 1, 5),
-        ]);
+        let xs = CpuSet::from_iter(vec![cpu_loc(0, 0, 0, 2)]);
+        let ys = CpuSet::from_iter(vec![cpu_loc(1, 1, 1, 5)]);
         assert!(xs.is_disjoint(&ys));
         assert!(ys.is_disjoint(&xs));
 
@@ -990,12 +994,8 @@ mod test {
         assert!(ys.is_subset(&xs));
         assert!(ys.is_superset(&xs));
 
-        let xs = CpuSet::from_iter(vec![
-            cpu_loc(0, 0, 0, 2),
-        ]);
-        let ys = CpuSet::from_iter(vec![
-            cpu_loc(1, 1, 1, 5),
-        ]);
+        let xs = CpuSet::from_iter(vec![cpu_loc(0, 0, 0, 2)]);
+        let ys = CpuSet::from_iter(vec![cpu_loc(1, 1, 1, 5)]);
         assert!(!xs.is_subset(&ys));
         assert!(!xs.is_superset(&ys));
         assert!(!ys.is_subset(&xs));
@@ -1018,25 +1018,15 @@ mod test {
         assert!(!ys.is_subset(&xs));
         assert!(!ys.is_superset(&xs));
 
-        let xs = CpuSet::from_iter(vec![
-            cpu_loc(0, 0, 0, 2),
-        ]);
-        let ys = CpuSet::from_iter(vec![
-            cpu_loc(0, 0, 0, 2),
-            cpu_loc(1, 1, 1, 5),
-        ]);
+        let xs = CpuSet::from_iter(vec![cpu_loc(0, 0, 0, 2)]);
+        let ys = CpuSet::from_iter(vec![cpu_loc(0, 0, 0, 2), cpu_loc(1, 1, 1, 5)]);
         assert!(xs.is_subset(&ys));
         assert!(!xs.is_superset(&ys));
         assert!(!ys.is_subset(&xs));
         assert!(ys.is_superset(&xs));
 
-        let xs = CpuSet::from_iter(vec![
-            cpu_loc(1, 1, 1, 5),
-            cpu_loc(0, 0, 0, 2),
-        ]);
-        let ys = CpuSet::from_iter(vec![
-            cpu_loc(1, 1, 1, 5),
-        ]);
+        let xs = CpuSet::from_iter(vec![cpu_loc(1, 1, 1, 5), cpu_loc(0, 0, 0, 2)]);
+        let ys = CpuSet::from_iter(vec![cpu_loc(1, 1, 1, 5)]);
         assert!(!xs.is_subset(&ys));
         assert!(xs.is_superset(&ys));
         assert!(ys.is_subset(&xs));
@@ -1078,10 +1068,7 @@ mod test {
         ]);
 
         let mut i = 0;
-        let expected = [
-            cpu_loc(0, 0, 0, 0),
-            cpu_loc(0, 0, 0, 1),
-        ];
+        let expected = [cpu_loc(0, 0, 0, 0), cpu_loc(0, 0, 0, 1)];
         for x in a.intersection(&b) {
             assert!(expected.contains(x));
             i += 1
@@ -1234,7 +1221,6 @@ mod test {
             cpu_loc(0, 0, 0, 1),
             cpu_loc(1, 1, 1, 3),
         ]);
-
 
         i = 0;
         for x in a.union(&b) {

--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -246,12 +246,6 @@ impl CpuSet {
         self
     }
 
-    /// Returns a reference to the [`CpuLocation`]s currently included in the
-    /// `CpuSet`.
-    pub fn as_vec(&self) -> Vec<&CpuLocation> {
-        self.0.iter().collect()
-    }
-
     /// Checks whether the `CpuSet` is empty.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
@@ -265,11 +259,6 @@ impl CpuSet {
     /// Returns the number of CPUs included in the `CpuSet`.
     pub fn len(&self) -> usize {
         self.0.len()
-    }
-
-    /// Consumes the `CpuSet` and returns the [`CpuLocation`]s.
-    fn take(mut self) -> Vec<CpuLocation> {
-        self.0.drain().collect()
     }
 
     // Delegate Set implementation
@@ -437,9 +426,13 @@ impl CpuSetGenerator {
             Self::Fenced(cpus) => CpuIter::from_vec(cpus.clone().into_iter().collect()),
             Self::MaxSpread(it) => CpuIter::from_option(it.next()),
             Self::MaxPack(it) => CpuIter::from_option(it.next()),
-            Self::Custom(cpu_sets) => {
-                CpuIter::Multi(cpu_sets.pop().expect("insufficient cpu sets").take())
-            }
+            Self::Custom(cpu_sets) => CpuIter::Multi(
+                cpu_sets
+                    .pop()
+                    .expect("insufficient cpu sets")
+                    .into_iter()
+                    .collect(),
+            ),
         }
     }
 }

--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -590,8 +590,7 @@ mod test {
         let set = set.filter(|_| false);
         assert_eq!(0, set.len());
         assert!(set.is_empty());
-        let v: Vec<_> = set.into_iter().collect();
-        assert_eq!(0, v.len());
+        assert_eq!(0, set.into_iter().count());
     }
 
     #[test]

--- a/glommio/src/sys/hardware_topology.rs
+++ b/glommio/src/sys/hardware_topology.rs
@@ -14,7 +14,7 @@ use std::{
 use super::sysfs::ListIterator;
 
 /// A description of the CPU's location in the machine topology.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct CpuLocation {
     /// Holds the CPU id.  This is the most granular field and will distinguish
     /// among [`hyper-threads`].


### PR DESCRIPTION
### What does this PR do?

This PR adds set API to CpuSet, by delegating to `collections::HashSet`.

### Motivation

I am building a service abstraction that needs to be able to validate that multiple Glommio tasks do not share `CpuLocation` instances.

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[x] If applicable, I have discussed my architecture
