### PR TITLE
fix failing tests asserting IO errors

### DIFF
--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -80,7 +80,7 @@ use super::{LocalExecutor, LocalExecutorPoolBuilder};
 /// [`LocalExecutorPoolBuilder::on_all_shards`] would return an `Err` when using
 /// `MaxSpread`.
 ///
-/// ```
+/// ```no_run
 /// use glommio::{CpuSet, LocalExecutorPoolBuilder, Placement};
 ///
 /// let cpus = CpuSet::online()

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -1826,14 +1826,13 @@ mod test {
         match op {
             Ok(_) => panic!("should have failed"),
             Err(err) => {
-                let kind = err.kind();
-                match kind {
-                    io::ErrorKind::Other => {
-                        let x = format!("{}", err.into_inner().unwrap());
-                        assert!(x.starts_with(expected_err));
-                    }
-                    _ => panic!("Wrong error"),
-                }
+                let x = format!("{}", err.into_inner().unwrap());
+                assert!(
+                    x.starts_with(expected_err),
+                    "expected {} got {}",
+                    expected_err,
+                    x
+                );
             }
         }
     }


### PR DESCRIPTION
Don't assert the strongly typed errors, just the string representations.
The `Io:ErrorKind` of the errors we were matching against used to be
`Other` and have moved to be `Uncategorized`.
The documentation explicitly advises against matching for
`Uncategorized` errors as they are meant to eventually get their own
dedicated `Io:ErrorKind` in future rust versions.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
