### PR TITLE
Don't run placement example

### DIFF
--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -80,7 +80,7 @@ use super::{LocalExecutor, LocalExecutorPoolBuilder};
 /// [`LocalExecutorPoolBuilder::on_all_shards`] would return an `Err` when using
 /// `MaxSpread`.
 ///
-/// ```
+/// ```no_run
 /// use glommio::{CpuSet, LocalExecutorPoolBuilder, Placement};
 ///
 /// let cpus = CpuSet::online()


### PR DESCRIPTION
### What does this PR do?

Marks an example with `no-run`.

### Motivation

The example requires the executing host to have 4 cpus, which may not be the
case. We could change it to 1 cpu, but then the example would look weird.

### Related issues

### Additional Notes

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
