### PR TITLE
skew the scheduler towards locality and throughput

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -99,3 +99,7 @@ harness = false
 [[bench]]
 name = "spsc_queue"
 harness = false
+
+[[bench]]
+name = "noise"
+harness = false

--- a/glommio/benches/noise.rs
+++ b/glommio/benches/noise.rs
@@ -1,0 +1,64 @@
+use glommio::{enclose, prelude::*};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    task::{Poll, Waker},
+    time::Instant,
+};
+
+fn noise(tasks: usize) {
+    let local_ex = LocalExecutorBuilder::new()
+        .pin_to_cpu(0)
+        .spawn(move || async move {
+            let iter: usize = 10_000;
+            let t = Instant::now();
+
+            let waker: Rc<RefCell<Option<Waker>>> = Default::default();
+            let counter: Rc<RefCell<usize>> = Default::default();
+
+            let _futs: Vec<Local> = (0..tasks)
+                .map(|_| {
+                    Local::local(enclose!( (waker) async move {
+                        loop {
+                            if let Some(ref waker) = *waker.borrow() {
+                                waker.wake_by_ref();
+                            }
+                            futures_lite::future::yield_now().await;
+                        }
+                    }))
+                })
+                .collect();
+
+            let driver_task = futures_lite::future::poll_fn(enclose!(
+                (waker, counter) | cx | {
+                    if waker.borrow_mut().replace(cx.waker().clone()).is_none() {
+                        cx.waker().wake_by_ref();
+                    }
+                    *counter.borrow_mut() += 1;
+                    if *counter.borrow() >= iter {
+                        Poll::Ready(())
+                    } else {
+                        Poll::Pending
+                    }
+                }
+            ));
+
+            driver_task.await;
+
+            let t = t.elapsed();
+            println!(
+                "time to complete for {} tasks: {:#?} ({:#?} per task)",
+                tasks,
+                t,
+                t / tasks as u32
+            );
+        })
+        .unwrap();
+    local_ex.join().unwrap();
+}
+
+fn main() {
+    noise(100);
+    noise(1000);
+    noise(10000);
+}

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -168,7 +168,7 @@ impl TaskQueue {
         self.active
     }
 
-    fn get_task(&mut self) -> Option<multitask::Runnable> {
+    fn get_task(&self) -> Option<multitask::Runnable> {
         self.ex.get_task()
     }
 
@@ -1056,7 +1056,7 @@ impl LocalExecutor {
 
                 let mut tasks_executed_this_loop = 0;
                 loop {
-                    let mut queue_ref = queue.borrow_mut();
+                    let queue_ref = queue.borrow();
                     if self.need_preempt() || queue_ref.yielded() {
                         break;
                     }

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -1074,6 +1074,7 @@ impl LocalExecutor {
 
                 let (need_repush, last_vruntime) = {
                     let mut state = queue.borrow_mut();
+                    state.ex.make_fair();
                     let last_vruntime = state.account_vruntime(runtime);
                     (state.is_active(), last_vruntime)
                 };
@@ -2089,32 +2090,6 @@ mod test {
             if task.is_ok() {
                 unreachable!("Should have failed");
             }
-        });
-    }
-
-    #[test]
-    fn ten_yielding_queues() {
-        let local_ex = LocalExecutor::default();
-
-        // 0 -> no one
-        // 1 -> t1
-        // 2 -> t2...
-        let executed_last = Rc::new(RefCell::new(0));
-        local_ex.run(async {
-            let mut joins = Vec::with_capacity(10);
-            for id in 1..11 {
-                let exec = executed_last.clone();
-                joins.push(Task::local(async move {
-                    for _ in 0..10_000 {
-                        let mut last = exec.borrow_mut();
-                        assert_ne!(id, *last);
-                        *last = id;
-                        drop(last);
-                        Local::later().await;
-                    }
-                }));
-            }
-            futures::future::join_all(joins).await;
         });
     }
 

--- a/glommio/src/executor/multitask.rs
+++ b/glommio/src/executor/multitask.rs
@@ -13,7 +13,7 @@ use crate::{
     task::{task_impl, JoinHandle},
 };
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     collections::VecDeque,
     future::Future,
     marker::PhantomData,
@@ -35,6 +35,10 @@ use std::{
 /// is woken. When it's woken up, its schedule function is called, which means
 /// the `Runnable` gets pushed into a task queue in an executor.
 pub(crate) type Runnable = task_impl::Task;
+
+/// An identity fingerprint of a runnable task; useful to compare two tasks for
+/// equality without keeping references
+pub(crate) type RunnableId = task_impl::TaskId;
 
 /// A spawned future.
 ///
@@ -110,10 +114,31 @@ impl LocalQueue {
     }
 }
 
+const MAX_UNFAIR_SCHEDULING: usize = 256;
+
 /// A single-threaded executor.
 #[derive(Debug)]
 pub(crate) struct LocalExecutor {
     local_queue: LocalQueue,
+
+    /// run_next, if present is a runnable that was scheduled by the previous
+    /// task and should be run next instead of what's in the local queue.
+    /// This approach eliminates the (potentially large) scheduling latency
+    /// that otherwise arises from adding the scheduled runnable to the end of
+    /// the run queue.
+    ///
+    /// Another way to look at this is as a 1-element LIFO buffer in front of
+    /// the fair (FIFO) task queue. The latter is an instrument for fairness
+    /// while this optimizes for throughput.
+    run_next: RefCell<Option<Runnable>>,
+    /// last_popped is the last runnable return by this executor
+    /// It is used to avoid placing the same task in run_next
+    last_popped: RefCell<Option<RunnableId>>,
+
+    /// run_next_count counts the number of throughput-oriented scheduling
+    /// decision we have made in a row. It is used to inject some fairness into
+    /// the mix.
+    run_next_count: Cell<usize>,
 
     /// Make sure the type is `!Send` and `!Sync`.
     _marker: PhantomData<Rc<()>>,
@@ -128,6 +153,9 @@ impl LocalExecutor {
     pub(crate) fn new() -> LocalExecutor {
         LocalExecutor {
             local_queue: LocalQueue::new(),
+            run_next: RefCell::new(None),
+            last_popped: RefCell::new(None),
+            run_next_count: Cell::new(0),
             _marker: PhantomData,
         }
     }
@@ -146,10 +174,7 @@ impl LocalExecutor {
             let tq = tq.upgrade();
 
             if let Some(tq) = tq {
-                {
-                    let queue = tq.borrow();
-                    queue.ex.local_queue.push(runnable);
-                }
+                tq.borrow().ex.push_task(runnable);
                 maybe_activate(tq);
             }
         };
@@ -159,6 +184,7 @@ impl LocalExecutor {
         task_impl::spawn_local(executor_id, future, schedule)
     }
 
+    /// Creates a [`Task`] for a given future and runs it immediately
     pub(crate) fn spawn_and_run<T>(
         &self,
         executor_id: usize,
@@ -170,6 +196,7 @@ impl LocalExecutor {
         Task(Some(handle))
     }
 
+    /// Creates a [`Task`] for a given future and schedules it to run eventually
     pub(crate) fn spawn_and_schedule<T>(
         &self,
         executor_id: usize,
@@ -185,10 +212,77 @@ impl LocalExecutor {
     ///
     /// Returns an option rapping the task.
     pub(crate) fn get_task(&self) -> Option<Runnable> {
-        self.local_queue.pop()
+        let mut run_next = self.run_next.borrow_mut();
+
+        let ret = match (
+            run_next.take(),
+            self.run_next_count.get() < MAX_UNFAIR_SCHEDULING,
+        ) {
+            (Some(runnable), true) => {
+                // run the next task immediately
+                self.run_next_count.replace(self.run_next_count.get() + 1);
+                Some(runnable)
+            }
+            (Some(runnable), false) => {
+                // pop from the queue instead
+                self.run_next_count.replace(0);
+                Some(if let Some(ret) = self.local_queue.pop() {
+                    self.local_queue.push(runnable);
+                    ret
+                } else {
+                    // there is nothing in the queue so run the priority runnable anyway
+                    runnable
+                })
+            }
+            (_, _) => {
+                self.run_next_count.replace(0);
+                self.local_queue.pop()
+            }
+        };
+
+        self.last_popped.replace(ret.as_ref().map(RunnableId::from));
+        ret
     }
 
+    /// Returns true if this [`LocalExecutor`] has some scheduled work
     pub(crate) fn is_active(&self) -> bool {
-        !self.local_queue.queue.borrow().is_empty()
+        !(self.local_queue.queue.borrow().is_empty() && self.run_next.borrow().is_none())
+    }
+
+    /// Reset the state of this [`LocalExecutor`] to be fair wrt scheduling
+    /// decisions
+    pub(crate) fn make_fair(&self) {
+        // empty the priority slot so that we pick a task from the queue next time
+        let _ = self.last_popped.borrow_mut().take();
+        if let Some(runnable) = self.run_next.borrow_mut().take() {
+            self.local_queue.push(runnable)
+        }
+        self.run_next_count.replace(0);
+    }
+
+    /// Schedule a given task for execution on this LocalExecutor
+    /// If next is false, runnable is added to the tail of the runnable queue.
+    /// If next is true, runnable is set as the immediate next task to run.
+    fn push_task(&self, runnable: Runnable) {
+        // Check whether the task we try to schedule is the same that's currently
+        // running, if any. If so then the task is yielding voluntarily so we
+        // put it at the tail of the queue
+        let reentrant = self
+            .last_popped
+            .borrow()
+            .as_ref()
+            .map_or(false, |last| *last == RunnableId::from(&runnable));
+
+        // if run_next is already populated, kick the runnable out into the regular
+        // queue
+        let runnable = if !reentrant {
+            self.run_next.borrow_mut().replace(runnable)
+        } else {
+            Some(runnable)
+        };
+
+        if let Some(runnable) = runnable {
+            self.local_queue.push(runnable)
+        }
     }
 }

--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -176,3 +176,21 @@ impl fmt::Debug for Task {
             .finish()
     }
 }
+
+/// A TaskId contains the same information as [`Task`] but is typed such
+/// that it's unusable other than to compare two tasks for equality.
+/// Specifically, a [`TaskId`] doesn't count towards the task reference counter
+/// and dropping it is a no-op.
+#[derive(Debug, PartialEq)]
+pub struct TaskId {
+    /// A pointer to the heap-allocated task.
+    raw_task: NonNull<()>,
+}
+
+impl From<&Task> for TaskId {
+    fn from(task: &Task) -> Self {
+        Self {
+            raw_task: task.raw_task,
+        }
+    }
+}

--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -125,16 +125,20 @@ impl Task {
         })
     }
 
+    /// Behave like ['run'] but schedule the tak immediately
     pub(crate) fn run_right_away(self) -> bool {
         let ptr = self.raw_task.as_ptr();
-        let header = ptr as *const Header;
-        mem::forget(self);
-
-        unsafe {
-            let refs = (*header).references.fetch_add(1, Ordering::Relaxed);
-            assert_ne!(refs, i16::max_value());
-            ((*header).vtable.run)(ptr)
-        }
+        dbg_context!(ptr, "run_right_away", {
+            let header = ptr as *const Header;
+            mem::forget(self);
+            #[cfg(feature = "debugging")]
+            TaskDebugger::set_current_task(ptr);
+            unsafe {
+                let refs = (*header).references.fetch_add(1, Ordering::Relaxed);
+                assert_ne!(refs, i16::max_value());
+                ((*header).vtable.run)(ptr)
+            }
+        })
     }
 }
 


### PR DESCRIPTION
This PR changes how the scheduler behaves within a task queue
to favor throughput and locality.

This is a trick from the Go scheduler to get most of the benefits of a
LIFO queue but preserve the fairness we get from a FIFO queue. This
approach eliminates the (potentially large) scheduling latency that
otherwise arises from adding scheduled runnable to the end of the
task queue.

The change works as such:
* scheduled tasks go in a "priority slot" instead of the queue. If
the slot is already taken, the previous task is replaced and the old one
goes at the back of the queue.
* when the scheduler retrieves the next task, it'll take the task from
the priority slot instead of the queue, if any.
* The `LocalExecutor` maintains an internal counter that is incremented
each time we run a task from the priority slot instead of the queue.
When this counter reaches a constant (256 as of this commit), the task
in the priority slot is pushed at the back of the queue, and we pop the
next task as normal.
* Each time we switch task queues, the priority slot is emptied such
that we pick from the FIFO queue the next time we visit it.

I added a new benchmark that simulates a worst-case scenario for the
scheduler. Those are the results for glommio master:

```
time to complete for 100 tasks: 40.715854ms (407.158µs per task)
time to complete for 1000 tasks: 397.54535ms (397.545µs per task)
time to complete for 10000 tasks: 3.81689191s (381.689µs per task)
```

And after I apply the changes in this PR:
```
time to complete for 100 tasks: 836.719µs (8.367µs per task)
time to complete for 1000 tasks: 1.014916ms (1.014µs per task)
time to complete for 10000 tasks: 2.421971ms (242ns per task)
```

I also get a 40% improvement when running the glommio SPSC
buffered shared channel benchmark!

Such wow! 