### PR TITLE
protect the executor against reentrant tasks

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -100,3 +100,7 @@ harness = false
 [[bench]]
 name = "spsc_queue"
 harness = false
+
+[[bench]]
+name = "noise"
+harness = false

--- a/glommio/benches/noise.rs
+++ b/glommio/benches/noise.rs
@@ -1,0 +1,64 @@
+use glommio::{enclose, prelude::*, Task};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    task::{Poll, Waker},
+    time::Instant,
+};
+
+fn noise(tasks: usize) {
+    let local_ex = LocalExecutorBuilder::new()
+        .pin_to_cpu(0)
+        .spawn(move || async move {
+            let iter: usize = 10_000;
+            let t = Instant::now();
+
+            let waker: Rc<RefCell<Option<Waker>>> = Default::default();
+            let counter: Rc<RefCell<usize>> = Default::default();
+
+            let _futs: Vec<Task<()>> = (0..tasks)
+                .map(|_| {
+                    glommio::spawn_local(enclose!( (waker) async move {
+                        loop {
+                            if let Some(ref waker) = *waker.borrow() {
+                                waker.wake_by_ref();
+                            }
+                            futures_lite::future::yield_now().await;
+                        }
+                    }))
+                })
+                .collect();
+
+            let driver_task = futures_lite::future::poll_fn(enclose!(
+                (waker, counter) | cx | {
+                    if waker.borrow_mut().replace(cx.waker().clone()).is_none() {
+                        cx.waker().wake_by_ref();
+                    }
+                    *counter.borrow_mut() += 1;
+                    if *counter.borrow() >= iter {
+                        Poll::Ready(())
+                    } else {
+                        Poll::Pending
+                    }
+                }
+            ));
+
+            driver_task.await;
+
+            let t = t.elapsed();
+            println!(
+                "time to complete for {} tasks: {:#?} ({:#?} per task)",
+                tasks,
+                t,
+                t / tasks as u32
+            );
+        })
+        .unwrap();
+    local_ex.join().unwrap();
+}
+
+fn main() {
+    noise(100);
+    noise(1000);
+    noise(10000);
+}

--- a/glommio/benches/noise.rs
+++ b/glommio/benches/noise.rs
@@ -6,7 +6,7 @@ use std::{
     time::Instant,
 };
 
-fn noise(tasks: usize) {
+fn noise_common_task_queue(tasks: usize) {
     let local_ex = LocalExecutorBuilder::new()
         .pin_to_cpu(0)
         .spawn(move || async move {
@@ -57,8 +57,73 @@ fn noise(tasks: usize) {
     local_ex.join().unwrap();
 }
 
+fn noise_separate_task_queue(tasks: usize) {
+    let local_ex = LocalExecutorBuilder::new()
+        .pin_to_cpu(0)
+        .spawn(move || async move {
+            let iter: usize = 10_000;
+            let t = Instant::now();
+
+            let waker: Rc<RefCell<Option<Waker>>> = Default::default();
+            let counter: Rc<RefCell<usize>> = Default::default();
+
+            let tq = glommio::executor().create_task_queue(
+                Shares::Static(1000),
+                Latency::NotImportant,
+                "foo",
+            );
+
+            let _futs: Vec<Task<()>> = (0..tasks)
+                .map(|_| {
+                    glommio::spawn_local_into(
+                        enclose!( (waker) async move {
+                            loop {
+                                if let Some(ref waker) = *waker.borrow() {
+                                    waker.wake_by_ref();
+                                }
+                                futures_lite::future::yield_now().await;
+                            }
+                        }),
+                        tq,
+                    )
+                    .unwrap()
+                })
+                .collect();
+
+            let driver_task = futures_lite::future::poll_fn(enclose!(
+                (waker, counter) | cx | {
+                    if waker.borrow_mut().replace(cx.waker().clone()).is_none() {
+                        cx.waker().wake_by_ref();
+                    }
+                    *counter.borrow_mut() += 1;
+                    if *counter.borrow() >= iter {
+                        Poll::Ready(())
+                    } else {
+                        Poll::Pending
+                    }
+                }
+            ));
+
+            driver_task.await;
+
+            let t = t.elapsed();
+            println!(
+                "time to complete for {} tasks: {:#?} ({:#?} per task)",
+                tasks,
+                t,
+                t / tasks as u32
+            );
+        })
+        .unwrap();
+    local_ex.join().unwrap();
+}
+
 fn main() {
-    noise(100);
-    noise(1000);
-    noise(10000);
+    noise_common_task_queue(100);
+    noise_common_task_queue(1000);
+    noise_common_task_queue(10000);
+
+    noise_separate_task_queue(100);
+    noise_separate_task_queue(1000);
+    noise_separate_task_queue(10000);
 }

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -173,7 +173,7 @@ impl TaskQueue {
         self.active
     }
 
-    fn get_task(&mut self) -> Option<multitask::Runnable> {
+    fn get_task(&self) -> Option<multitask::Runnable> {
         self.ex.get_task()
     }
 
@@ -1062,7 +1062,7 @@ impl LocalExecutor {
 
                 let mut tasks_executed_this_loop = 0;
                 loop {
-                    let mut queue_ref = queue.borrow_mut();
+                    let queue_ref = queue.borrow();
                     if self.need_preempt() || queue_ref.yielded() {
                         break;
                     }

--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -176,3 +176,21 @@ impl fmt::Debug for Task {
             .finish()
     }
 }
+
+/// A TaskId contains the same information as [`Task`] but is typed such
+/// that it's unusable other than to compare two tasks for equality.
+/// Specifically, a [`TaskId`] doesn't count towards the task reference counter
+/// and dropping it is a no-op.
+#[derive(Debug, PartialEq)]
+pub struct TaskId {
+    /// A pointer to the heap-allocated task.
+    raw_task: NonNull<()>,
+}
+
+impl From<&Task> for TaskId {
+    fn from(task: &Task) -> Self {
+        Self {
+            raw_task: task.raw_task,
+        }
+    }
+}

--- a/glommio/src/task/task_impl.rs
+++ b/glommio/src/task/task_impl.rs
@@ -125,16 +125,20 @@ impl Task {
         })
     }
 
+    /// Behave like ['run'] but schedule the tak immediately
     pub(crate) fn run_right_away(self) -> bool {
         let ptr = self.raw_task.as_ptr();
-        let header = ptr as *const Header;
-        mem::forget(self);
-
-        unsafe {
-            let refs = (*header).references.fetch_add(1, Ordering::Relaxed);
-            assert_ne!(refs, i16::max_value());
-            ((*header).vtable.run)(ptr)
-        }
+        dbg_context!(ptr, "run_right_away", {
+            let header = ptr as *const Header;
+            mem::forget(self);
+            #[cfg(feature = "debugging")]
+            TaskDebugger::set_current_task(ptr);
+            unsafe {
+                let refs = (*header).references.fetch_add(1, Ordering::Relaxed);
+                assert_ne!(refs, i16::max_value());
+                ((*header).vtable.run)(ptr)
+            }
+        })
     }
 }
 


### PR DESCRIPTION
### What does this PR do?
Reentrant tasks are problematic in Glommio today. Consider the following
code snippet:

```rust
glommio::spawn_local_into(async move {
    loop {
        glommio::executor().yield_now().await;
    }
}, some_tq).unwrap();

// do other useful stuff
```

The problem with this pattern is that the Glommio executor runs task
queues in order of virtual runtime. Because this particular task yields
immediately, the `vruntime` of its queue will increase very slowly. 
The result is that the above task will run repeatedly until it has spun
enough that the parent queue `vruntime` is no longer the smallest of all
the queues. Before that, other queues will not run, even after
preemption.

The solution to this problem is to detect "reentrant" tasks (i.e.,
self-scheduled tasks that were not preempted) and segregate them. The
executor still visits all task queues each time it ticks but once a task
is marked as reentrant, the executor will ignore it until the next
tick. We perform the same trick on task queues too. Once a queue
contains only reentrant tasks, it is no longer polled until the next
time the executor ticks.

After this change, the above task runs exactly once per executor tick, 
freeing CPU time for more demanding tasks.

It is very easy to shoot yourself in the foot with this issue because
yielding triggers it. i.e. being cooperative and yielding to the
runtime worsen performance.