### PR TITLE
update `nix` to 0.23

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -21,7 +21,7 @@ concurrent-queue = "1.2"
 futures-lite = "1.12"
 libc = "~0.2"
 socket2 = { version = "~0.3", features = ["unix", "reuseport"] }
-nix = "~0.22.0"
+nix = "~0.23.0"
 bitflags = "1.3"
 bitmaps = "3.1.0"
 typenum = "1.14"

--- a/glommio/src/iou/sqe.rs
+++ b/glommio/src/iou/sqe.rs
@@ -393,6 +393,7 @@ impl<'a> SQE<'a> {
             POSIX_FADV_NOREUSE => libc::POSIX_FADV_NOREUSE,
             POSIX_FADV_WILLNEED => libc::POSIX_FADV_WILLNEED,
             POSIX_FADV_DONTNEED => libc::POSIX_FADV_DONTNEED,
+            _ => unreachable!(),
         };
         uring_sys::io_uring_prep_fadvise(self.sqe, fd.as_raw_fd(), off as _, len as _, advice);
         fd.update_sqe(self);
@@ -419,6 +420,7 @@ impl<'a> SQE<'a> {
             MADV_DONTDUMP => libc::MADV_DONTDUMP,
             MADV_DODUMP => libc::MADV_DODUMP,
             MADV_FREE => libc::MADV_FREE,
+            _ => unreachable!(),
         };
         uring_sys::io_uring_prep_madvise(
             self.sqe,
@@ -440,6 +442,7 @@ impl<'a> SQE<'a> {
             EpollOp::EpollCtlAdd => libc::EPOLL_CTL_ADD,
             EpollOp::EpollCtlDel => libc::EPOLL_CTL_DEL,
             EpollOp::EpollCtlMod => libc::EPOLL_CTL_MOD,
+            _ => unreachable!(),
         };
         let event = event.map_or(ptr::null_mut(), |event| event as *mut EpollEvent as *mut _);
         uring_sys::io_uring_prep_epoll_ctl(self.sqe, epoll_fd, fd, op, event);


### PR DESCRIPTION
0.22 has a security vulnerability. See https://rustsec.org/advisories/RUSTSEC-2021-0119 for details.
This new version marks some enums with `#[non_exhaustive]` to force downstream users to match against wildcard. See https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
