### PR TITLE
Channel panic

### DIFF
--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -311,6 +311,17 @@ macro_rules! wake {
     };
 }
 
+/// Call `Waker::wake_by_ref()` and log to `error` if panicked.
+macro_rules! wake_by_ref {
+    ($waker:expr $(,)?) => {
+        use log::error;
+
+        if let Err(x) = std::panic::catch_unwind(|| $waker.wake_by_ref()) {
+            error!("Panic while calling waker! {:?}", x);
+        }
+    };
+}
+
 mod free_list;
 
 #[allow(clippy::redundant_slicing)]

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -257,6 +257,14 @@ impl Reactor {
         id
     }
 
+    pub(crate) fn wake_wakers(&self, id: u64) {
+        if let Some(wakers) = self.shared_channels.borrow_mut().wakers_map.get(&id) {
+            wakers.0.iter().for_each(|w| {
+                wake_by_ref!(w);
+            })
+        };
+    }
+
     pub(crate) fn unregister_shared_channel(&self, id: u64) {
         let mut channels = self.shared_channels.borrow_mut();
         channels.wakers_map.remove(&id);


### PR DESCRIPTION
### What does this PR do?

Fixes a panic when a `ConnectedSender` is `close`d in one task while the same `ConnectedSender` is blocked on `send` in another task (see new unit test).

### Motivation

Fix panic.

### Related issues

na

### Additional Notes

na

### Checklist

[y] I have added unit tests to the code I am submitting
[~] My unit tests cover both failure and success scenarios~
[~] If applicable, I have discussed my architecture~
