### PR TITLE
add a poll variant to `DmaStreamReader::get_buffer_aligned`

### DIFF
--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -626,7 +626,7 @@ impl DmaStreamReader {
         Poll::Ready(Ok(x))
     }
 
-    fn get_buffer(
+    fn poll_get_buffer(
         &mut self,
         cx: &mut Context<'_>,
         len: u64,


### PR DESCRIPTION
### What does this PR do?

Related to #445 and #446

Since `DmaStreamReader` is a stream, we have to play well with other
streams and make our functions easy to use from a polling context.
`get_buffer_aligned` is an async function and, as such, is hard to use
from there (not impossible, just hard).

If we look at the `AsyncRead` trait, one may see that it defines only
poll functions. Async functions are then built on top in the
`AsyncReadExt.` This is done because creating a future from a poll
function is trivial, while the other way around is hard.

Therefore, we create a new function `poll_get_buffer_aligned` and we
reimplement `get_buffer_aligned` as a wrapper around it:

```rust
pub async fn get_buffer_aligned(&mut self, len: u64) -> Result<ReadResult> {
    poll_fn(|cx| self.poll_get_buffer_aligned(cx, len)).await
}
```
