### PR TITLE
fix foreign wakes

### DIFF
--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -228,7 +228,7 @@ where
                 let notifier = raw.notifier();
                 notifier.queue_waker(Waker::from_raw(Self::clone_waker(ptr)));
                 if (*raw.header).latency_matters {
-                    notifier.notify_if_needed();
+                    notifier.notify_if_sleeping();
                 }
             });
         } else {


### PR DESCRIPTION
A subtle bug was introduced in a previous refactor. Two boolean values
were simplified to a single one and a bug sneaked in, marking an
awakened reactor as being asleep to remote ones. That lead to
significant performance slow-downs because shards would issue a syscall
each time they would wake up a foreign waker.

Also, I simplified the code a little and replaced two standalone atomic
load and swap operations with a single CAS one.

The relevant commit was 2fb4fb47ee3d3c0375ad9380c8a1892e4bc52404.