### PR TITLE
Re-implement standard traits for socket using poll + recv

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -31,16 +31,16 @@
 "fastrand","https://github.com/smol-rs/fastrand","Apache-2.0 OR MIT","Stjepan Glavina <stjepang@gmail.com>"
 "flate2","https://github.com/rust-lang/flate2-rs","Apache-2.0 OR MIT","Alex Crichton <alex@alexcrichton.com>|Josh Triplett <josh@joshtriplett.org>"
 "fnv","https://github.com/servo/rust-fnv","Apache-2.0 OR MIT","Alex Crichton <alex@alexcrichton.com>"
-"futures","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT","Alex Crichton <alex@alexcrichton.com>"
-"futures-channel","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT","Alex Crichton <alex@alexcrichton.com>"
-"futures-core","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT","Alex Crichton <alex@alexcrichton.com>"
-"futures-executor","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT","Alex Crichton <alex@alexcrichton.com>"
-"futures-io","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT","Alex Crichton <alex@alexcrichton.com>"
+"futures","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT",
+"futures-channel","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT",
+"futures-core","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT",
+"futures-executor","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT",
+"futures-io","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT",
 "futures-lite","https://github.com/smol-rs/futures-lite","Apache-2.0 OR MIT","Stjepan Glavina <stjepang@gmail.com>|Contributors to futures-rs"
-"futures-macro","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT","Taylor Cramer <cramertj@google.com>|Taiki Endo <te316e89@gmail.com>"
-"futures-sink","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT","Alex Crichton <alex@alexcrichton.com>"
-"futures-task","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT","Alex Crichton <alex@alexcrichton.com>"
-"futures-util","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT","Alex Crichton <alex@alexcrichton.com>"
+"futures-macro","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT",
+"futures-sink","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT",
+"futures-task","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT",
+"futures-util","https://github.com/rust-lang/futures-rs","Apache-2.0 OR MIT",
 "getopts","https://github.com/rust-lang/getopts","Apache-2.0 OR MIT","The Rust Project Developers"
 "getrandom","https://github.com/rust-random/getrandom","Apache-2.0 OR MIT","The Rand Project Developers"
 "glommio","https://github.com/DataDog/glommio","Apache-2.0 OR MIT","Glauber Costa <glommer@gmail.com>|Hippolyte Barraud <hippolyte.barraud@datadoghq.com>|DataDog <info@datadoghq.com>"
@@ -86,8 +86,6 @@
 "ppv-lite86","https://github.com/cryptocorrosion/cryptocorrosion","Apache-2.0 OR MIT","The CryptoCorrosion Contributors"
 "pretty-bytes","https://github.com/banyan/rust-pretty-bytes","MIT","Kohei Hasegawa"
 "pretty_env_logger","https://github.com/seanmonstar/pretty-env-logger","Apache-2.0 OR MIT","Sean McArthur <sean@seanmonstar>"
-"proc-macro-hack","https://github.com/dtolnay/proc-macro-hack","Apache-2.0 OR MIT","David Tolnay <dtolnay@gmail.com>"
-"proc-macro-nested","https://github.com/dtolnay/proc-macro-hack","Apache-2.0 OR MIT","David Tolnay <dtolnay@gmail.com>"
 "proc-macro2","https://github.com/dtolnay/proc-macro2","Apache-2.0 OR MIT","David Tolnay <dtolnay@gmail.com>|Alex Crichton <alex@alexcrichton.com>"
 "quick-error","http://github.com/tailhook/quick-error","Apache-2.0 OR MIT","Paul Colomiets <paul@colomiets.name>|Colin Kiegel <kiegel@gmx.de>"
 "quote","https://github.com/dtolnay/quote","Apache-2.0 OR MIT","David Tolnay <dtolnay@gmail.com>"

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -343,6 +343,7 @@ macro_rules! poll_err {
 /// Unwraps an Option to Poll<T>: if Some returns right away.
 ///
 /// Usage is similar to `future_lite::ready!`
+#[allow(unused)]
 macro_rules! poll_some {
     ($e:expr $(,)?) => {
         match $e {

--- a/glommio/src/net/stream.rs
+++ b/glommio/src/net/stream.rs
@@ -279,7 +279,7 @@ impl<S: AsRawFd> NonBufferedStream<S> {
                     self.source_rx = Some(reactor.poll_read_ready(self.stream.as_raw_fd()));
                     // The `rush_dispatch`s here and after could be removed to
                     // improve performance if #458 is handled appropriately.
-                    reactor.rush_dispatch(self.source_rx.as_ref().unwrap());
+                    // reactor.rush_dispatch(self.source_rx.as_ref().unwrap());
                 }
                 return Poll::Ready(Ok(result));
             }
@@ -289,7 +289,7 @@ impl<S: AsRawFd> NonBufferedStream<S> {
 
         if no_pending_poll {
             self.source_rx = Some(reactor.poll_read_ready(self.stream.as_raw_fd()));
-            reactor.rush_dispatch(self.source_rx.as_ref().unwrap());
+            // reactor.rush_dispatch(self.source_rx.as_ref().unwrap());
         }
 
         let source = self.source_rx.as_ref().unwrap();

--- a/glommio/src/net/stream.rs
+++ b/glommio/src/net/stream.rs
@@ -5,112 +5,237 @@
 //
 use crate::{
     reactor::Reactor,
-    sys::{self, DmaBuffer, Source, SourceType},
-    ByteSliceMutExt,
+    sys::{self, Source, SourceType},
 };
 use futures_lite::ready;
 use nix::sys::socket::MsgFlags;
 use std::{
     cell::Cell,
-    convert::TryFrom,
     io,
     net::Shutdown,
     os::unix::io::{AsRawFd, FromRawFd, RawFd},
     rc::{Rc, Weak},
-    task::{Context, Poll},
-    time::Duration,
+    task::{Context, Poll, Waker},
+    time::{Duration, Instant},
 };
 
 type Result<T> = crate::Result<T, ()>;
 
-struct RecvBuffer {
-    buf: DmaBuffer,
+/// Root trait for socket stream receive buffer
+pub trait RxBuf {
+    fn read(&mut self, buf: &mut [u8]) -> usize;
+    fn peek(&self, buf: &mut [u8]) -> usize;
+    fn is_empty(&mut self) -> bool;
+    fn as_bytes(&self) -> &[u8];
+    fn consume(&mut self, amt: usize);
+    fn buffer_size(&self) -> usize;
+    fn handle_result(&mut self, result: usize);
+    fn unfilled(&mut self) -> &mut [u8];
 }
 
-impl TryFrom<Source> for RecvBuffer {
-    type Error = io::Error;
+#[derive(Debug, Default)]
+pub struct NonBuffered;
 
-    fn try_from(source: Source) -> io::Result<RecvBuffer> {
-        let res = source.result();
-        match source.extract_source_type() {
-            SourceType::SockRecv(mut buf) => {
-                let sz = res.unwrap()?;
-                let mut buf = buf.take().unwrap();
-                buf.trim_to_size(sz);
-                Ok(RecvBuffer { buf })
-            }
-            _ => unreachable!(),
+impl RxBuf for NonBuffered {
+    fn read(&mut self, _buf: &mut [u8]) -> usize {
+        0
+    }
+
+    fn peek(&self, _buf: &mut [u8]) -> usize {
+        0
+    }
+
+    fn is_empty(&mut self) -> bool {
+        true
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &[]
+    }
+
+    fn consume(&mut self, _amt: usize) {}
+
+    fn buffer_size(&self) -> usize {
+        0
+    }
+
+    fn handle_result(&mut self, _result: usize) {}
+
+    fn unfilled(&mut self) -> &mut [u8] {
+        &mut []
+    }
+}
+
+/// Trait for receive buffer implementations
+pub trait Buffered: RxBuf {}
+
+/// Non-shared fixed sized receive buffer allocated
+/// when buffered stream is created
+#[derive(Debug)]
+pub struct Preallocated {
+    buf: Vec<u8>,
+    head: usize,
+    tail: usize,
+    cap: usize,
+}
+
+impl Preallocated {
+    const DEFAULT_BUFFER_SIZE: usize = 8192;
+
+    /// Creates a fixed sized receive buffer
+    pub fn new(size: usize) -> Self {
+        Self {
+            buf: vec![0; size],
+            tail: 0,
+            head: 0,
+            cap: size,
         }
     }
 }
 
-const DEFAULT_BUFFER_SIZE: usize = 8192;
+impl Default for Preallocated {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_BUFFER_SIZE)
+    }
+}
+
+impl Preallocated {
+    fn len(&self) -> usize {
+        self.tail - self.head
+    }
+}
+
+impl Buffered for Preallocated {}
+
+impl RxBuf for Preallocated {
+    fn read(&mut self, buf: &mut [u8]) -> usize {
+        let sz = std::cmp::min(self.len(), buf.len());
+        if sz > 0 {
+            buf[..sz].copy_from_slice(&self.buf[self.head..self.head + sz]);
+            self.head += sz;
+        }
+        sz
+    }
+
+    fn peek(&self, buf: &mut [u8]) -> usize {
+        let sz = std::cmp::min(self.len(), buf.len());
+        if sz > 0 {
+            buf[..sz].copy_from_slice(&self.buf[self.head..self.head + sz]);
+        }
+        sz
+    }
+
+    fn is_empty(&mut self) -> bool {
+        self.head >= self.tail
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.buf[self.head..self.tail]
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.head += std::cmp::min(self.len(), amt);
+    }
+
+    fn buffer_size(&self) -> usize {
+        self.cap
+    }
+
+    fn handle_result(&mut self, result: usize) {
+        self.tail += result;
+    }
+
+    fn unfilled(&mut self) -> &mut [u8] {
+        if self.len() == 0 {
+            self.head = 0;
+            self.tail = 0;
+        }
+        &mut self.buf[self.tail..]
+    }
+}
 
 #[derive(Debug)]
-pub(crate) struct GlommioStream<S: AsRawFd + FromRawFd + From<socket2::Socket>> {
-    pub(crate) reactor: Weak<Reactor>,
-    pub(crate) stream: S,
-    pub(crate) source_tx: Option<Source>,
-    pub(crate) source_rx: Option<Source>,
-
-    pub(crate) write_timeout: Cell<Option<Duration>>,
-    pub(crate) read_timeout: Cell<Option<Duration>>,
-
-    // you only live once, you've got no time to block! if this is set to true try a direct
-    // non-blocking syscall otherwise schedule for sending later over the ring
-    //
-    // If you are familiar with high throughput networking code you might have seen similar
-    // techniques with names such as "optimistic" "speculative" or things like that. But frankly
-    // "yolo" is such a better name. Calling this "yolo" is likely glommio's biggest
-    // contribution to humankind.
-    pub(crate) tx_yolo: bool,
-    pub(crate) rx_yolo: bool,
-
-    pub(crate) rx_buf: Option<DmaBuffer>,
-    pub(crate) tx_buf: Option<DmaBuffer>,
-
-    pub(crate) rx_buf_size: usize,
+struct Timeout {
+    id: u64,
+    timeout: Cell<Option<Duration>>,
+    timer: Cell<Option<Instant>>,
 }
 
-impl<S: AsRawFd + FromRawFd + From<socket2::Socket>> From<socket2::Socket> for GlommioStream<S> {
-    fn from(socket: socket2::Socket) -> GlommioStream<S> {
-        let stream = socket.into();
-        GlommioStream {
-            reactor: Rc::downgrade(&crate::executor().reactor()),
-            stream,
-            source_tx: None,
-            source_rx: None,
-            write_timeout: Cell::new(None),
-            read_timeout: Cell::new(None),
-            tx_yolo: true,
-            rx_yolo: true,
-            rx_buf: None,
-            tx_buf: None,
-            rx_buf_size: DEFAULT_BUFFER_SIZE,
+impl Timeout {
+    fn new(id: u64) -> Self {
+        Self {
+            id,
+            timeout: Cell::new(None),
+            timer: Cell::new(None),
         }
     }
-}
 
-impl<S: AsRawFd + FromRawFd + From<socket2::Socket>> AsRawFd for GlommioStream<S> {
-    fn as_raw_fd(&self) -> RawFd {
-        self.stream.as_raw_fd()
+    fn get(&self) -> Option<Duration> {
+        self.timeout.get()
+    }
+
+    fn set(&self, dur: Option<Duration>) -> Result<()> {
+        if let Some(dur) = dur.as_ref() {
+            if dur.as_nanos() == 0 {
+                return Err(io::Error::from_raw_os_error(libc::EINVAL).into());
+            }
+        }
+        self.timeout.set(dur);
+        Ok(())
+    }
+
+    fn maybe_set_timer(&self, reactor: &Reactor, waker: &Waker) {
+        if let Some(timeout) = self.timeout.get() {
+            if self.timer.get().is_none() {
+                let deadline = Instant::now() + timeout;
+                reactor.insert_timer(self.id, deadline, waker.clone());
+                self.timer.set(Some(deadline));
+            }
+        }
+    }
+
+    fn cancel_timer(&self, reactor: &Reactor) {
+        if self.timer.take().is_some() {
+            reactor.remove_timer(self.id);
+        }
+    }
+
+    fn check(&self, reactor: &Reactor) -> io::Result<()> {
+        if let Some(deadline) = self.timer.get() {
+            if !reactor.timer_exists(&(deadline, self.id)) {
+                reactor.remove_timer(self.id);
+                self.timer.take();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "Operation timed out",
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
-impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> FromRawFd for GlommioStream<S> {
-    unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        let socket = socket2::Socket::from_raw_fd(fd);
-        GlommioStream::from(socket)
-    }
+#[derive(Debug)]
+pub(crate) struct NonBufferedStream<S> {
+    reactor: Weak<Reactor>,
+    stream: S,
+    source_tx: Option<Source>,
+    source_rx: Option<Source>,
+    write_timeout: Timeout,
+    read_timeout: Timeout,
 }
 
-impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> GlommioStream<S> {
-    /// Receives data on the socket from the remote address to which it is
-    /// connected, without removing that data from the queue.
-    ///
-    /// On success, returns the number of bytes peeked.
-    /// Successive calls return the same data. This is accomplished by passing
-    /// `MSG_PEEK` as a flag to the underlying `recv` system call.
+impl<S: AsRawFd> NonBufferedStream<S> {
+    fn init(&mut self) {
+        let reactor = self.reactor.upgrade().unwrap();
+        let stream_fd = self.stream.as_raw_fd();
+        self.source_rx = Some(reactor.poll_read_ready(stream_fd));
+    }
+
+    pub(crate) fn try_peek(&self, buf: &mut [u8]) -> Option<io::Result<usize>> {
+        super::yolo_peek(self.stream.as_raw_fd(), buf)
+    }
+
     pub(crate) async fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
         let source = self.reactor.upgrade().unwrap().recv(
             self.stream.as_raw_fd(),
@@ -128,18 +253,90 @@ impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> GlommioStream<S> {
         Ok(sz)
     }
 
-    fn consume_receive_buffer(&mut self, buf: &mut [u8]) -> Option<io::Result<usize>> {
-        if let Some(src) = self.rx_buf.as_mut() {
-            let sz = std::cmp::min(src.len(), buf.len());
-            buf[0..sz].copy_from_slice(&src.as_bytes()[0..sz]);
-            src.trim_front(sz);
-            if src.is_empty() {
-                self.rx_buf.take();
+    pub(crate) fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let reactor = self.reactor.upgrade().unwrap();
+        let reactor = reactor.as_ref();
+
+        let no_pending_poll = self
+            .source_rx
+            .as_ref()
+            .map(|src| src.result().is_some())
+            .unwrap_or(true);
+
+        if no_pending_poll {
+            if let Some(result) = super::yolo_recv(self.stream.as_raw_fd(), buf) {
+                self.source_rx.take();
+                self.read_timeout.cancel_timer(reactor);
+                let result = poll_err!(result);
+                // Start an early poll if the buffer is not fully filled. So when
+                // the next time `poll_read` is called, it will be known immediately
+                // whether the underlying stream is ready for reading.
+                if result > 0 && result < buf.len() {
+                    self.source_rx = Some(reactor.poll_read_ready(self.stream.as_raw_fd()));
+                    // The `rush_dispatch`s here and after could be removed to
+                    // improve performance if #458 is handled appropriately.
+                    reactor.rush_dispatch(self.source_rx.as_ref().unwrap());
+                }
+                return Poll::Ready(Ok(result));
             }
-            Some(Ok(sz))
-        } else {
-            None
         }
+
+        poll_err!(self.read_timeout.check(reactor));
+
+        if no_pending_poll {
+            self.source_rx = Some(reactor.poll_read_ready(self.stream.as_raw_fd()));
+            reactor.rush_dispatch(self.source_rx.as_ref().unwrap());
+        }
+
+        let source = self.source_rx.as_ref().unwrap();
+        source.add_waiter_single(cx.waker());
+        self.read_timeout.maybe_set_timer(reactor, cx.waker());
+        Poll::Pending
+    }
+
+    pub(crate) fn poll_write(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        // On the write path, we always start with calling `yolo_send`, because
+        // it is very likely to success. It could be a waste if it already timed
+        // out since the last `poll_write`, but it would not cost much more to
+        // give it one last chance in this case.
+        if let Some(result) = super::yolo_send(self.stream.as_raw_fd(), buf) {
+            let reactor = self.reactor.upgrade().unwrap();
+            self.write_timeout.cancel_timer(reactor.as_ref());
+            self.source_tx.take();
+            return Poll::Ready(result);
+        }
+
+        let reactor = self.reactor.upgrade().unwrap();
+        let reactor = reactor.as_ref();
+        poll_err!(self.write_timeout.check(reactor));
+
+        let no_pending_poll = self
+            .source_tx
+            .as_ref()
+            .map(|src| src.result().is_some())
+            .unwrap_or(true);
+
+        if no_pending_poll {
+            self.source_tx = Some(reactor.poll_write_ready(self.stream.as_raw_fd()));
+        }
+
+        let source = self.source_tx.as_ref().unwrap();
+        source.add_waiter_single(cx.waker());
+        self.write_timeout.maybe_set_timer(reactor, cx.waker());
+        Poll::Pending
+    }
+
+    pub(crate) fn poll_close(&mut self, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.source_tx.take();
+        Poll::Ready(sys::shutdown(self.stream.as_raw_fd(), Shutdown::Write))
     }
 
     /// io_uring has support for shutdown now, but it is not in any released
@@ -153,114 +350,90 @@ impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> GlommioStream<S> {
     ) -> Poll<io::Result<()>> {
         Poll::Ready(sys::shutdown(self.stream.as_raw_fd(), how))
     }
+}
 
-    pub(crate) fn allocate_buffer(&self, size: usize) -> DmaBuffer {
-        self.reactor.upgrade().unwrap().alloc_dma_buffer(size)
-    }
+#[derive(Debug)]
+pub(crate) struct GlommioStream<S, B> {
+    stream: NonBufferedStream<S>,
+    rx_buf: B,
+    rx_done: Cell<bool>,
+}
 
-    pub(crate) fn set_write_timeout(&self, dur: Option<Duration>) -> Result<()> {
-        if let Some(dur) = dur.as_ref() {
-            if dur.as_nanos() == 0 {
-                return Err(io::Error::from_raw_os_error(libc::EINVAL).into());
-            }
-        }
-        self.write_timeout.set(dur);
-        Ok(())
-    }
-
-    pub(crate) fn set_read_timeout(&self, dur: Option<Duration>) -> Result<()> {
-        if let Some(dur) = dur.as_ref() {
-            if dur.as_nanos() == 0 {
-                return Err(io::Error::from_raw_os_error(libc::EINVAL).into());
-            }
-        }
-        self.read_timeout.set(dur);
-        Ok(())
-    }
-
-    pub(crate) fn write_timeout(&self) -> Option<Duration> {
-        self.write_timeout.get()
-    }
-
-    pub(crate) fn read_timeout(&self) -> Option<Duration> {
-        self.read_timeout.get()
-    }
-
-    pub(crate) fn yolo_rx(&mut self, buf: &mut [u8]) -> Option<io::Result<usize>> {
-        if self.rx_yolo {
-            super::yolo_recv(self.stream.as_raw_fd(), buf)
-        } else {
-            None
-        }
-        .or_else(|| {
-            self.rx_yolo = false;
-            None
-        })
-    }
-
-    pub(crate) fn yolo_tx(&mut self, buf: &[u8]) -> Option<io::Result<usize>> {
-        if self.tx_yolo {
-            super::yolo_send(self.stream.as_raw_fd(), buf)
-        } else {
-            None
-        }
-        .or_else(|| {
-            self.tx_yolo = false;
-            None
-        })
-    }
-
-    pub(crate) fn poll_replenish_buffer(
-        &mut self,
-        cx: &mut Context<'_>,
-        size: usize,
-    ) -> Poll<io::Result<usize>> {
-        let source = match self.source_rx.take() {
-            Some(source) => source,
-            None => poll_err!(self.reactor.upgrade().unwrap().rushed_recv(
-                self.stream.as_raw_fd(),
-                size,
-                self.read_timeout.get()
-            )),
+impl<S> From<socket2::Socket> for GlommioStream<S, NonBuffered>
+where
+    S: AsRawFd + From<socket2::Socket> + Unpin,
+{
+    fn from(socket: socket2::Socket) -> Self {
+        let reactor = crate::executor().reactor();
+        let mut stream = NonBufferedStream {
+            reactor: Rc::downgrade(&reactor),
+            stream: socket.into(),
+            source_tx: None,
+            source_rx: None,
+            write_timeout: Timeout::new(reactor.register_timer()),
+            read_timeout: Timeout::new(reactor.register_timer()),
         };
-
-        if source.result().is_none() {
-            source.add_waiter_single(cx.waker().clone());
-            self.source_rx = Some(source);
-            Poll::Pending
-        } else {
-            let buf = poll_err!(RecvBuffer::try_from(source));
-            self.rx_yolo = true;
-            self.rx_buf = Some(buf.buf);
-            Poll::Ready(Ok(self.rx_buf.as_ref().unwrap().len()))
+        stream.init();
+        GlommioStream {
+            stream,
+            rx_buf: NonBuffered,
+            rx_done: Cell::new(false),
         }
     }
+}
 
-    pub(crate) fn write_dma(
-        &mut self,
-        cx: &mut Context<'_>,
-        buf: DmaBuffer,
-    ) -> Poll<io::Result<usize>> {
-        let source = match self.source_tx.take() {
-            Some(source) => source,
-            None => poll_err!(self.reactor.upgrade().unwrap().rushed_send(
-                self.stream.as_raw_fd(),
-                buf,
-                self.write_timeout.get()
-            )),
-        };
+impl<S: AsRawFd> AsRawFd for GlommioStream<S, NonBuffered> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.stream.stream.as_raw_fd()
+    }
+}
 
-        match source.result() {
-            None => {
-                source.add_waiter_single(cx.waker().clone());
-                self.source_tx = Some(source);
-                Poll::Pending
-            }
-            Some(res) => {
-                self.tx_yolo = true;
-                Poll::Ready(res)
+impl<S> FromRawFd for GlommioStream<S, NonBuffered>
+where
+    S: AsRawFd + FromRawFd + From<socket2::Socket> + Unpin,
+{
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        let socket = socket2::Socket::from_raw_fd(fd);
+        GlommioStream::from(socket)
+    }
+}
+
+impl<S> GlommioStream<S, NonBuffered> {
+    pub(crate) fn buffered_with<B: Buffered>(self, rx_buf: B) -> GlommioStream<S, B> {
+        GlommioStream {
+            stream: self.stream,
+            rx_buf,
+            rx_done: self.rx_done,
+        }
+    }
+}
+
+impl<S: AsRawFd, B: RxBuf> GlommioStream<S, B> {
+    /// Receives data on the socket from the remote address to which it is
+    /// connected, without removing that data from the queue.
+    ///
+    /// On success, returns the number of bytes peeked.
+    /// Successive calls return the same data. This is accomplished by passing
+    /// `MSG_PEEK` as a flag to the underlying `recv` system call.
+    pub(crate) async fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut pos = self.rx_buf.peek(buf);
+        if pos < buf.len() && !self.rx_done.get() {
+            if let Some(result) = self.stream.try_peek(&mut buf[pos..]) {
+                match result {
+                    Err(e) => return Err(e),
+                    Ok(len) => {
+                        pos += len;
+                        if len == 0 {
+                            self.rx_done.set(true);
+                        }
+                    }
+                }
             }
         }
+        if pos > 0 || self.rx_done.get() {
+            return Ok(pos);
+        }
+        self.stream.peek(buf).await
     }
 
     pub(crate) fn poll_read(
@@ -268,20 +441,24 @@ impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> GlommioStream<S> {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        poll_some!(self.consume_receive_buffer(buf));
-        poll_some!(self.yolo_rx(buf));
-        poll_err!(ready!(self.poll_replenish_buffer(cx, buf.len())));
-        poll_some!(self.consume_receive_buffer(buf));
-        unreachable!();
+        if self.rx_buf.is_empty() {
+            if buf.len() >= self.rx_buf.buffer_size() {
+                return self.stream.poll_read(cx, buf);
+            }
+            if !self.rx_done.get() {
+                poll_err!(ready!(self.poll_replenish_buffer(cx)));
+            }
+        }
+        Poll::Ready(Ok(self.rx_buf.read(buf)))
     }
 
-    pub(crate) fn consume(&mut self, amt: usize) {
-        let buf_ref = self.rx_buf.as_mut().unwrap();
-        let amt = std::cmp::min(amt, buf_ref.len());
-        buf_ref.trim_front(amt);
-        if buf_ref.is_empty() {
-            self.rx_buf.take();
+    fn poll_replenish_buffer(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+        let result = poll_err!(ready!(self.stream.poll_read(cx, self.rx_buf.unfilled())));
+        self.rx_buf.handle_result(result);
+        if result == 0 {
+            self.rx_done.set(true);
         }
+        Poll::Ready(Ok(result))
     }
 
     pub(crate) fn poll_write(
@@ -289,18 +466,55 @@ impl<S: FromRawFd + AsRawFd + From<socket2::Socket>> GlommioStream<S> {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        poll_some!(self.yolo_tx(buf));
-        let mut dma = self.allocate_buffer(buf.len());
-        assert_eq!(dma.write_at(0, buf), buf.len());
-        self.write_dma(cx, dma)
+        self.stream.poll_write(cx, buf)
     }
 
     pub(crate) fn poll_flush(&self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(Ok(()))
     }
 
-    pub(crate) fn poll_close(&mut self, _: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.source_tx.take();
-        Poll::Ready(sys::shutdown(self.stream.as_raw_fd(), Shutdown::Write))
+    pub(crate) fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.stream.poll_close(cx)
+    }
+
+    pub(crate) fn poll_shutdown(
+        &self,
+        cx: &mut Context<'_>,
+        how: Shutdown,
+    ) -> Poll<io::Result<()>> {
+        self.stream.poll_shutdown(cx, how)
+    }
+
+    pub(crate) fn set_write_timeout(&self, dur: Option<Duration>) -> Result<()> {
+        self.stream.write_timeout.set(dur)
+    }
+
+    pub(crate) fn set_read_timeout(&self, dur: Option<Duration>) -> Result<()> {
+        self.stream.read_timeout.set(dur)
+    }
+
+    pub(crate) fn write_timeout(&self) -> Option<Duration> {
+        self.stream.write_timeout.get()
+    }
+
+    pub(crate) fn read_timeout(&self) -> Option<Duration> {
+        self.stream.read_timeout.get()
+    }
+
+    pub(crate) fn stream(&self) -> &S {
+        &self.stream.stream
+    }
+}
+
+impl<S: AsRawFd, B: Buffered> GlommioStream<S, B> {
+    pub(crate) fn poll_fill_buf(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        if self.rx_buf.is_empty() {
+            poll_err!(ready!(self.poll_replenish_buffer(cx)));
+        }
+        Poll::Ready(Ok(self.rx_buf.as_bytes()))
+    }
+
+    pub(crate) fn consume(&mut self, amt: usize) {
+        self.rx_buf.consume(amt);
     }
 }

--- a/glommio/src/sys/dma_buffer.rs
+++ b/glommio/src/sys/dma_buffer.rs
@@ -118,12 +118,6 @@ impl DmaBuffer {
         self.size = newsize;
     }
 
-    pub(crate) fn trim_front(&mut self, trim: usize) {
-        assert!(trim <= self.size);
-        self.trim += trim;
-        self.size -= trim;
-    }
-
     /// Returns a representation of the current addressable contents of this
     /// `DmaBuffer` as a byte slice
     pub fn as_bytes(&self) -> &[u8] {

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -1121,12 +1121,12 @@ pub(crate) struct Reactor {
     rings_depth: usize,
 }
 
-fn common_flags() -> PollFlags {
+pub(crate) fn common_flags() -> PollFlags {
     PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL
 }
 
 /// Epoll flags for all possible readability events.
-fn read_flags() -> PollFlags {
+pub(crate) fn read_flags() -> PollFlags {
     PollFlags::POLLIN | PollFlags::POLLPRI
 }
 
@@ -1297,6 +1297,11 @@ impl Reactor {
 
     pub(crate) fn read_buffered(&self, source: &Source, pos: u64, size: usize) {
         let op = UringOpDescriptor::Read(pos, size);
+        self.queue_standard_request(source, op);
+    }
+
+    pub(crate) fn poll_ready(&self, source: &Source, flags: PollFlags) {
+        let op = UringOpDescriptor::PollAdd(flags);
         self.queue_standard_request(source, op);
     }
 


### PR DESCRIPTION
This is a continuation of #451. In this PR, the standard traits for `GlommioStream` is re-implemented using poll + recv. Performance of the `echo` and `proxy` benchmarks improved compared to current master branch, but the result could be even better if invocations to `rush_dispatch` could be removed from `poll_recv`. However, to do that, #458 needs to be addressed first, otherwise there is good probability for the proxy benchmark to deadlock in the 1000-client cases.

I also tested two epoll based implementations, which gives the best performance among all. The efficiency of them comes from edge-triggered epoll: no additional overhead will be introduced after when the socket fd is registered to the epoll. While in the poll + recv implementation, an additional SQE is needed each time we poll the socket fd, because poll on io-uring works in oneshot mode.

There may be a chance for an fast-poll based implementation to surpass the epoll ones in some scenarios. But I believe it could only happen after #458 is handled appropriately so we can avoid `rush_dispatch` in socket io.

![Screenshot from 2021-11-15 11-13-07](https://user-images.githubusercontent.com/1327305/141716579-4b0cd727-c401-4894-92ab-b8641cde6293.png)

