### PR TITLE
make the depth of the io rings a configurable knob

### DIFF
--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -62,7 +62,6 @@ use crate::{
     parking,
     reactor,
     sys,
-    sys::DEFAULT_RING_SUBMISSION_DEPTH,
     task::{self, waker_fn::dummy_waker},
     GlommioError,
     IoRequirements,
@@ -72,6 +71,11 @@ use crate::{
     Shares,
 };
 use ahash::AHashMap;
+
+pub(crate) const DEFAULT_EXECUTOR_NAME: &str = "unnamed";
+pub(crate) const DEFAULT_PREEMPT_TIMER: Duration = Duration::from_millis(100);
+pub(crate) const DEFAULT_IO_MEMORY: usize = 10 << 20;
+pub(crate) const DEFAULT_RING_SUBMISSION_DEPTH: usize = 128;
 
 /// Result type alias that removes the need to specify a type parameter
 /// that's only valid in the channel variants of the error. Otherwise, it
@@ -438,10 +442,10 @@ impl LocalExecutorBuilder {
         LocalExecutorBuilder {
             placement,
             spin_before_park: None,
-            name: String::from("unnamed"),
-            io_memory: 10 << 20,
+            name: String::from(DEFAULT_EXECUTOR_NAME),
+            io_memory: DEFAULT_IO_MEMORY,
             ring_depth: DEFAULT_RING_SUBMISSION_DEPTH,
-            preempt_timer_duration: Duration::from_millis(100),
+            preempt_timer_duration: DEFAULT_PREEMPT_TIMER,
         }
     }
 
@@ -659,10 +663,10 @@ impl LocalExecutorPoolBuilder {
     pub fn new(placement: PoolPlacement) -> Self {
         Self {
             spin_before_park: None,
-            name: String::from("unnamed"),
-            io_memory: 10 << 20,
+            name: String::from(DEFAULT_EXECUTOR_NAME),
+            io_memory: DEFAULT_IO_MEMORY,
             ring_depth: DEFAULT_RING_SUBMISSION_DEPTH,
-            preempt_timer_duration: Duration::from_millis(100),
+            preempt_timer_duration: DEFAULT_PREEMPT_TIMER,
             placement,
         }
     }

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -62,6 +62,7 @@ use crate::{
     parking,
     reactor,
     sys,
+    sys::DEFAULT_RING_SUBMISSION_DEPTH,
     task::{self, waker_fn::dummy_waker},
     GlommioError,
     IoRequirements,
@@ -898,7 +899,11 @@ impl LocalExecutor {
             queues: Rc::new(RefCell::new(queues)),
             parker: p,
             id: notifier.id(),
-            reactor: Rc::new(reactor::Reactor::new(notifier, io_memory)),
+            reactor: Rc::new(reactor::Reactor::new(
+                notifier,
+                io_memory,
+                DEFAULT_RING_SUBMISSION_DEPTH,
+            )),
         })
     }
 

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -11,7 +11,7 @@ use crate::{
         read_result::ReadResult,
         ScheduledSource,
     },
-    sys::{self, sysfs, DirectIo, DmaBuffer, PollableStatus, DEFAULT_RING_SUBMISSION_DEPTH},
+    sys::{self, sysfs, DirectIo, DmaBuffer, PollableStatus},
 };
 use futures_lite::{Stream, StreamExt};
 use nix::sys::statfs::*;
@@ -333,7 +333,7 @@ impl DmaFile {
             )
         });
         ReadManyResult {
-            inner: OrderedBulkIo::new(self.clone(), DEFAULT_RING_SUBMISSION_DEPTH, it),
+            inner: OrderedBulkIo::new(self.clone(), 128, it),
             current: Default::default(),
         }
     }

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -11,7 +11,7 @@ use crate::{
         read_result::ReadResult,
         ScheduledSource,
     },
-    sys::{self, sysfs, DirectIo, DmaBuffer, PollableStatus, RING_SUBMISSION_DEPTH},
+    sys::{self, sysfs, DirectIo, DmaBuffer, PollableStatus, DEFAULT_RING_SUBMISSION_DEPTH},
 };
 use futures_lite::{Stream, StreamExt};
 use nix::sys::statfs::*;
@@ -333,7 +333,7 @@ impl DmaFile {
             )
         });
         ReadManyResult {
-            inner: OrderedBulkIo::new(self.clone(), RING_SUBMISSION_DEPTH, it),
+            inner: OrderedBulkIo::new(self.clone(), DEFAULT_RING_SUBMISSION_DEPTH, it),
             current: Default::default(),
         }
     }

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -333,7 +333,7 @@ impl DmaFile {
             )
         });
         ReadManyResult {
-            inner: OrderedBulkIo::new(self.clone(), 128, it),
+            inner: OrderedBulkIo::new(self.clone(), crate::executor().reactor().ring_depth(), it),
             current: Default::default(),
         }
     }

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -224,6 +224,10 @@ impl Reactor {
         self.sys.id()
     }
 
+    pub(crate) fn ring_depth(&self) -> usize {
+        self.sys.ring_depth()
+    }
+
     fn new_source(
         &self,
         raw: RawFd,

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -189,8 +189,12 @@ pub(crate) struct Reactor {
 }
 
 impl Reactor {
-    pub(crate) fn new(notifier: Arc<SleepNotifier>, io_memory: usize) -> Reactor {
-        let sys = sys::Reactor::new(notifier, io_memory)
+    pub(crate) fn new(
+        notifier: Arc<SleepNotifier>,
+        io_memory: usize,
+        ring_depth: usize,
+    ) -> Reactor {
+        let sys = sys::Reactor::new(notifier, io_memory, ring_depth)
             .expect("cannot initialize I/O event notification");
         let (preempt_ptr_head, preempt_ptr_tail) = sys.preempt_pointers();
         Reactor {

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -58,7 +58,6 @@ use nix::sys::{
 };
 
 const MSG_ZEROCOPY: i32 = 0x4000000;
-pub(crate) const DEFAULT_RING_SUBMISSION_DEPTH: usize = 128;
 
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -1772,7 +1771,7 @@ mod tests {
     #[test]
     fn timeout_smoke_test() {
         let notifier = sys::new_sleep_notifier().unwrap();
-        let reactor = Reactor::new(notifier, 0, DEFAULT_RING_SUBMISSION_DEPTH).unwrap();
+        let reactor = Reactor::new(notifier, 0, 128).unwrap();
 
         fn timeout_source(millis: u64) -> (Source, UringOpDescriptor) {
             let source = Source::new(

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -1117,6 +1117,8 @@ pub(crate) struct Reactor {
     source_map: Rc<RefCell<SourceMap>>,
 
     syscall_thread: BlockingThread,
+
+    rings_depth: usize,
 }
 
 fn common_flags() -> PollFlags {
@@ -1233,11 +1235,16 @@ impl Reactor {
             notifier,
             eventfd_src,
             source_map,
+            rings_depth: ring_depth,
         })
     }
 
     pub(crate) fn id(&self) -> usize {
         self.notifier.id()
+    }
+
+    pub(crate) fn ring_depth(&self) -> usize {
+        self.rings_depth
     }
 
     pub(crate) fn install_eventfd(&self) {


### PR DESCRIPTION
Previously our io rings had a depth of 128. A user can now override this
if they feel like it. If they do, the setting will be used as the concurrency
level of `reqad_many` as well.