### PR TITLE
update dependencies to avoid depending on the `chrono` crate

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -47,7 +47,7 @@ hdrhistogram = "7.3.0"
 pretty_env_logger = "~0.4"
 rand = "~0.8"
 tokio = { version = "1.12", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time", "sync"] }
-tracing-subscriber = "~0.2"
+tracing-subscriber = { version = "~0.3", features = ["env-filter"] }
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
The `chrono` crate has a security vulnerability, and the ecosystem is
moving away from it, so should we (also it annoys me that `cargo-check`
doesn't pass anymore because of this).

See https://rustsec.org/advisories/RUSTSEC-2020-0159 for details.

Cargo-check can't be configured to tolerate vulnerabilities in dev
dependencies right now. It's a feature request, so maybe it'll come one
day:
https://github.com/EmbarkStudios/cargo-deny/issues/322