### PR TITLE
make it easy to consume a `DmaStreamReader` without copying

### DIFF
--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -569,6 +569,12 @@ impl DmaStreamReader {
             let state = self.state.borrow();
             let start_id = state.buffer_id(self.current_pos);
             let offset = state.offset_of(self.current_pos);
+
+            // enforce max_pos
+            if self.current_pos + len > state.max_pos {
+                len = state.max_pos - self.current_pos;
+            }
+
             (start_id, (self.buffer_size - offset as u64).min(len))
         };
 


### PR DESCRIPTION
The `get_buffer_aligned` API could be better. It relies on user code to be
aware of buffer boundaries locations. This makes user code more
complicated and brittle because the buffer size will generally be a
configurable knob, subject to change.

Fear not, however, for there is a better way!

Instead of failing when reading too much in `get_buffer_aligned,` read
whatever we can from the current buffer and return the number of
remaining bytes. This allows the following:
* If the read fits inside a buffer, the user can consume the result
directly without any copy;
* If the read crosses buffer boundaries and the user can consume partial
results, it can do so in a loop without any copies;
* If the read crosses buffer boundaries and the user needs a complete
result, `get_buffer_aligned` may be used trivially in a loop that
concatenates the results in a reusable user-allocated buffer.

This PR also replaces the ad-hoc `poll_read` implementation for a proxy
call to `get_buffer_aligned`, resulting in a very nice reduction in complexity.