### PR TITLE
add a way to measure and report IO latency

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -35,6 +35,7 @@ pin-project-lite = "~0.2"
 rlimit = "~0.6"
 scoped-tls = "1.0.0"
 scopeguard = "1.1"
+sketches-ddsketch = "0.1"
 smallvec = { version = "1.7", features = ["union"] }
 socket2 = { version = "~0.3", features = ["unix", "reuseport"] }
 tracing = "~0.1"

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -853,10 +853,11 @@ pub(crate) mod test {
             }})
             .await;
         assert_eq!(*total_reads.borrow(), 512);
-        assert_eq!(
-            crate::executor().io_stats().all_rings().file_reads().0,
-            4096 / new_file.o_direct_alignment
-        );
+
+        let io_stats = crate::executor().io_stats().all_rings();
+        assert_eq!(io_stats.file_reads().0, 4096 / new_file.o_direct_alignment);
+        assert_eq!(io_stats.post_reactor_io_scheduler_latency_us().count(), 1);
+        assert_eq!(io_stats.io_latency_us().count(), 1);
         new_file.close_rc().await.expect("failed to close file");
     });
 
@@ -884,10 +885,10 @@ pub(crate) mod test {
             }})
             .await;
         assert_eq!(*total_reads.borrow(), 511);
-        assert_eq!(
-            crate::executor().io_stats().all_rings().file_reads().0,
-            4096 / new_file.o_direct_alignment
-        );
+        let io_stats = crate::executor().io_stats().all_rings();
+        assert_eq!(io_stats.file_reads().0, 4096 / new_file.o_direct_alignment);
+        assert_eq!(io_stats.post_reactor_io_scheduler_latency_us().count(), 1);
+        assert_eq!(io_stats.io_latency_us().count(), 1);
         new_file.close_rc().await.expect("failed to close file");
     });
 
@@ -915,10 +916,10 @@ pub(crate) mod test {
             .await;
 
         assert_eq!(*total_reads.borrow(), 511);
-        assert_eq!(
-            crate::executor().io_stats().all_rings().file_reads().0,
-            4096 / new_file.o_direct_alignment
-        );
+        let io_stats = crate::executor().io_stats().all_rings();
+        assert_eq!(io_stats.file_reads().0, 4096 / new_file.o_direct_alignment);
+        assert_eq!(io_stats.post_reactor_io_scheduler_latency_us().count(), 1);
+        assert_eq!(io_stats.io_latency_us().count(), 1);
         new_file.close_rc().await.expect("failed to close file");
     });
 }

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -295,9 +295,6 @@ extern crate lazy_static;
 #[macro_use(defer)]
 extern crate scopeguard;
 
-use crate::reactor::Reactor;
-use std::{fmt::Debug, time::Duration};
-
 /// Call [`Waker::wake()`] and log to `error` if panicked.
 macro_rules! wake {
     ($waker:expr $(,)?) => {
@@ -464,6 +461,7 @@ mod shares;
 pub mod sync;
 pub mod timer;
 
+use crate::reactor::Reactor;
 pub use crate::{
     byte_slice_ext::{ByteSliceExt, ByteSliceMutExt},
     error::{
@@ -501,7 +499,12 @@ pub use crate::{
 };
 pub use enclose::enclose;
 pub use scopeguard::defer;
-use std::iter::Sum;
+use sketches_ddsketch::DDSketch;
+use std::{
+    fmt::{Debug, Formatter},
+    iter::Sum,
+    time::Duration,
+};
 
 /// Provides common imports that almost all Glommio applications will need
 pub mod prelude {
@@ -574,8 +577,9 @@ impl IoRequirements {
 }
 
 /// Stores information about IO performed in a specific ring
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Clone)]
 pub struct RingIoStats {
+    // Counters
     pub(crate) files_opened: u64,
     pub(crate) files_closed: u64,
     pub(crate) file_reads: u64,
@@ -588,13 +592,60 @@ pub struct RingIoStats {
     pub(crate) file_bytes_written: u64,
     pub(crate) file_buffered_writes: u64,
     pub(crate) file_buffered_bytes_written: u64,
+
+    // Distributions
+    pub(crate) io_latency_us: sketches_ddsketch::DDSketch,
+    pub(crate) post_reactor_io_scheduler_latency_us: sketches_ddsketch::DDSketch,
+}
+
+impl Default for RingIoStats {
+    fn default() -> Self {
+        Self {
+            files_opened: 0,
+            files_closed: 0,
+            file_reads: 0,
+            file_bytes_read: 0,
+            file_buffered_reads: 0,
+            file_buffered_bytes_read: 0,
+            file_deduped_reads: 0,
+            file_deduped_bytes_read: 0,
+            file_writes: 0,
+            file_bytes_written: 0,
+            file_buffered_writes: 0,
+            file_buffered_bytes_written: 0,
+            io_latency_us: sketches_ddsketch::DDSketch::new(sketches_ddsketch::Config::new(
+                0.01, 2048, 1.0e-9,
+            )),
+            post_reactor_io_scheduler_latency_us: sketches_ddsketch::DDSketch::new(
+                sketches_ddsketch::Config::new(0.01, 2048, 1.0e-9),
+            ),
+        }
+    }
+}
+
+impl Debug for RingIoStats {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RingIoStats")
+            .field("files_opened", &self.files_opened)
+            .field("files_closed", &self.files_closed)
+            .field("file_reads", &self.file_reads)
+            .field("file_bytes_read", &self.file_bytes_read)
+            .field("file_buffered_reads", &self.file_buffered_reads)
+            .field("file_buffered_bytes_read", &self.file_buffered_bytes_read)
+            .field("file_deduped_reads", &self.file_deduped_reads)
+            .field("file_deduped_bytes_read", &self.file_deduped_bytes_read)
+            .field("file_writes", &self.file_writes)
+            .field("file_bytes_written", &self.file_bytes_written)
+            .field("file_buffered_writes", &self.file_buffered_writes)
+            .field(
+                "file_buffered_bytes_written",
+                &self.file_buffered_bytes_written,
+            )
+            .finish_non_exhaustive()
+    }
 }
 
 impl RingIoStats {
-    fn new() -> Self {
-        Default::default()
-    }
-
     /// The total amount of files opened in this executor so far.
     ///
     /// [`files_opened`] - [`files_closed`] gives the current open files count
@@ -650,24 +701,45 @@ impl RingIoStats {
     pub fn file_buffered_writes(&self) -> (u64, u64) {
         (self.file_buffered_writes, self.file_buffered_bytes_written)
     }
+
+    /// The IO latency
+    ///
+    /// Returns a distribution of measures tracking the time sources spent in
+    /// the ring
+    pub fn io_latency_us(&self) -> &DDSketch {
+        &self.io_latency_us
+    }
+
+    /// The post-reactor IO scheduler latency
+    ///
+    /// Returns a distribution of measures tracking the time between the moment
+    /// an IO operation was marked as fulfilled by the reactor and when the
+    /// result was consumed by the application code.
+    pub fn post_reactor_io_scheduler_latency_us(&self) -> &DDSketch {
+        &self.post_reactor_io_scheduler_latency_us
+    }
 }
 
-impl Sum<RingIoStats> for RingIoStats {
-    fn sum<I: Iterator<Item = RingIoStats>>(iter: I) -> Self {
-        iter.fold(RingIoStats::new(), |a, b| RingIoStats {
-            files_opened: a.files_opened + b.files_opened,
-            files_closed: a.files_closed + b.files_closed,
-            file_reads: a.file_reads + b.file_reads,
-            file_bytes_read: a.file_bytes_read + b.file_bytes_read,
-            file_buffered_reads: a.file_buffered_reads + b.file_buffered_reads,
-            file_buffered_bytes_read: a.file_buffered_bytes_read + b.file_buffered_bytes_read,
-            file_deduped_reads: a.file_deduped_reads + b.file_deduped_reads,
-            file_deduped_bytes_read: a.file_deduped_bytes_read + b.file_deduped_bytes_read,
-            file_writes: a.file_writes + b.file_writes,
-            file_bytes_written: a.file_bytes_written + b.file_bytes_written,
-            file_buffered_writes: a.file_buffered_writes + b.file_buffered_writes,
-            file_buffered_bytes_written: a.file_buffered_bytes_written
-                + b.file_buffered_bytes_written,
+impl<'a> Sum<&'a RingIoStats> for RingIoStats {
+    fn sum<I: Iterator<Item = &'a RingIoStats>>(iter: I) -> Self {
+        iter.fold(RingIoStats::default(), |mut a, b| {
+            a.files_opened += b.files_opened;
+            a.files_closed += b.files_closed;
+            a.file_reads += b.file_reads;
+            a.file_bytes_read += b.file_bytes_read;
+            a.file_buffered_reads += b.file_buffered_reads;
+            a.file_buffered_bytes_read += b.file_buffered_bytes_read;
+            a.file_deduped_reads += b.file_deduped_reads;
+            a.file_deduped_bytes_read += b.file_deduped_bytes_read;
+            a.file_writes += b.file_writes;
+            a.file_bytes_written += b.file_bytes_written;
+            a.file_buffered_writes += b.file_buffered_writes;
+            a.file_buffered_bytes_written += b.file_buffered_bytes_written;
+            a.post_reactor_io_scheduler_latency_us
+                .merge(&b.post_reactor_io_scheduler_latency_us)
+                .unwrap();
+            a.io_latency_us.merge(&b.io_latency_us).unwrap();
+            a
         })
     }
 }
@@ -694,7 +766,7 @@ impl IoStats {
 
     /// Combine stats from all rings
     pub fn all_rings(&self) -> RingIoStats {
-        [self.main_ring, self.latency_ring, self.poll_ring]
+        [&self.main_ring, &self.latency_ring, &self.poll_ring]
             .iter()
             .copied()
             .sum()

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -378,10 +378,12 @@ macro_rules! to_io_error {
 #[cfg(test)]
 macro_rules! test_executor {
     ($( $fut:expr ),+ ) => {
-    use crate::executor::{LocalExecutor};
     use futures::future::join_all;
 
-    let local_ex = LocalExecutor::default();
+    let local_ex = crate::executor::LocalExecutorBuilder::new(crate::executor::Placement::Unbound)
+            .record_io_latencies(true)
+            .make()
+            .unwrap();
     local_ex.run(async move {
         let mut joins = Vec::new();
         $(

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -176,6 +176,7 @@ pub(crate) struct Reactor {
     shared_channels: RefCell<SharedChannels>,
 
     io_scheduler: Rc<IoScheduler>,
+    record_io_latencies: bool,
 
     /// Whether there are events in the latency ring.
     ///
@@ -196,6 +197,7 @@ impl Reactor {
         notifier: Arc<SleepNotifier>,
         io_memory: usize,
         ring_depth: usize,
+        record_io_latencies: bool,
     ) -> Reactor {
         let sys = sys::Reactor::new(notifier, io_memory, ring_depth)
             .expect("cannot initialize I/O event notification");
@@ -205,6 +207,7 @@ impl Reactor {
             timers: RefCell::new(Timers::new()),
             shared_channels: RefCell::new(SharedChannels::new()),
             io_scheduler: Rc::new(IoScheduler::new()),
+            record_io_latencies,
             preempt_ptr_head,
             preempt_ptr_tail: preempt_ptr_tail as _,
         }
@@ -500,12 +503,16 @@ impl Reactor {
                     stats.file_deduped_bytes_read += *result as u64 * op_count;
                 }
             }),
-            latency: Some(|io_lat, sched_lat, stats| {
-                stats.io_latency_us.add(io_lat.as_micros() as f64);
-                stats
-                    .post_reactor_io_scheduler_latency_us
-                    .add(sched_lat.as_micros() as f64)
-            }),
+            latency: if self.record_io_latencies {
+                Some(|io_lat, sched_lat, stats| {
+                    stats.io_latency_us.add(io_lat.as_micros() as f64);
+                    stats
+                        .post_reactor_io_scheduler_latency_us
+                        .add(sched_lat.as_micros() as f64)
+                })
+            } else {
+                None
+            },
         };
 
         let source = self.new_source(raw, SourceType::Read(pollable, None), Some(stats));
@@ -540,12 +547,16 @@ impl Reactor {
                 }
             }),
             reused: None,
-            latency: Some(|io_lat, sched_lat, stats| {
-                stats.io_latency_us.add(io_lat.as_micros() as f64);
-                stats
-                    .post_reactor_io_scheduler_latency_us
-                    .add(sched_lat.as_micros() as f64)
-            }),
+            latency: if self.record_io_latencies {
+                Some(|io_lat, sched_lat, stats| {
+                    stats.io_latency_us.add(io_lat.as_micros() as f64);
+                    stats
+                        .post_reactor_io_scheduler_latency_us
+                        .add(sched_lat.as_micros() as f64)
+                })
+            } else {
+                None
+            },
         };
 
         let source = self.new_source(

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -303,6 +303,7 @@ impl Reactor {
                 }
             }),
             reused: None,
+            post_reactor_scheduler_latency: None,
         };
 
         let source = self.new_source(
@@ -323,6 +324,7 @@ impl Reactor {
                 }
             }),
             reused: None,
+            post_reactor_scheduler_latency: None,
         };
 
         let source = self.new_source(
@@ -498,6 +500,7 @@ impl Reactor {
                     stats.file_deduped_bytes_read += *result as u64 * op_count;
                 }
             }),
+            post_reactor_scheduler_latency: None,
         };
 
         let source = self.new_source(raw, SourceType::Read(pollable, None), Some(stats));
@@ -532,6 +535,7 @@ impl Reactor {
                 }
             }),
             reused: None,
+            post_reactor_scheduler_latency: None,
         };
 
         let source = self.new_source(
@@ -616,6 +620,7 @@ impl Reactor {
                     }
                 }),
                 reused: None,
+                post_reactor_scheduler_latency: None,
             }),
         );
         self.sys.close(&source);
@@ -658,6 +663,7 @@ impl Reactor {
                     }
                 }),
                 reused: None,
+                post_reactor_scheduler_latency: None,
             }),
         );
         self.sys.open_at(&source, flags, mode);

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -500,7 +500,12 @@ impl Reactor {
                     stats.file_deduped_bytes_read += *result as u64 * op_count;
                 }
             }),
-            latency: None,
+            latency: Some(|io_lat, sched_lat, stats| {
+                stats.io_latency_us.add(io_lat.as_micros() as f64);
+                stats
+                    .post_reactor_io_scheduler_latency_us
+                    .add(sched_lat.as_micros() as f64)
+            }),
         };
 
         let source = self.new_source(raw, SourceType::Read(pollable, None), Some(stats));
@@ -535,7 +540,12 @@ impl Reactor {
                 }
             }),
             reused: None,
-            latency: None,
+            latency: Some(|io_lat, sched_lat, stats| {
+                stats.io_latency_us.add(io_lat.as_micros() as f64);
+                stats
+                    .post_reactor_io_scheduler_latency_us
+                    .add(sched_lat.as_micros() as f64)
+            }),
         };
 
         let source = self.new_source(

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -303,7 +303,7 @@ impl Reactor {
                 }
             }),
             reused: None,
-            post_reactor_scheduler_latency: None,
+            latency: None,
         };
 
         let source = self.new_source(
@@ -324,7 +324,7 @@ impl Reactor {
                 }
             }),
             reused: None,
-            post_reactor_scheduler_latency: None,
+            latency: None,
         };
 
         let source = self.new_source(
@@ -500,7 +500,7 @@ impl Reactor {
                     stats.file_deduped_bytes_read += *result as u64 * op_count;
                 }
             }),
-            post_reactor_scheduler_latency: None,
+            latency: None,
         };
 
         let source = self.new_source(raw, SourceType::Read(pollable, None), Some(stats));
@@ -535,7 +535,7 @@ impl Reactor {
                 }
             }),
             reused: None,
-            post_reactor_scheduler_latency: None,
+            latency: None,
         };
 
         let source = self.new_source(
@@ -620,7 +620,7 @@ impl Reactor {
                     }
                 }),
                 reused: None,
-                post_reactor_scheduler_latency: None,
+                latency: None,
             }),
         );
         self.sys.close(&source);
@@ -663,7 +663,7 @@ impl Reactor {
                     }
                 }),
                 reused: None,
-                post_reactor_scheduler_latency: None,
+                latency: None,
             }),
         );
         self.sys.open_at(&source, flags, mode);

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -457,6 +457,9 @@ pub(super) struct Wakers {
     /// Raw result of the operation.
     pub(super) result: Option<io::Result<usize>>,
 
+    /// The timestamp at which the reactor inserted the source in the ring
+    pub(super) seen_at: Option<std::time::Instant>,
+
     /// The timestamp at which the reactor fulfilled the source
     pub(super) fulfilled_at: Option<std::time::Instant>,
 
@@ -468,6 +471,7 @@ impl Wakers {
     pub(super) fn new() -> Self {
         Wakers {
             result: None,
+            seen_at: None,
             fulfilled_at: None,
             waiters: Default::default(),
         }

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -457,6 +457,9 @@ pub(super) struct Wakers {
     /// Raw result of the operation.
     pub(super) result: Option<io::Result<usize>>,
 
+    /// The timestamp at which the reactor fulfilled the source
+    pub(super) fulfilled_at: Option<std::time::Instant>,
+
     /// Tasks waiting for the next event.
     pub(super) waiters: SmallVec<[Waker; 1]>,
 }
@@ -465,6 +468,7 @@ impl Wakers {
     pub(super) fn new() -> Self {
         Wakers {
             result: None,
+            fulfilled_at: None,
             waiters: Default::default(),
         }
     }

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -1774,6 +1774,7 @@ fn queue_request_into_ring(
     descriptor: UringOpDescriptor,
     source_map: &mut SourceMap,
 ) {
+    source.inner.borrow_mut().wakers.seen_at = Some(Instant::now());
     let q = ring.borrow_mut().submission_queue();
     let id = source_map.add_source(source, Rc::clone(&q));
 


### PR DESCRIPTION
Add the plumbings necessary to measure various kinds of IO latency,

We now keep track of two kinds of IO latency: 
* The time sources spend in the ring, including the submission queue;
* The post-reactor scheduler latency, or the time the scheduler takes to
come back at the tasks that consume the IO;

We now export them as distribution in the `IoStats` struct. And this PR
adds distribution support to Glommio. We use "sketches" that give a 
statistical approximation of quantiles because we want the overhead 
(space and time) to be low when recording latencies.

A side effect of this is that pulling the stats from the reactor now
clears them (because a distribution needs to be cleared regularly to be
helpful). I don't expect this to be problematic because, in practice,
users want rates from the stats and keep the previous values in memory
to compute deltas. This should, therefore, greatly simplify this logic.
