### PR TITLE
update to rust-1.57 

### DIFF
--- a/glommio/benches/sharding.rs
+++ b/glommio/benches/sharding.rs
@@ -22,7 +22,7 @@ fn main() {
 
     #[derive(Clone)]
     struct RequestHandler {
-        nr_shards: usize,
+        _nr_shards: usize,
     }
 
     impl Handler<i32> for RequestHandler {
@@ -38,7 +38,7 @@ fn main() {
     let shards = LocalExecutorPoolBuilder::new(PoolPlacement::MaxSpread(nr_shards, None))
         .spin_before_park(Duration::from_millis(10))
         .on_all_shards(enclose!((mesh) move || async move {
-            let handler = RequestHandler { nr_shards };
+            let handler = RequestHandler { _nr_shards: nr_shards };
             let mut sharded = Sharded::new(mesh, get_shard_for, handler).await.unwrap();
             if sharded.shard_id() == 0 {
                 sharded.handle(repeat(1).take(n)).unwrap();

--- a/glommio/src/channels/channel_mesh.rs
+++ b/glommio/src/channels/channel_mesh.rs
@@ -360,8 +360,7 @@ impl<T: 'static + Send, A: MeshAdapter> MeshBuilder<T, A> {
 
             let peers: Vec<_> = peers
                 .iter_mut()
-                .map(|notifier| notifier.notifier.take())
-                .flatten()
+                .filter_map(|notifier| notifier.notifier.take())
                 .collect();
 
             Ok(RegisterResult::NotificationSenders(peers))

--- a/glommio/src/channels/local_channel.rs
+++ b/glommio/src/channels/local_channel.rs
@@ -63,7 +63,7 @@ pub struct LocalSender<T> {
 /// [`StreamExt`]: https://docs.rs/futures/0.3.6/futures/stream/trait.StreamExt.html
 pub struct LocalReceiver<T> {
     channel: LocalChannel<T>,
-    node: WaiterNode,
+    _node: WaiterNode,
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
@@ -420,7 +420,7 @@ impl<T> LocalChannel<T> {
             },
             LocalReceiver {
                 channel,
-                node: WaiterNode {
+                _node: WaiterNode {
                     waker: RefCell::new(None),
                     link: LinkedListLink::new(),
                     kind: RefCell::new(None),

--- a/glommio/src/channels/sharding.rs
+++ b/glommio/src/channels/sharding.rs
@@ -209,7 +209,7 @@ mod tests {
 
         #[derive(Clone)]
         struct RequestHandler {
-            nr_shards: usize,
+            _nr_shards: usize,
         }
 
         impl Handler<Msg> for RequestHandler {
@@ -223,7 +223,7 @@ mod tests {
 
         let shards = (0..nr_shards).map(|_| {
             LocalExecutorBuilder::default().spawn(enclose!((mesh) move || async move {
-                let handler = RequestHandler { nr_shards };
+                let handler = RequestHandler { _nr_shards: nr_shards };
                 let mut sharded = Sharded::new(mesh, shard_fn, handler).await.unwrap();
                 for i in 0..nr_shards {
                     sharded.send(i).await.unwrap();
@@ -249,7 +249,7 @@ mod tests {
 
         #[derive(Clone)]
         struct RequestHandler {
-            nr_shards: usize,
+            _nr_shards: usize,
         }
 
         impl Handler<Msg> for RequestHandler {
@@ -263,7 +263,7 @@ mod tests {
 
         let shards = (0..nr_shards).map(|_| {
             LocalExecutorBuilder::default().spawn(enclose!((mesh) move || async move {
-                let handler = RequestHandler { nr_shards };
+                let handler = RequestHandler { _nr_shards: nr_shards };
                 let mut sharded = Sharded::new(mesh, shard_fn, handler).await.unwrap();
                 for i in 0..nr_shards {
                     sharded.send_to(i, i).await.unwrap();

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -676,10 +676,7 @@ mod test {
                         // all good
                     }
                     Err(other_err) => {
-                        panic!(
-                            "incorrect error type: '{}' for channel send",
-                            other_err.to_string()
-                        )
+                        panic!("incorrect error type: '{}' for channel send", other_err)
                     }
                 }
             })

--- a/glommio/src/controllers/deadline_queue.rs
+++ b/glommio/src/controllers/deadline_queue.rs
@@ -133,8 +133,7 @@ type QueueItem<T> = Rc<dyn DeadlineSource<Output = T>>;
 struct InnerQueue<T> {
     queue: RefCell<VecDeque<(Instant, QueueItem<T>)>>,
     last_admitted: Cell<Instant>,
-
-    last_adjusted: Cell<Instant>,
+    _last_adjusted: Cell<Instant>,
     last_shares: Cell<usize>,
     accumulated_error: Cell<f64>,
     adjustment_period: Duration,
@@ -281,7 +280,7 @@ impl<T> InnerQueue<T> {
         Self {
             queue: RefCell::new(VecDeque::new()),
             last_admitted: Cell::new(now),
-            last_adjusted: Cell::new(now),
+            _last_adjusted: Cell::new(now),
             last_shares: Cell::new(1),
             accumulated_error: Cell::new(0.0),
             adjustment_period,
@@ -369,7 +368,7 @@ pub struct DeadlineQueue<T> {
     tq: TaskQueueHandle,
     sender: LocalSender<Rc<dyn DeadlineSource<Output = T>>>,
     responder: LocalReceiver<T>,
-    handle: task::join_handle::JoinHandle<()>,
+    _handle: task::join_handle::JoinHandle<()>,
     queue: Rc<InnerQueue<T>>,
 }
 
@@ -451,7 +450,7 @@ impl<T: 'static> DeadlineQueue<T> {
             tq,
             sender,
             responder,
-            handle,
+            _handle: handle,
             queue,
         }
     }

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -444,6 +444,7 @@ impl LocalExecutorBuilder {
     }
 
     /// Spin for duration before parking a reactor
+    #[must_use = "The builder must be built to be useful"]
     pub fn spin_before_park(mut self, spin: Duration) -> LocalExecutorBuilder {
         self.spin_before_park = Some(spin);
         self
@@ -451,6 +452,7 @@ impl LocalExecutorBuilder {
 
     /// Names the thread-to-be. Currently, the name is used for identification
     /// only in panic messages.
+    #[must_use = "The builder must be built to be useful"]
     pub fn name(mut self, name: &str) -> LocalExecutorBuilder {
         self.name = String::from(name);
         self
@@ -463,6 +465,7 @@ impl LocalExecutorBuilder {
     ///
     /// The system will always try to allocate at least 64 kiB for I/O memory,
     /// and the default is 10 MiB.
+    #[must_use = "The builder must be built to be useful"]
     pub fn io_memory(mut self, io_memory: usize) -> LocalExecutorBuilder {
         self.io_memory = io_memory;
         self
@@ -473,6 +476,7 @@ impl LocalExecutorBuilder {
     /// greater number of IO requests to the kernel at once.
     ///
     /// Values above zero are valid and the default is 128.
+    #[must_use = "The builder must be built to be useful"]
     pub fn ring_depth(mut self, ring_depth: usize) -> LocalExecutorBuilder {
         assert!(ring_depth > 0, "ring depth should be strictly positive");
         self.ring_depth = ring_depth;
@@ -490,6 +494,7 @@ impl LocalExecutorBuilder {
     ///
     /// [`need_preempt`]: ExecutorProxy::need_preempt
     /// [`Latency`]: crate::Latency
+    #[must_use = "The builder must be built to be useful"]
     pub fn preempt_timer(mut self, dur: Duration) -> LocalExecutorBuilder {
         self.preempt_timer_duration = dur;
         self
@@ -668,6 +673,7 @@ impl LocalExecutorPoolBuilder {
     /// Please see documentation under
     /// [`LocalExecutorBuilder::spin_before_park`] for details.  The setting
     /// is applied to all executors in the pool.
+    #[must_use = "The builder must be built to be useful"]
     pub fn spin_before_park(mut self, spin: Duration) -> Self {
         self.spin_before_park = Some(spin);
         self
@@ -678,6 +684,7 @@ impl LocalExecutorPoolBuilder {
     /// that when a thread is spawned, the `name` is combined with a hyphen
     /// and numeric id (e.g. `myname-1`) such that each thread has a unique
     /// name.
+    #[must_use = "The builder must be built to be useful"]
     pub fn name(mut self, name: &str) -> Self {
         self.name = String::from(name);
         self
@@ -685,6 +692,7 @@ impl LocalExecutorPoolBuilder {
 
     /// Please see documentation under [`LocalExecutorBuilder::io_memory`] for
     /// details.  The setting is applied to all executors in the pool.
+    #[must_use = "The builder must be built to be useful"]
     pub fn io_memory(mut self, io_memory: usize) -> Self {
         self.io_memory = io_memory;
         self
@@ -692,6 +700,7 @@ impl LocalExecutorPoolBuilder {
 
     /// Please see documentation under [`LocalExecutorBuilder::ring_depth`] for
     /// details.  The setting is applied to all executors in the pool.
+    #[must_use = "The builder must be built to be useful"]
     pub fn ring_depth(mut self, ring_depth: usize) -> Self {
         assert!(ring_depth > 0, "ring depth should be strictly positive");
         self.ring_depth = ring_depth;
@@ -700,6 +709,7 @@ impl LocalExecutorPoolBuilder {
 
     /// Please see documentation under [`LocalExecutorBuilder::preempt_timer`]
     /// for details.  The setting is applied to all executors in the pool.
+    #[must_use = "The builder must be built to be useful"]
     pub fn preempt_timer(mut self, dur: Duration) -> Self {
         self.preempt_timer_duration = dur;
         self
@@ -3111,7 +3121,7 @@ mod test {
 
         for nn in 1..2 {
             let nr_execs = nn * cpu_set.len();
-            let placements = [
+            let mut placements = vec![
                 PoolPlacement::Unbound(nr_execs),
                 PoolPlacement::Fenced(nr_execs, cpu_set.clone()),
                 PoolPlacement::MaxSpread(nr_execs, None),
@@ -3120,7 +3130,7 @@ mod test {
                 PoolPlacement::MaxPack(nr_execs, Some(cpu_set.clone())),
             ];
 
-            for pp in std::array::IntoIter::new(placements) {
+            for pp in placements.drain(..) {
                 let ids = Arc::new(Mutex::new(HashMap::new()));
                 let cpus = Arc::new(Mutex::new(HashMap::new()));
                 let cpu_hard_bind =
@@ -3175,7 +3185,7 @@ mod test {
 
         // test: confirm that we can always get shards up to the # of cpus
         {
-            let placements = [
+            let mut placements = vec![
                 (false, PoolPlacement::Unbound(cpu_set.len())),
                 (false, PoolPlacement::Fenced(cpu_set.len(), cpu_set.clone())),
                 (true, PoolPlacement::MaxSpread(cpu_set.len(), None)),
@@ -3190,7 +3200,7 @@ mod test {
                 ),
             ];
 
-            for (_shard_limited, p) in std::array::IntoIter::new(placements) {
+            for (_shard_limited, p) in placements.drain(..) {
                 LocalExecutorPoolBuilder::new(p)
                     .on_all_shards(|| async move {})
                     .unwrap()
@@ -3200,7 +3210,7 @@ mod test {
 
         // test: confirm that some placements fail when shards are # of cpus + 1
         {
-            let placements = [
+            let mut placements = vec![
                 (false, PoolPlacement::Unbound(1 + cpu_set.len())),
                 (
                     false,
@@ -3218,7 +3228,7 @@ mod test {
                 ),
             ];
 
-            for (shard_limited, p) in std::array::IntoIter::new(placements) {
+            for (shard_limited, p) in placements.drain(..) {
                 match LocalExecutorPoolBuilder::new(p).on_all_shards(|| async move {}) {
                     Ok(handles) => {
                         handles.join_all();

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -98,18 +98,12 @@ pub(crate) fn executor_id() -> Option<usize> {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Hash)]
 /// An opaque handle indicating in which queue a group of tasks will execute.
 /// Tasks in the same group will execute in FIFO order but no guarantee is made
 /// about ordering on different task queues.
 pub struct TaskQueueHandle {
     index: usize,
-}
-
-impl Default for TaskQueueHandle {
-    fn default() -> Self {
-        TaskQueueHandle { index: 0 }
-    }
 }
 
 impl TaskQueueHandle {
@@ -126,7 +120,7 @@ pub(crate) struct TaskQueue {
     shares: Shares,
     vruntime: u64,
     io_requirements: IoRequirements,
-    name: String,
+    _name: String,
     last_adjustment: Instant,
     // for dynamic shares classes
     yielded: bool,
@@ -171,7 +165,7 @@ impl TaskQueue {
             shares,
             vruntime: 0,
             io_requirements: ioreq,
-            name: name.into(),
+            _name: name.into(),
             last_adjustment: Instant::now(),
             yielded: false,
         }))

--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -338,6 +338,7 @@ impl CpuSet {
     ///
     /// println!("The filtered CPUs are: {:#?}", cpus);
     /// ```
+    #[must_use]
     pub fn filter<F>(mut self, f: F) -> Self
     where
         F: FnMut(&CpuLocation) -> bool,

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -260,6 +260,7 @@ impl StreamReaderBuilder {
     /// Reads from the [`StreamReader`] will start from this position
     ///
     /// [`StreamReader`]: struct.StreamReader.html
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_start_pos(mut self, start: u64) -> Self {
         self.start = start;
         self
@@ -271,6 +272,7 @@ impl StreamReaderBuilder {
     /// file is larger.
     ///
     /// [`StreamReader`]: struct.StreamReader.html
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_end_pos(mut self, end: u64) -> Self {
         self.end = end;
         self
@@ -279,6 +281,7 @@ impl StreamReaderBuilder {
     /// Define the buffer size that will be used by the [`StreamReader`]
     ///
     /// [`StreamReader`]: struct.StreamReader.html
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
         self.buffer_size = std::cmp::max(buffer_size, 1);
         self
@@ -331,6 +334,7 @@ impl StreamWriterBuilder {
     /// Chooses whether to issue a sync operation when closing the file
     /// (default enabled). Disabling this is dangerous and in most cases may
     /// lead to data loss upon power failure.
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_sync_on_close_disabled(mut self, flush_disabled: bool) -> Self {
         self.sync_on_close = !flush_disabled;
         self
@@ -339,6 +343,7 @@ impl StreamWriterBuilder {
     /// Define the buffer size that will be used by the [`StreamWriter`]
     ///
     /// [`StreamWriter`]: struct.StreamWriter.html
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
         self.buffer_size = std::cmp::max(buffer_size, 1);
         self

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -373,6 +373,7 @@ impl<V: IoVec + Unpin, S: Stream<Item = (ScheduledSource, ReadManyArgs<V>)> + Un
     ///
     /// This function should be called before the stream is first polled and
     /// will panic otherwise.
+    #[must_use]
     pub fn with_concurrency(mut self, concurrency: usize) -> Self {
         self.inner.set_concurrency(concurrency);
         self

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -331,7 +331,7 @@ impl Drop for DmaStreamReaderState {
 /// struct.DmaStreamReader.html#method.get_buffer_aligned
 /// [`AsyncRead`]: https://docs.rs/futures/0.3.5/futures/io/trait.AsyncRead.html
 pub struct DmaStreamReader {
-    start: u64,
+    _start: u64,
     end: u64,
     current_pos: u64,
     buffer_size: u64,
@@ -412,7 +412,7 @@ impl DmaStreamReader {
 
         DmaStreamReader {
             file: builder.file,
-            start: builder.start,
+            _start: builder.start,
             end: builder.end,
             current_pos: builder.start,
             buffer_size: builder.buffer_size as _,

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -128,6 +128,7 @@ impl DmaStreamReaderBuilder {
     /// Reads from the [`DmaStreamReader`] will start from this position
     ///
     /// [`DmaStreamReader`]: struct.DmaStreamReader.html
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_start_pos(mut self, start: u64) -> Self {
         self.start = start;
         self
@@ -139,6 +140,7 @@ impl DmaStreamReaderBuilder {
     /// file is larger.
     ///
     /// [`DmaStreamReader`]: struct.DmaStreamReader.html
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_end_pos(mut self, end: u64) -> Self {
         self.end = end;
         self
@@ -151,6 +153,7 @@ impl DmaStreamReaderBuilder {
     /// usage.
     ///
     /// [`DmaStreamReader`]: struct.DmaStreamReader.html
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_read_ahead(mut self, read_ahead: usize) -> Self {
         self.read_ahead = read_ahead;
         self
@@ -159,6 +162,7 @@ impl DmaStreamReaderBuilder {
     /// Define the buffer size that will be used by the [`DmaStreamReader`]
     ///
     /// [`DmaStreamReader`]: struct.DmaStreamReader.html
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
         let buffer_size = std::cmp::max(buffer_size, 1);
         self.buffer_size = self.file.align_up(buffer_size as _) as usize;
@@ -663,6 +667,7 @@ impl DmaStreamWriterBuilder {
     /// writing to this [`DmaStreamWriter`] will not block.
     ///
     /// [`DmaStreamWriter`]: struct.DmaStreamWriter.html
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_write_behind(mut self, write_behind: usize) -> Self {
         self.write_behind = std::cmp::max(write_behind, 1);
         self
@@ -670,6 +675,7 @@ impl DmaStreamWriterBuilder {
 
     /// Does not issue a sync operation when closing the file. This is dangerous
     /// and in most cases may lead to data loss.
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_sync_on_close_disabled(mut self, flush_disabled: bool) -> Self {
         self.sync_on_close = !flush_disabled;
         self
@@ -678,6 +684,7 @@ impl DmaStreamWriterBuilder {
     /// Define the buffer size that will be used by the [`DmaStreamWriter`]
     ///
     /// [`DmaStreamWriter`]: struct.DmaStreamWriter.html
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
         let buffer_size = std::cmp::max(buffer_size, 1);
         self.buffer_size = self.file.align_up(buffer_size as _) as usize;

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -107,6 +107,7 @@ where
     /// [`seal`]: ImmutableFilePreSealSink::seal
     /// [`build_sink`]: ImmutableFileBuilder::build_sink
     /// [`build_existing`]: ImmutableFileBuilder::build_existing
+    #[must_use = "The builder must be built to be useful"]
     pub fn new(fname: P) -> Self {
         Self {
             path: fname,
@@ -126,6 +127,7 @@ where
     /// more memory usage.
     ///
     /// [`ImmutableFile`]: ImmutableFile
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_sequential_concurrency(mut self, concurrency: usize) -> Self {
         self.concurrency = concurrency;
         self
@@ -142,6 +144,7 @@ where
     ///
     /// [`ImmutableFile`]: ImmutableFile
     /// [`ImmutableFilePreSealSink`]: ImmutableFilePreSealSink
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_sync_on_close_disabled(mut self, flush_disabled: bool) -> Self {
         self.flush_disabled = flush_disabled;
         self
@@ -151,6 +154,7 @@ where
     /// this [`ImmutableFile`]
     ///
     /// [`ImmutableFile`]: ImmutableFile
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
         self.buffer_size = buffer_size;
         self
@@ -158,6 +162,7 @@ where
 
     /// pre-allocates space in the filesystem to hold a file at least as big as
     /// the size argument.
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_pre_allocation(mut self, size: Option<u64>) -> Self {
         self.pre_allocate = size;
         self
@@ -177,6 +182,7 @@ where
     ///
     /// It is important not to set the extent size too big. Writes can fail
     /// otherwise if the extent can't be allocated.
+    #[must_use = "The builder must be built to be useful"]
     pub fn with_hint_extent_size(mut self, size: Option<usize>) -> Self {
         self.hint_extent_size = size;
         self

--- a/glommio/src/iou/sqe.rs
+++ b/glommio/src/iou/sqe.rs
@@ -503,7 +503,7 @@ impl<'a> SQE<'a> {
     }
 
     pub unsafe fn raw_mut(&mut self) -> &mut uring_sys::io_uring_sqe {
-        &mut self.sqe
+        self.sqe
     }
 }
 

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -552,14 +552,14 @@ pub enum Latency {
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct IoRequirements {
     latency_req: Latency,
-    io_handle: usize,
+    _io_handle: usize,
 }
 
 impl Default for IoRequirements {
     fn default() -> Self {
         Self {
             latency_req: Latency::NotImportant,
-            io_handle: 0,
+            _io_handle: 0,
         }
     }
 }
@@ -568,7 +568,7 @@ impl IoRequirements {
     fn new(latency: Latency, handle: usize) -> Self {
         Self {
             latency_req: latency,
-            io_handle: handle,
+            _io_handle: handle,
         }
     }
 }

--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -35,6 +35,7 @@ impl FromStr for StorageCache {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub(crate) struct BlockDevice {
     memory_device: bool,
     rotational: bool,

--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -211,7 +211,7 @@ impl ListIterator {
             .get(beg..)
             .expect("invalid range: this is a bug")
             .find(|c: char| !c.is_ascii_digit())
-            .unwrap_or_else(|| self.list_str.len() - beg);
+            .unwrap_or(self.list_str.len() - beg);
 
         self.list_str
             .get(beg..self.idx)
@@ -241,7 +241,7 @@ impl ListIterator {
             .get(self.idx..idx_max)
             .expect("invalid range: this is a bug")
             .find(|c| c != ',' && !is_space(c))
-            .unwrap_or_else(|| idx_max - self.idx);
+            .unwrap_or(idx_max - self.idx);
     }
 
     fn skip_char(&mut self, chr: char) -> bool {

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -473,7 +473,7 @@ fn transmute_error(res: io::Result<u32>) -> io::Result<usize> {
 
 fn record_stats<Ring: ReactorRing>(ring: &mut Ring, src: &InnerSource, res: &io::Result<usize>) {
     if let Some(fulfilled) = src.stats_collection.and_then(|x| x.fulfilled) {
-        fulfilled(res, &mut ring.io_stats_mut(), 1);
+        fulfilled(res, ring.io_stats_mut(), 1);
         if let Some(handle) = src.task_queue {
             fulfilled(res, ring.io_stats_for_task_queue_mut(handle), 1);
         }
@@ -482,7 +482,7 @@ fn record_stats<Ring: ReactorRing>(ring: &mut Ring, src: &InnerSource, res: &io:
     let waiters = usize::saturating_sub(src.wakers.waiters.len(), 1);
     if waiters > 0 {
         if let Some(reused) = src.stats_collection.and_then(|x| x.reused) {
-            reused(res, &mut ring.io_stats_mut(), waiters as u64);
+            reused(res, ring.io_stats_mut(), waiters as u64);
             if let Some(handle) = src.task_queue {
                 reused(
                     res,

--- a/glommio/src/task/raw.rs
+++ b/glommio/src/task/raw.rs
@@ -370,16 +370,15 @@ where
             let raw = Self::from_ptr(ptr);
             Self::increment_references(&mut *(raw.header as *mut Header));
 
-            let guard;
             // Calling of schedule functions itself does not increment references,
             // if the schedule function has captured variables, increment references
             // so if task being dropped inside schedule function , function itself
             // will keep valid data till the end of execution.
-            if mem::size_of::<S>() > 0 {
-                guard = Some(Waker::from_raw(Self::clone_waker(ptr)));
+            let guard = if mem::size_of::<S>() > 0 {
+                Some(Waker::from_raw(Self::clone_waker(ptr)))
             } else {
-                guard = None;
-            }
+                None
+            };
 
             let task = Task {
                 raw_task: NonNull::new_unchecked(ptr as *mut ()),


### PR DESCRIPTION
Rust 1.57 adds new linter checks in Clippy, namely a better dead code
detector. It turns out we have quite a few dead variables around. I am
not sure if they are helpful or if we should remove them instead. I
prepended them with an underscore for now.

This PR also applies the linter suggestions from 1.59-nightly. 