### PR TITLE
improve latency of latency-sensitive task queues performing IO

### DIFF
--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -1200,8 +1200,7 @@ impl LocalExecutor {
                 // requests that are latency sensitive we want them out of the
                 // ring ASAP (before we run the task queues). We will also use
                 // the opportunity to install the timer.
-                let duration = self.preempt_timer_duration();
-                self.parker.poll_io(duration);
+                self.parker.poll_io(|| Some(self.preempt_timer_duration()));
                 let run = self.run_task_queues();
                 let cur_time = Instant::now();
                 self.queues.borrow_mut().stats.total_runtime += cur_time - pre_time;

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -756,7 +756,7 @@ impl Reactor {
     }
 
     /// Processes new events, blocking until the first event or the timeout.
-    pub(crate) fn react(&self, timeout: Option<Duration>) -> io::Result<()> {
+    pub(crate) fn react(&self, timeout: impl Fn() -> Option<Duration>) -> io::Result<()> {
         // Process ready timers.
         let (next_timer, woke) = self.process_external_events();
 


### PR DESCRIPTION
This fixes an issue whereby a task queue waiting for external events
(those coming from the reactor, like IO or timers) would not be woken up
 according to its latency requirement.

Consider the following setup: we have two task queues, `(A)` and `(B)`.
`(A)` is latency-sensitive with a preemption timer of 1ms and performs
IO. `(B)` doesn't have a latency requirement and therefore defaults to
the executor's timer: 100ms. `(B)` is CPU intensive but highly
cooperative.

And now the following sequence of events:
* `(A)` and `(B)` are both `READY`; therefore, the preemption timer is
  set to the minimum of the two, 1ms;
* `(A)` runs and schedules all the IO it can. The task returns
  `Poll::Pending`;
* `(B)` runs and eventually gets preempted after ~1ms;
* The reactor enters the rings and posts the IO from `(A)`;
* `(A)` is `PENDING` and `(B)` is `READY,` so the preemption timer is
  set to `(B)`: 100ms;
* `(B)` runs for 100ms, until it is preempted;
* The reactor enters the rings and collects the IO results, waking up
  `(A)` in the process;
* `(A)` and `(B)` are both `READY`; therefore, the preemption timer is
  set to the minimum of the two, 1ms;
* `(A)` collects the result of the IOs
* ...

This isn't right: `(A)` wants to be woken up within 1ms of being marked
`READY`! To fix this issue durably, all IO from latency-sensitive queues
are now posted on the latency ring. This means that as soon as the
kernel creates a CQE on the latency ring, tasks get preempted by the
next call to `yield_if_needed.`

This improves the latency of these IO operations significantly. Right
now, this means the poll ring is only used when IO is submitted from
a throughput task queue. We may try to improve upon this later on.