### PR TITLE
update doc for previously blocking synchronous operations

### DIFF
--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -199,14 +199,16 @@ impl BufferedFile {
 
     /// Truncates a file to the specified size.
     ///
-    /// **Warning:** synchronous operation, will block the reactor
+    /// Note: this syscall might be issued in a background thread depending on
+    /// the system's capabilities.
     pub async fn truncate(&self, size: u64) -> Result<()> {
         self.file.truncate(size).await.map_err(Into::into)
     }
 
     /// rename this file.
     ///
-    /// **Warning:** synchronous operation, will block the reactor
+    /// Note: this syscall might be issued in a background thread depending on
+    /// the system's capabilities.
     pub async fn rename<P: AsRef<Path>>(&mut self, new_path: P) -> Result<()> {
         self.file.rename(new_path).await.map_err(Into::into)
     }
@@ -217,7 +219,8 @@ impl BufferedFile {
     /// the name from the filesystem but the file will still be accessible for
     /// as long as it is open.
     ///
-    /// **Warning:** synchronous operation, will block the reactor
+    /// Note: this syscall might be issued in a background thread depending on
+    /// the system's capabilities.
     pub async fn remove(&self) -> Result<()> {
         self.file.remove().await.map_err(Into::into)
     }

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -374,25 +374,28 @@ impl DmaFile {
 
     /// Truncates a file to the specified size.
     ///
-    /// **Warning:** synchronous operation, will block the reactor
+    /// Note: this syscall might be issued in a background thread depending on
+    /// the system's capabilities.
     pub async fn truncate(&self, size: u64) -> Result<()> {
         self.file.truncate(size).await
     }
 
-    /// rename this file.
+    /// Rename this file.
     ///
-    /// **Warning:** synchronous operation, will block the reactor
+    /// Note: this syscall might be issued in a background thread depending on
+    /// the system's capabilities.
     pub async fn rename<P: AsRef<Path>>(&self, new_path: P) -> Result<()> {
         self.file.rename(new_path).await
     }
 
-    /// remove this file.
+    /// Remove this file.
     ///
     /// The file does not have to be closed to be removed. Removing removes
     /// the name from the filesystem but the file will still be accessible for
     /// as long as it is open.
     ///
-    /// **Warning:** synchronous operation, will block the reactor
+    /// Note: this syscall might be issued in a background thread depending on
+    /// the system's capabilities.
     pub async fn remove(&self) -> Result<()> {
         self.file.remove().await
     }

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -416,20 +416,22 @@ impl ImmutableFile {
             .read_many(iovs, max_merged_buffer_size, max_read_amp)
     }
 
-    /// rename this file.
+    /// Rename this file.
     ///
-    /// **Warning:** synchronous operation, will block the reactor
+    /// Note: this syscall might be issued in a background thread depending on
+    /// the system's capabilities.
     pub async fn rename<P: AsRef<Path>>(&self, new_path: P) -> Result<()> {
         self.stream_builder.file.rename(new_path).await
     }
 
-    /// remove this file.
+    /// Remove this file.
     ///
     /// The file does not have to be closed to be removed. Removing removes
     /// the name from the filesystem but the file will still be accessible for
     /// as long as it is open.
     ///
-    /// **Warning:** synchronous operation, will block the reactor
+    /// Note: this syscall might be issued in a background thread depending on
+    /// the system's capabilities.
     pub async fn remove(&self) -> Result<()> {
         self.stream_builder.file.remove().await
     }


### PR DESCRIPTION
`io_uring` doesn't support all the regular file operations yet. In the
past, we were filling the gaps by issuing blocking syscalls directly,
blocking the reactor thread. Because this kind of sucks, we added a
warning in the docs to warn application writers.

Nowadays, we perform these blocking operations in a background thread.
Therefore, we no longer block the reactor thread, and the warning is no
longer relevant.