### PR TITLE
allow polling single-device md devices

### DIFF
--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -146,7 +146,7 @@ impl BlockDevice {
     }
 
     pub(crate) fn is_md(major: usize, minor: usize) -> bool {
-        !block_property!(DEV_MAP, subcomponents, major, minor).is_empty()
+        block_property!(DEV_MAP, subcomponents, major, minor).len() > 1
     }
 }
 


### PR DESCRIPTION
Linux is weird. LVM devices can present themselves as md devices with a
single underlying device. That device may be polled (but ones with
more than a single underlying device can't). Right now, if a
device is md, we opt out of polling entirely, even though polling is
allowed under that edge-case.

This commit changes the logic to disable polling only if an md device
has more than a single device underneath it.

> Note: I have not tested this under a RAID configuration with a single
disk. Logic would have that it would work too, but as we established,
Linux is weird.