### PR TITLE
probe `sysfs` to detect the minimum alignment io size

### DIFF
--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -158,7 +158,9 @@ impl DmaFile {
 
         Ok(DmaFile {
             file,
-            o_direct_alignment: sysfs::BlockDevice::minimum_io_size(major, minor) as u64,
+            o_direct_alignment: (sysfs::BlockDevice::minimum_io_size(major, minor) as u64)
+                .max(sysfs::BlockDevice::logical_block_size(major, minor) as u64)
+                .max(512), // make sure the alignment is at least 512 in any case
             max_sectors_size,
             max_segment_size,
             pollable,

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -1686,32 +1686,32 @@ mod test {
         reader.close().await.unwrap();
     });
 
-    file_stream_read_test!(read_get_buffer_aligned_cross_boundaries, path, _k, file, _file_size: 2048, {
+    file_stream_read_test!(read_get_buffer_aligned_cross_boundaries, path, _k, file, _file_size: 16384, {
         let mut reader = DmaStreamReaderBuilder::new(file)
-            .with_buffer_size(1024)
+            .with_buffer_size(4096)
             .build();
 
-        reader.skip(1022);
+        reader.skip(4094);
 
         match reader.get_buffer_aligned(130).await {
             Err(_) => panic!("Expected partial success"),
             Ok(res) => {
                 assert_eq!(res.len(), 2);
-                check_contents!(*res, 1022);
+                check_contents!(*res, 4094);
             },
         }
-        assert_eq!(reader.current_pos(), 1024);
+        assert_eq!(reader.current_pos(), 4096);
 
         match reader.get_buffer_aligned(64).await {
             Err(_) => panic!("Expected success"),
             Ok(res) => {
                 assert_eq!(res.len(), 64);
-                check_contents!(*res, 1024);
+                check_contents!(*res, 4096);
             },
         }
-        assert_eq!(reader.current_pos(), 1088);
+        assert_eq!(reader.current_pos(), 4160);
 
-        reader.skip(896);
+        reader.skip(12160);
 
         // EOF
         match reader.get_buffer_aligned(128).await {
@@ -1721,7 +1721,7 @@ mod test {
                 check_contents!(*res, 1984);
             },
         }
-        assert_eq!(reader.current_pos(), 2048);
+        assert_eq!(reader.current_pos(), 16384);
 
         let eof = reader.get_buffer_aligned(64).await.unwrap();
         assert_eq!(eof.len(), 0);


### PR DESCRIPTION
From https://people.redhat.com/msnitzer/docs/io-limits.txt:
> Storage vendors can also supply "I/O hints" about a device's preferred
minimum unit for random I/O ('minimum_io_size') and streaming I/O
('optimal_io_size'). For example, these hints may correspond to a RAID
device's chunk size and stripe size respectively.
