### PR TITLE
fast IO cancellation

### DIFF
--- a/glommio/src/iou/sqe.rs
+++ b/glommio/src/iou/sqe.rs
@@ -680,6 +680,12 @@ impl<'ring> Iterator for SQEs<'ring> {
     }
 }
 
+impl<'ring> Drop for SQEs<'ring> {
+    fn drop(&mut self) {
+        self.sq.sqe_tail -= self.remaining()
+    }
+}
+
 /// An Iterator of [`SQE`]s which will be hard linked together.
 pub struct HardLinked<'ring, 'a> {
     sqes: &'a mut SQEs<'ring>,

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -31,6 +31,7 @@ use std::{
     mem::MaybeUninit,
     os::unix::io::RawFd,
     path::PathBuf,
+    pin::Pin,
     rc::Rc,
     task::{Poll, Waker},
     time::Duration,
@@ -159,7 +160,7 @@ impl fmt::Debug for InnerSource {
 
 #[derive(Debug)]
 pub struct Source {
-    pub(crate) inner: Rc<RefCell<InnerSource>>,
+    pub(crate) inner: Pin<Rc<RefCell<InnerSource>>>,
 }
 
 impl Source {
@@ -172,7 +173,7 @@ impl Source {
         task_queue: Option<TaskQueueHandle>,
     ) -> Source {
         Source {
-            inner: Rc::new(RefCell::new(InnerSource {
+            inner: Rc::pin(RefCell::new(InnerSource {
                 raw,
                 wakers: Wakers::new(),
                 source_type,

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -21,6 +21,7 @@ use std::{
     ops::Range,
     os::unix::io::RawFd,
     panic,
+    pin::Pin,
     ptr,
     rc::Rc,
     sync::Arc,
@@ -585,8 +586,8 @@ where
     None
 }
 
-type SourceMap = FreeList<Rc<RefCell<InnerSource>>>;
-pub(crate) type SourceId = Idx<Rc<RefCell<InnerSource>>>;
+type SourceMap = FreeList<Pin<Rc<RefCell<InnerSource>>>>;
+pub(crate) type SourceId = Idx<Pin<Rc<RefCell<InnerSource>>>>;
 fn from_user_data(user_data: u64) -> SourceId {
     SourceId::from_raw((user_data - 1) as usize)
 }
@@ -615,7 +616,7 @@ impl SourceMap {
         f(self[id].borrow_mut())
     }
 
-    fn consume_source(&mut self, id: SourceId) -> Rc<RefCell<InnerSource>> {
+    fn consume_source(&mut self, id: SourceId) -> Pin<Rc<RefCell<InnerSource>>> {
         let source = self.dealloc(id);
         source.borrow_mut().enqueued.take();
         source

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -59,6 +59,7 @@ use nix::sys::{
     socket::{MsgFlags, SockAddr, SockFlag},
     stat::Mode as OpenMode,
 };
+use smallvec::SmallVec;
 
 const MSG_ZEROCOPY: i32 = 0x4000000;
 
@@ -525,7 +526,7 @@ fn extract_one_chain(
     source_map: &mut SourceMap,
     queue: &mut VecDeque<UringDescriptor>,
     chain: Range<usize>,
-) -> Vec<UringDescriptor> {
+) -> SmallVec<[UringDescriptor; 1]> {
     queue
         .drain(chain)
         .filter(move |op| {


### PR DESCRIPTION
So far, to cancel a source in glommio, the code would:
* Probe the submitting queue of the associated ring to find its
  corresponding `UringOpDescriptor`;
* If one is found, it is removed;
* Otherwise, a cancellation request is sent on the ring.

The issue with this way of handling cancellation is that the first step
is a linear probing over a potentially large number of descriptors.
Specifically, it means that canceling a source is _O(n)_ where _n_ is
the total number of queued sources in the ring.

Therefore, a realistic application canceling a query (that issues
many IOs) is an _O(kn)_ operation where _k_ is the number of sources
created by the request. Uh oh. That's a lot of work done in a destructor
where we can't cooperate and yield.

Instead, this commit changes the behavior of source cancellation to be
lazy. When dropped, a source marks itself as "canceled" if it wasn't
submitted yet. Meanwhile, the reactor now filters out canceled sources.
If the source was dispatched, we submit a cancel request like before.

Co-authored with @glommer 