### PR TITLE
Revert "allow polling single-device md devices (#488)"

### DIFF
--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -146,7 +146,7 @@ impl BlockDevice {
     }
 
     pub(crate) fn is_md(major: usize, minor: usize) -> bool {
-        block_property!(DEV_MAP, subcomponents, major, minor).len() > 1
+        !block_property!(DEV_MAP, subcomponents, major, minor).is_empty()
     }
 }
 


### PR DESCRIPTION
This reverts commit 16d9166c4753e93ecd886237d6dbd48eb8ab3e5c.

See #488