### PR TITLE
better `read_many` interface and defaults 

### DIFF
--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -12,6 +12,8 @@ use glommio::{
         DmaStreamReader,
         DmaStreamReaderBuilder,
         DmaStreamWriterBuilder,
+        MergedBufferLimit,
+        ReadAmplificationLimit,
         StreamReaderBuilder,
         StreamWriterBuilder,
     },
@@ -167,9 +169,13 @@ impl Reader {
     ) {
         match &self {
             Reader::Direct(file) => {
-                file.read_many(futures_lite::stream::iter(iovs), max_buffer_size, None)
-                    .for_each(|_| {})
-                    .await;
+                file.read_many(
+                    futures_lite::stream::iter(iovs),
+                    MergedBufferLimit::Custom(max_buffer_size),
+                    ReadAmplificationLimit::NoAmplification,
+                )
+                .for_each(|_| {})
+                .await;
             }
             Reader::Buffered(_) => {
                 panic!("bulk io is not available for buffered files")

--- a/glommio/benches/competing_io.rs
+++ b/glommio/benches/competing_io.rs
@@ -2,7 +2,7 @@ use futures::future::join;
 use futures_lite::{stream, AsyncWriteExt, StreamExt};
 use glommio::{
     enclose,
-    io::{ImmutableFile, ImmutableFileBuilder},
+    io::{ImmutableFile, ImmutableFileBuilder, MergedBufferLimit, ReadAmplificationLimit},
     Latency,
     LocalExecutorBuilder,
     Placement,
@@ -100,8 +100,8 @@ async fn run_io(name: &str, file: &ImmutableFile, count: usize, size: usize) {
             at: Instant::now(),
         })
         .take(count),
-        0,
-        Some(0),
+        MergedBufferLimit::NoMerging,
+        ReadAmplificationLimit::NoAmplification,
     )
     .for_each(|res| {
         let (io, _) = res.unwrap();

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -58,6 +58,8 @@ pub(crate) fn align_down(v: u64, align: u64) -> u64 {
 pub struct DmaFile {
     file: GlommioFile,
     o_direct_alignment: u64,
+    max_sectors_size: usize,
+    max_segment_size: usize,
     pollable: PollableStatus,
 }
 
@@ -143,10 +145,16 @@ impl DmaFile {
         {
             pollable = PollableStatus::NonPollable(DirectIo::Enabled);
         }
+        let max_sectors_size =
+            sysfs::BlockDevice::max_sectors_size(file.dev_major as _, file.dev_minor as _);
+        let max_segment_size =
+            sysfs::BlockDevice::max_segment_size(file.dev_major as _, file.dev_minor as _);
 
         Ok(DmaFile {
             file,
             o_direct_alignment: 4096,
+            max_sectors_size,
+            max_segment_size,
             pollable,
         })
     }

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -161,7 +161,7 @@ pub use self::{
         StreamWriter,
         StreamWriterBuilder,
     },
-    bulk_io::{IoVec, ReadManyResult},
+    bulk_io::{IoVec, MergedBufferLimit, ReadAmplificationLimit, ReadManyResult},
     directory::Directory,
     dma_file::{CloseResult, DmaFile},
     dma_file_stream::{

--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -43,6 +43,8 @@ pub(crate) struct BlockDevice {
     optimal_io_size: usize,
     logical_block_size: usize,
     physical_block_size: usize,
+    max_sectors_size: usize,
+    max_segment_size: usize,
     cache: StorageCache,
     subcomponents: Vec<PathBuf>,
 }
@@ -77,6 +79,8 @@ impl BlockDevice {
             optimal_io_size: 128 << 10,
             logical_block_size: 512,
             physical_block_size: 512,
+            max_sectors_size: 128 << 10,
+            max_segment_size: (u32::MAX - 1) as usize,
             cache: StorageCache::WriteBack,
             subcomponents: Vec::new(),
         }
@@ -101,6 +105,8 @@ impl BlockDevice {
         let optimal_io_size = read_int(&queue.join("optimal_io_size")) as _;
         let logical_block_size = read_int(&queue.join("logical_block_size")) as _;
         let physical_block_size = read_int(&queue.join("physical_block_size")) as _;
+        let max_sectors_kb = read_int(&queue.join("max_sectors_kb")) as usize;
+        let max_segment_size = read_int(&queue.join("max_segment_size")) as usize;
 
         let cache_data = read_to_string(&queue.join("write_cache")).unwrap();
         let cache = cache_data.parse::<StorageCache>().unwrap();
@@ -116,6 +122,8 @@ impl BlockDevice {
             optimal_io_size,
             logical_block_size,
             physical_block_size,
+            max_sectors_size: max_sectors_kb << 10,
+            max_segment_size,
             cache,
             subcomponents,
         }
@@ -143,6 +151,14 @@ impl BlockDevice {
 
     pub(crate) fn physical_block_size(major: usize, minor: usize) -> usize {
         block_property!(DEV_MAP, physical_block_size, major, minor)
+    }
+
+    pub(crate) fn max_sectors_size(major: usize, minor: usize) -> usize {
+        block_property!(DEV_MAP, max_sectors_size, major, minor)
+    }
+
+    pub(crate) fn max_segment_size(major: usize, minor: usize) -> usize {
+        block_property!(DEV_MAP, max_segment_size, major, minor)
     }
 
     pub(crate) fn is_md(major: usize, minor: usize) -> bool {


### PR DESCRIPTION
* Provide a better, less confusing interface using named enums. This
  makes the code a lot more readable;
* Read sysfs to give good device-specific options for request merging 
  (if we merge too much, we may end up with a request so large the kernel has 
  to split it underneath our feet, which defeats the purpose).