### PR TITLE
do not panic when failing to create a `LocalExecutor`

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -52,7 +52,7 @@ async fn server(conns: usize) -> Result<()> {
         s.await.unwrap()?;
     }
 
-    client_handle.join().unwrap();
+    client_handle.join().unwrap().unwrap();
     Ok(())
 }
 
@@ -108,6 +108,6 @@ fn main() -> Result<()> {
     //
     // Now can you adapt it, so it uses multiple executors and all CPUs in your
     // system?
-    server_handle.join().unwrap();
+    server_handle.join().unwrap().unwrap();
     Ok(())
 }

--- a/glommio/src/error.rs
+++ b/glommio/src/error.rs
@@ -61,12 +61,20 @@ pub enum QueueErrorKind {
 pub enum ReactorErrorKind {
     /// Indicates an incorrect source type.
     IncorrectSourceType,
+
+    /// Reactor unable to lock memory (max allowed, min required)
+    MemLockLimit(u64, u64),
 }
 
 impl fmt::Display for ReactorErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ReactorErrorKind::IncorrectSourceType => write!(f, "Incorrect source type!"),
+            ReactorErrorKind::MemLockLimit(max, min) => write!(
+                f,
+                "The memlock resource limit is too low: {} (recommended {})",
+                max, min
+            ),
         }
     }
 }
@@ -449,6 +457,7 @@ impl<T> Debug for GlommioError<T> {
             GlommioError::ReactorError(kind) => {
                 let kind = match kind {
                     ReactorErrorKind::IncorrectSourceType => "IncorrectSourceType",
+                    ReactorErrorKind::MemLockLimit(_, _) => "MemLockLimit",
                 };
                 write!(f, "ReactorError {{ kind: '{}' }}", kind)
             }

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -485,6 +485,7 @@ pub use crate::{
         spawn_scoped_local_into,
         yield_if_needed,
         CpuSet,
+        ExecutorJoinHandle,
         ExecutorProxy,
         ExecutorStats,
         LocalExecutor,

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -857,7 +857,7 @@ mod tests {
             .spawn(move || async move {
                 let receiver = addr_receiver.connect().await;
                 let addr = receiver.recv().await.unwrap();
-                TcpStream::connect(addr).await.unwrap()
+                TcpStream::connect(addr).await.unwrap();
             })
             .unwrap();
 

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -198,11 +198,10 @@ impl Reactor {
         io_memory: usize,
         ring_depth: usize,
         record_io_latencies: bool,
-    ) -> Reactor {
-        let sys = sys::Reactor::new(notifier, io_memory, ring_depth)
-            .expect("cannot initialize I/O event notification");
+    ) -> io::Result<Reactor> {
+        let sys = sys::Reactor::new(notifier, io_memory, ring_depth)?;
         let (preempt_ptr_head, preempt_ptr_tail) = sys.preempt_pointers();
-        Reactor {
+        Ok(Reactor {
             sys,
             timers: RefCell::new(Timers::new()),
             shared_channels: RefCell::new(SharedChannels::new()),
@@ -210,7 +209,7 @@ impl Reactor {
             record_io_latencies,
             preempt_ptr_head,
             preempt_ptr_tail: preempt_ptr_tail as _,
-        }
+        })
     }
 
     pub(crate) fn io_stats(&self) -> IoStats {


### PR DESCRIPTION
Errors should propagate to the end users instead. Additionally,
allow returning a struct from the boot future. It is possible to do so
when using the pool builder but not when using the simple one, so this
brings them to parity.