### PR TITLE
add `spawn_blocking` and use a blocking thread pool

### DIFF
--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -190,7 +190,7 @@ impl PoolPlacement {
     /// If `len` is greater than the number of placements in the pool, this has
     /// no effect.
     pub(super) fn shrink_to(self, count: usize) -> Self {
-        if count <= self.executor_count() {
+        if count > self.executor_count() {
             return self;
         }
         match self {

--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -184,6 +184,26 @@ impl PoolPlacement {
     pub fn generate_cpu_set(self) -> Result<CpuSetGenerator> {
         CpuSetGenerator::pool(self)
     }
+
+    /// Shrinks the pool placement policy to the first `len` placements.
+    ///
+    /// If `len` is greater than the number of placements in the pool, this has
+    /// no effect.
+    pub(super) fn shrink_to(self, count: usize) -> Self {
+        if count <= self.executor_count() {
+            return self;
+        }
+        match self {
+            PoolPlacement::Unbound(_) => PoolPlacement::Unbound(count),
+            PoolPlacement::Fenced(_, set) => PoolPlacement::Fenced(count, set),
+            PoolPlacement::MaxSpread(_, set) => PoolPlacement::MaxSpread(count, set),
+            PoolPlacement::MaxPack(_, set) => PoolPlacement::MaxPack(count, set),
+            PoolPlacement::Custom(mut cpus) => {
+                cpus.truncate(count);
+                PoolPlacement::Custom(cpus)
+            }
+        }
+    }
 }
 
 impl From<Placement> for PoolPlacement {

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -635,6 +635,12 @@ impl Reactor {
         source
     }
 
+    pub(crate) fn run_blocking(&self, func: Box<dyn FnOnce() + Send + 'static>) -> Source {
+        let source = self.new_source(-1, SourceType::BlockingFn, None);
+        self.sys.run_blocking(&source, func);
+        source
+    }
+
     pub(crate) fn close(&self, raw: RawFd) -> Source {
         let source = self.new_source(
             raw,

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -46,6 +46,7 @@ use crate::{
     IoRequirements,
     IoStats,
     Latency,
+    PoolPlacement,
     TaskQueueHandle,
 };
 use nix::poll::PollFlags;
@@ -198,8 +199,9 @@ impl Reactor {
         io_memory: usize,
         ring_depth: usize,
         record_io_latencies: bool,
+        thread_pool_placement: PoolPlacement,
     ) -> io::Result<Reactor> {
-        let sys = sys::Reactor::new(notifier, io_memory, ring_depth)?;
+        let sys = sys::Reactor::new(notifier, io_memory, ring_depth, thread_pool_placement)?;
         let (preempt_ptr_head, preempt_ptr_tail) = sys.preempt_pointers();
         Ok(Reactor {
             sys,

--- a/glommio/src/sys/blocking.rs
+++ b/glommio/src/sys/blocking.rs
@@ -1,14 +1,18 @@
-use crate::sys::{create_eventfd, read_eventfd, write_eventfd, SleepNotifier};
-use crossbeam::queue::ArrayQueue;
+use crate::{executor::bind_to_cpu_set, sys::SleepNotifier, PoolPlacement};
+use ahash::AHashMap;
+use alloc::rc::Rc;
+use core::fmt::{Debug, Formatter};
+use crossbeam::channel::{Receiver, Sender};
 use std::{
     cell::{Cell, RefCell},
-    collections::BTreeMap,
     convert::TryFrom,
     ffi::CString,
     io,
+    io::ErrorKind,
     os::unix::{ffi::OsStrExt, prelude::*},
     path::{Path, PathBuf},
     sync::Arc,
+    thread::JoinHandle,
 };
 
 // So hard to copy/clone io::Error, plus need to send between threads. Best to
@@ -55,6 +59,20 @@ pub(super) enum BlockingThreadOp {
     Fn(Box<dyn FnOnce() + Send + 'static>),
 }
 
+impl Debug for BlockingThreadOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            BlockingThreadOp::Rename(from, to) => write!(f, "rename `{:?}` -> `{:?}`", from, to),
+            BlockingThreadOp::Remove(path) => write!(f, "remove `{:?}`", path),
+            BlockingThreadOp::CreateDir(path, flags) => {
+                write!(f, "create dir `{:?}` (`{:b}`)", path, flags)
+            }
+            BlockingThreadOp::Truncate(fd, to) => write!(f, "truncate `{}` -> `{}`", fd, to),
+            BlockingThreadOp::Fn(_) => write!(f, "user function"),
+        }
+    }
+}
+
 impl BlockingThreadOp {
     fn execute(self) -> BlockingThreadResult {
         match self {
@@ -82,6 +100,7 @@ impl BlockingThreadOp {
     }
 }
 
+#[derive(Debug)]
 pub(super) enum BlockingThreadResult {
     Syscall(i64),
     Fn,
@@ -98,6 +117,7 @@ impl TryFrom<BlockingThreadResult> for std::io::Result<usize> {
     }
 }
 
+#[derive(Debug)]
 pub(super) struct BlockingThreadReq {
     op: BlockingThreadOp,
     id: u64,
@@ -110,35 +130,101 @@ pub(super) struct BlockingThreadResp {
 
 pub(super) type BlockingThreadHandler = Box<dyn Fn(BlockingThreadResult)>;
 
-pub(super) struct BlockingThread {
-    eventfd: RawFd,
-    queue: Arc<ArrayQueue<BlockingThreadReq>>,
-    responses: Arc<ArrayQueue<BlockingThreadResp>>,
-    waiters: RefCell<BTreeMap<u64, BlockingThreadHandler>>,
-    requests: Cell<u64>,
-}
+#[derive(Debug)]
+struct BlockingThread(JoinHandle<()>);
 
 impl BlockingThread {
-    pub(super) fn push(&self, op: BlockingThreadOp, action: Box<dyn Fn(BlockingThreadResult)>) {
+    pub(super) fn new(
+        reactor_sleep_notifier: Arc<SleepNotifier>,
+        rx: Arc<Receiver<BlockingThreadReq>>,
+        tx: Arc<Sender<BlockingThreadResp>>,
+        bindings: Option<impl IntoIterator<Item = usize> + Send + 'static>,
+    ) -> Self {
+        Self(std::thread::spawn(move || {
+            if let Some(bindings) = bindings {
+                bind_to_cpu_set(bindings).expect("failed to bind blocking thread");
+            }
+            while let Ok(el) = rx.recv() {
+                let res = el.op.execute();
+                let id = el.id;
+                let resp = BlockingThreadResp { id, res };
+
+                if tx.send(resp).is_err() {
+                    panic!("failed to send response");
+                }
+                reactor_sleep_notifier.notify(false);
+            }
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BlockingThreadPool {
+    tx: Sender<BlockingThreadReq>,
+    rx: Receiver<BlockingThreadResp>,
+    waiters: RefCell<AHashMap<u64, BlockingThreadHandler>>,
+    requests: Cell<u64>,
+    _threads: Vec<BlockingThread>,
+}
+
+impl BlockingThreadPool {
+    pub(crate) fn new(
+        placement: PoolPlacement,
+        sleep_notifier: Arc<SleepNotifier>,
+    ) -> crate::Result<Self, ()> {
+        let (in_tx, in_rx) = crossbeam::channel::unbounded();
+        let (out_tx, out_rx) = crossbeam::channel::unbounded();
+        let in_rx = Arc::new(in_rx);
+        let out_tx = Arc::new(out_tx);
+
+        let thread_count = placement.executor_count();
+        let mut placements = placement.generate_cpu_set()?;
+        let mut threads = Vec::with_capacity(thread_count);
+        for _ in 0..thread_count {
+            let bindings = placements.next().cpu_binding();
+            threads.push(BlockingThread::new(
+                sleep_notifier.clone(),
+                in_rx.clone(),
+                out_tx.clone(),
+                bindings,
+            ));
+        }
+
+        Ok(Self {
+            _threads: threads,
+            tx: in_tx,
+            rx: out_rx,
+            waiters: RefCell::new(Default::default()),
+            requests: Cell::new(0),
+        })
+    }
+
+    pub(super) fn push(
+        &self,
+        op: BlockingThreadOp,
+        action: BlockingThreadHandler,
+    ) -> io::Result<()> {
         let id = self.requests.get();
-        self.requests.set(id + 1);
+        self.requests.set(id.overflowing_add(1).0);
 
         let req = BlockingThreadReq { op, id };
 
-        if self.queue.push(req).is_err() {
-            panic!("syscall queue full!");
-        }
+        self.tx.send(req).map_err(|_| {
+            io::Error::new(
+                ErrorKind::WouldBlock,
+                "failed to enqueue blocking operation",
+            )
+        })?;
 
         let mut waiters = self.waiters.borrow_mut();
         waiters.insert(id, action);
-
-        write_eventfd(self.eventfd);
+        Ok(())
     }
 
     pub(super) fn flush(&self) -> usize {
         let mut woke = 0;
         let mut waiters = self.waiters.borrow_mut();
-        while let Some(x) = self.responses.pop() {
+        for x in self.rx.try_iter() {
             let id = x.id;
             let res = x.res;
             let func = waiters.remove(&id).unwrap();
@@ -146,39 +232,5 @@ impl BlockingThread {
             woke += 1;
         }
         woke
-    }
-
-    pub(super) fn new(reactor_sleep_notifier: Arc<SleepNotifier>) -> Self {
-        let eventfd = create_eventfd().unwrap();
-        let queue = Arc::new(ArrayQueue::<BlockingThreadReq>::new(1024));
-        let responses = Arc::new(ArrayQueue::<BlockingThreadResp>::new(1024));
-        let waiters = RefCell::new(BTreeMap::new());
-        let requests = Cell::new(0);
-
-        let tq = queue.clone();
-        let rsp = responses.clone();
-
-        std::thread::spawn(move || {
-            loop {
-                read_eventfd(eventfd);
-                while let Some(el) = tq.pop() {
-                    let res = el.op.execute();
-                    let id = el.id;
-                    let resp = BlockingThreadResp { id, res };
-
-                    if rsp.push(resp).is_err() {
-                        panic!("Could not add response to syscall response queue");
-                    }
-                }
-                reactor_sleep_notifier.notify(false);
-            }
-        });
-        BlockingThread {
-            eventfd,
-            queue,
-            responses,
-            waiters,
-            requests,
-        }
     }
 }

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -84,12 +84,6 @@ pub(crate) fn write_eventfd(eventfd: RawFd) {
     assert_eq!(ret, 8);
 }
 
-pub(crate) fn read_eventfd(eventfd: RawFd) {
-    let mut buf = [1u64; 1];
-    let ret = syscall!(read(eventfd, buf.as_mut_ptr() as _, 8)).unwrap();
-    assert_eq!(ret, 8);
-}
-
 pub(crate) fn send_syscall(fd: RawFd, buf: *const u8, len: usize, flags: i32) -> io::Result<usize> {
     syscall!(send(fd, buf as _, len, flags)).map(|x| x as usize)
 }

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -70,6 +70,7 @@ pub(crate) enum SourceType {
     Rename(PathBuf, PathBuf),
     CreateDir(PathBuf),
     Remove(PathBuf),
+    BlockingFn,
     Invalid,
     #[cfg(feature = "bench")]
     Noop,

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -1444,6 +1444,13 @@ impl Reactor {
         self.blocking_syscall(source, op);
     }
 
+    pub(crate) fn run_blocking(&self, source: &Source, f: Box<dyn FnOnce() + Send + 'static>) {
+        assert!(matches!(&*source.source_type(), SourceType::BlockingFn));
+
+        let op = BlockingThreadOp::Fn(f);
+        self.blocking_syscall(source, op);
+    }
+
     pub(crate) fn close(&self, source: &Source) {
         let op = UringOpDescriptor::Close;
         self.queue_standard_request(source, op);


### PR DESCRIPTION
Sometimes there is no way around doing a long, unyielding job. That's
the world we live in. These fall into two categories:
* Busy blocking jobs: usually, these are calls to external libraries
  that aren't cooperative and can't be easily broken into bite-size
  pieces. Your usual suspects are compression/decompression and
  marshaling/unmarshalling.
* Non-busy blocking jobs: stuff that acquires locks or syscalls waiting
  for events.

`spawn_blocking` works for both cases but is best suited for the latter
because they don't steal CPU cycles from the executor.

So far, we have had a single thread per executor used for blocking
operations. This has been fine to issue the odd syscall that couldn't go
into the ring, but now that we have `spawn_blocking,` we've opened
pandora's box. Users will submit all sorts of things in there, including
long-running jobs that could stall the entire system.

This commit introduces a static thread pool per executor instead. The
pool is static for now, meaning the threads are created once and live
for as long as the host executor does. Later on, we may want to be
smarter and automatically up/downscale the pool depending on usage.

This work is based #500.