### PR TITLE
update dependencies

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -16,39 +16,39 @@ categories = ["asynchronous", "concurrency", "os", "filesystem", "network-progra
 readme = "../README.md"
 
 [dependencies]
-ahash = "~0.7"
+ahash = "0.7"
 bitflags = "1.3"
-bitmaps = "3.1.0"
-buddy-alloc = "~0.4"
+bitmaps = "3.1"
+buddy-alloc = "0.4"
 concurrent-queue = "1.2"
-crossbeam = "~0.8"
+crossbeam = "0.8"
 enclose = "1.1"
 futures-lite = "1.12"
-intrusive-collections = "~0.9"
+intrusive-collections = "0.9"
 lazy_static = "1.4"
-libc = "~0.2"
-lockfree = "~0.5"
-log = "~0.4"
-membarrier = "~0.2"
-nix = "~0.23.0"
-pin-project-lite = "~0.2"
-rlimit = "~0.6"
-scoped-tls = "1.0.0"
+libc = "0.2"
+lockfree = "0.5"
+log = "0.4"
+membarrier = "0.2"
+nix = "0.23"
+pin-project-lite = "0.2"
+rlimit = "0.6"
+scoped-tls = "1.0"
 scopeguard = "1.1"
 sketches-ddsketch = "0.1"
 smallvec = { version = "1.7", features = ["union"] }
-socket2 = { version = "~0.3", features = ["unix", "reuseport"] }
-tracing = "~0.1"
-typenum = "1.14"
+socket2 = { version = "0.3", features = ["unix", "reuseport"] }
+tracing = "0.1"
+typenum = "1.15"
 
 [dev-dependencies]
-fastrand = "1.5"
-futures = "~0.3"
-hdrhistogram = "7.3.0"
-pretty_env_logger = "~0.4"
-rand = "~0.8"
-tokio = { version = "1.12", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time", "sync"] }
-tracing-subscriber = { version = "~0.3", features = ["env-filter"] }
+fastrand = "1"
+futures = "0"
+hdrhistogram = "7"
+pretty_env_logger = "0"
+rand = "0"
+tokio = { version = "1", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time", "sync"] }
+tracing-subscriber = { version = "0", features = ["env-filter"] }
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Pin our dependencies to the latest non-api-breaking version. 