### PR TITLE
fix race in `foreign_wake` unit test

### DIFF
--- a/glommio/src/task/tests.rs
+++ b/glommio/src/task/tests.rs
@@ -227,7 +227,6 @@ mod ref_count {
                 yield_now().await;
                 assert_eq!(2, TaskDebugger::task_count());
                 handle.await.unwrap();
-                assert_eq!(1, TaskDebugger::task_count());
             }),
             LocalExecutorBuilder::default().spawn(move || async move {
                 let receiver = receiver.connect().await;
@@ -258,7 +257,6 @@ mod ref_count {
                 yield_now().await;
                 assert_eq!(2, TaskDebugger::task_count());
                 handle.await.unwrap();
-                assert_eq!(1, TaskDebugger::task_count());
             }),
             LocalExecutorBuilder::default().spawn(move || async move {
                 let receiver = receiver.connect().await;


### PR DESCRIPTION
There is a race in the unit test between the local executor picking up
the foreign wake and the remote executor dropping the waker (and
therefore decrementing the refcount).

Therefore, remove that last assertion as it requires further
synchronization to work reliably.