### PR TITLE
limit test concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
         run: |
           cat << EOF > "run-gha-workflow.sh"
           PATH=$PATH:/usr/share/rust/.cargo/bin
-          echo "`nproc` CPU(s) availble"
+          echo "`nproc` CPU(s) available"
           rustup install nightly
           rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
           rustup show
           rustup default stable
           cargo install cargo-sort
-          cargo test --all-features -- --test-threads=1
+          cargo test --all-features -- --test-threads=`nproc`
           EOF
           sudo -E bash -c "ulimit -Sl 512 && ulimit -Hl 512 && bash run-gha-workflow.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,12 @@ jobs:
         run: |
           cat << EOF > "run-gha-workflow.sh"
           PATH=$PATH:/usr/share/rust/.cargo/bin
+          echo "`nproc` CPU(s) availble"
           rustup install nightly
           rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
           rustup show
           rustup default stable
           cargo install cargo-sort
-          cargo test --all-features
+          cargo test --all-features -- --test-threads=1
           EOF
           sudo -E bash -c "ulimit -Sl 512 && ulimit -Hl 512 && bash run-gha-workflow.sh"


### PR DESCRIPTION
We have a fair few tests that rely on timing and are otherwise highly
CPU intensive (`test_spin,` I am looking at you!). They have proven to
be quite flaky in CI. Ideally, we would have them run serially while
keeping the other ones running in parallel.
Rust lacks this functionality, however, so in the meantime, run
everything with a single thread in CI.