### PR TITLE
add throughput-based preemption 

### DIFF
--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -848,9 +848,9 @@ pub(crate) mod test {
             .task_queue_io_stats(q2)
             .expect("failed to retrieve task queue io stats");
         assert_eq!(stats.all_rings().files_opened(), 1);
-        assert_eq!(stats.latency_ring.files_opened(), 1);
+        assert_eq!(stats.main_ring.files_opened(), 1);
         assert_eq!(stats.all_rings().files_closed(), 1);
-        assert_eq!(stats.latency_ring.files_closed(), 1);
+        assert_eq!(stats.main_ring.files_closed(), 1);
         assert_eq!(stats.all_rings().file_reads().0, 2);
         assert_eq!(stats.all_rings().file_writes().0, 1);
     });

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -17,7 +17,6 @@ use crate::{
     },
     GlommioError,
     IoRequirements,
-    Latency,
     ReactorErrorKind,
     RingIoStats,
     TaskQueueHandle,
@@ -197,10 +196,6 @@ impl Source {
 
     pub(super) fn timeout_ref(&self) -> Ref<'_, Option<TimeSpec64>> {
         Ref::map(self.inner.borrow(), |x| &x.timeout)
-    }
-
-    pub(crate) fn latency_req(&self) -> Latency {
-        self.inner.borrow().io_requirements.latency_req
     }
 
     pub(super) fn source_type(&self) -> Ref<'_, SourceType> {

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -63,7 +63,7 @@ pub(crate) enum SourceType {
     LinkRings,
     ForeignNotifier(u64, bool),
     Statx(CString, Box<RefCell<libc::statx>>),
-    Timeout(TimeSpec64),
+    Timeout(TimeSpec64, u32),
     Connect(SockAddr),
     Accept(SockAddrStorage),
     Rename(PathBuf, PathBuf),


### PR DESCRIPTION
```
Preemption is difficult to get right. Implementations need to strike a
delicate balance between preempting too little at the risk of starving
the reactor or preempting too much at the expense of CPU performance
(d/i caches, branch prediction, etc.).

Glommio today uses two related mechanisms for preemption:
* An event-based preemption mechanism that preempts every time the
  latency ring has at least one CQE ready;
* A timer-based approach to preemption: every task queue in the system
  either defines or inherits a preemption duration representing the
  maximum amount of time we can spend outside the reactor. A timer is
  inserted in the latency ring based on this value. When it fires,
  condition (1) triggers, and we preempt.

This system is effective when a user submits some IO requests and values
the latency of those individual requests more than the system's
concurrency as a whole. In other words, the user trades throughput for
latency.

However, for workloads only interested in throughput, this system
doesn't work as well. Although it is intuitive to think a higher
preemption timer would favor throughput, it is the opposite for IO. If
the preemption timer is set to 100ms (the default), we will only submit
and collect requests once every 100ms. Although the CPU will deliver
very high throughput, the IO system will be barely utilized. Therefore,
users are encouraged to use lower and lower preemption timers to the
detriment of CPU throughput.

In this case, a good system would maximize both IO and CPU performance
by preempting exactly at the starvation tipping point: just before it
runs out of work. Such a system would maximize throughput because if the
system can process one thousand concurrent requests, then preemption
would trigger only once every 1k or so requests processed.

This is what this commit introduces: throughput-based preemption. We now
insert an additional timer in the main ring that only fires when a
minimum number of CQEs are available to collect. It does so rather
cleverly by defining a timer and linking it to a second SQE that writes
to the latency ring's eventfd. Because the latency ring always reads
this eventfd, we can trigger a preemption from an event on the main
ring.

I collected some numbers using the `competing_io` benchmark that I made 
to evaluate this use case:
```

| Preemption →   Shares↓ | 10ms                | 10ms + Tput          | 500us               | 500us + Tput        |
|-------------------------|---------------------|----------------------|---------------------|---------------------|
| IO:100  CPU:100        | IOPS: 39k CPU: 157M | IOPS: 297k CPU: 55M  | IOPS: 413k CPU: 28M | IOPS: 398k CPU: 31M |
| IO:100  CPU:10         | IOPS: 39k CPU: 159M | IOPS: 308k CPU: 54M  | IOPS: 471k CPU: 6M  | IOPS: 462k CPU: 5M  |