### PR TITLE
 Method RwLock#close returns error if some fibres still hold locks.

### DIFF
--- a/glommio/src/sync/rwlock.rs
+++ b/glommio/src/sync/rwlock.rs
@@ -766,7 +766,7 @@ impl<T> RwLock<T> {
         if state.writers > 0 || state.readers > 0 {
             return Err(GlommioError::CanNotBeClosed(
                 ResourceType::RwLock,
-                "Lock is still hold by fibers",
+                "Lock is still held by fiber(s)",
             ));
         }
 
@@ -917,6 +917,7 @@ impl<T: Default> Default for RwLock<T> {
 
 impl<T> Drop for RwLock<T> {
     fn drop(&mut self) {
+        //Lifetime annotation prohibits guards to outlive RwLock so such unwrap is safe.
         self.close().unwrap();
         assert!(self.state.borrow().waiters_queue.is_empty());
     }


### PR DESCRIPTION
### What does this PR do?

 Method RwLock#close returns error if some fibres still hold locks.

### Motivation

This change is done to remove panic from Deref implementations of RwLockRead(Write)Guards if RwLock is already closed.

### Related issues

Issue #482

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[x] If applicable, I have discussed my architecture
