### PR TITLE
do not assume files are pollable

### DIFF
--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -249,7 +249,7 @@ impl BufferedFile {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::io::dma_file::test::make_test_directories;
+    use crate::test_utils::make_test_directories;
 
     macro_rules! buffered_file_test {
         ( $name:ident, $dir:ident, $kind:ident, $code:block) => {

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -691,7 +691,7 @@ impl AsyncBufRead for Stdin {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::io::dma_file::test::make_test_directories;
+    use crate::test_utils::make_test_directories;
     use futures_lite::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, StreamExt};
     use std::io::ErrorKind;
 

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -452,37 +452,17 @@ impl DmaFile {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use crate::{enclose, test_utils::*, ByteSliceMutExt, Latency, Shares};
+    use crate::{
+        enclose,
+        test_utils::{make_test_directories, TestDirectoryKind},
+        ByteSliceMutExt,
+        Latency,
+        Shares,
+    };
     use futures::join;
     use futures_lite::{stream, StreamExt};
     use rand::{seq::SliceRandom, thread_rng};
     use std::{cell::RefCell, path::PathBuf, time::Duration};
-
-    #[cfg(test)]
-    pub(crate) fn make_test_directories(test_name: &str) -> std::vec::Vec<TestDirectory> {
-        let mut vec = Vec::new();
-
-        // Glommio currently only supports NVMe-backed volumes formatted with XFS or
-        // EXT4. We therefore let the user decide what directory glommio should
-        // use to host the unit tests in. For more information regarding this
-        // limitation, see the README
-        match std::env::var("GLOMMIO_TEST_POLLIO_ROOTDIR") {
-            Err(_) => {
-                eprintln!(
-                    "Glommio currently only supports NVMe-backed volumes formatted with XFS or \
-                     EXT4. To run poll io-related tests, please set GLOMMIO_TEST_POLLIO_ROOTDIR \
-                     to a NVMe-backed directory path in your environment.\nPoll io tests will not \
-                     run."
-                );
-            }
-            Ok(path) => {
-                vec.push(make_poll_test_directory(path, test_name));
-            }
-        };
-
-        vec.push(make_tmp_test_directory(test_name));
-        vec
-    }
 
     macro_rules! dma_file_test {
         ( $name:ident, $dir:ident, $kind:ident, $code:block) => {

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -142,16 +142,17 @@ impl DmaFile {
         } else {
             sys::direct_io_ify(file.as_raw_fd(), flags)?;
             let reactor = file.reactor.upgrade().unwrap();
-            if reactor.probe_iopoll_support(file.as_raw_fd()).await {
+            if reactor
+                .probe_iopoll_support(file.as_raw_fd(), major, minor)
+                .await
+            {
                 PollableStatus::Pollable
             } else {
                 PollableStatus::NonPollable(DirectIo::Enabled)
             }
         };
-        let max_sectors_size =
-            sysfs::BlockDevice::max_sectors_size(file.dev_major as _, file.dev_minor as _);
-        let max_segment_size =
-            sysfs::BlockDevice::max_segment_size(file.dev_major as _, file.dev_minor as _);
+        let max_sectors_size = sysfs::BlockDevice::max_sectors_size(major, minor);
+        let max_segment_size = sysfs::BlockDevice::max_segment_size(major, minor);
 
         Ok(DmaFile {
             file,

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -1376,10 +1376,7 @@ impl AsyncWrite for DmaStreamWriter {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        io::dma_file::{align_up, test::make_test_directories},
-        timer::Timer,
-    };
+    use crate::{io::dma_file::align_up, test_utils::make_test_directories, timer::Timer};
     use futures::{task::noop_waker_ref, AsyncRead, AsyncReadExt, AsyncWriteExt};
     use std::{io::ErrorKind, path::Path, time::Duration};
 

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -450,7 +450,7 @@ impl ImmutableFile {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{enclose, io::DmaFile, test_utils::make_tmp_test_directory};
+    use crate::{enclose, io::DmaFile, test_utils::make_test_directories};
     use futures::{AsyncReadExt, AsyncWriteExt};
     use futures_lite::stream::{self, StreamExt};
 
@@ -458,9 +458,10 @@ mod test {
         ( $name:ident, $dir:ident, $code:block) => {
             #[test]
             fn $name() {
-                let tmpdir = make_tmp_test_directory(stringify!($name));
-                let $dir = tmpdir.path.clone();
-                test_executor!(async move { $code });
+                for dir in make_test_directories(&format!("immutable-dma-{}", stringify!($name))) {
+                    let $dir = dir.path.clone();
+                    test_executor!(async move { $code });
+                }
             }
         };
 
@@ -468,9 +469,10 @@ mod test {
             #[test]
             #[should_panic]
             fn $name() {
-                let tmpdir = make_tmp_test_directory(stringify!($name));
-                let $dir = tmpdir.path.clone();
-                test_executor!(async move { $code });
+                for dir in make_test_directories(&format!("immutable-dma-{}", stringify!($name))) {
+                    let $dir = dir.path.clone();
+                    test_executor!(async move { $code });
+                }
             }
         };
     }

--- a/glommio/src/io/sched.rs
+++ b/glommio/src/io/sched.rs
@@ -242,8 +242,9 @@ impl Drop for ScheduledSource {
 pub(crate) mod test {
     use super::*;
     use crate::{
-        io::{dma_file::test::make_test_directories, DmaFile, OpenOptions, ReadResult},
+        io::{DmaFile, OpenOptions, ReadResult},
         sys::SourceType,
+        test_utils::make_test_directories,
     };
     use futures::join;
     use std::rc::Rc;

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -821,6 +821,33 @@ pub(crate) mod test_utils {
         }
     }
 
+    pub(crate) fn make_test_directories(test_name: &str) -> std::vec::Vec<TestDirectory> {
+        let mut vec = Vec::new();
+
+        // Glommio currently only supports NVMe-backed volumes formatted with XFS or
+        // EXT4. We therefore let the user decide what directory glommio should
+        // use to host the unit tests in. For more information regarding this
+        // limitation, see the README
+        match std::env::var("GLOMMIO_TEST_POLLIO_ROOTDIR") {
+            Err(_) => {
+                eprintln!(
+                    "Glommio currently only supports NVMe-backed volumes formatted with XFS or \
+                     EXT4. To run poll io-related tests, please set GLOMMIO_TEST_POLLIO_ROOTDIR \
+                     to a NVMe-backed directory path in your environment.\nPoll io tests will not \
+                     run."
+                );
+            }
+            Ok(path) => {
+                for p in path.split(',') {
+                    vec.push(make_poll_test_directory(p, test_name));
+                }
+            }
+        };
+
+        vec.push(make_tmp_test_directory(test_name));
+        vec
+    }
+
     pub(crate) fn make_poll_test_directory<P: AsRef<Path>>(
         path: P,
         test_name: &str,


### PR DESCRIPTION
Currently, Glommio panics when reading and writing using the poll
ring on a file that doesn't support iopoll (also confusingly known as
`hipri` and `mq_poll` at the VFS layer).

Unfortunately, some filesystems don't support polling. Even though we
are explicit in the documentation that we only support filesystems that
do (XFS, EXT4); this is not enough:
* LVM and dmcrypt mess with it;
* EXT4 iopoll support is somewhat recent;

So far, our approach has been that:
* MD devices never support iopoll;
* Everything else supports it.

If that's not the case, however, we currently fail hard. Instead, this
commit adds a new step when opening a file to exercise the
iopoll code path and probe whether it fails or not such that we can fall
back on interrupt-based IO if needed.

On a side note here, I have spent a good amount of time trying to find a
way to determine whether iopoll is supported on a given
/sys/block/device or a given FD, but there's nothing.

Additionally, we currently don't assume that if iopoll works on a
device, it will work for every file on that device. I believe this is a
safe assumption to make, though, and in the future, we could cache that
information to avoid the extra overhead every time a file is opened.