### PR TITLE
offer the option to use native TLS LLVM support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,23 @@ jobs:
         run: which deadlinks || cargo install cargo-deadlinks
 
       - name: Generate documentation
-        run: cargo doc --all-features
+        run: cargo doc --all
+
+  doc-nightly:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache setup
+        uses: ./.github/actions/cache-setup
+
+      - name: Install cargo-deadlinks
+        run: which deadlinks || cargo install cargo-deadlinks
+
+      - name: Generate documentation
+        run: cargo +nightly doc --features=nightly --all
 
     # temporarily disabled.
     # - name: Validate links
@@ -41,7 +57,21 @@ jobs:
         uses: ./.github/actions/cache-setup
 
       - name: Build all targets
-        run: cargo build --all --all-targets --all-features
+        run: cargo build --all --all-targets
+
+  build-nightly:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache setup
+        uses: ./.github/actions/cache-setup
+
+      - name: Build all targets on the nigthly channel
+        run: cargo build --all --all-targets --features=nightly
+
 
   test:
     runs-on: ubuntu-latest
@@ -64,6 +94,29 @@ jobs:
           rustup show
           rustup default stable
           cargo install cargo-sort
-          cargo test --all-features -- --test-threads=`nproc`
+          cargo test -- --test-threads=`nproc`
           EOF
           sudo -E bash -c "ulimit -Sl 512 && ulimit -Hl 512 && bash run-gha-workflow.sh"
+
+    test-nightly:
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: Cache setup
+          uses: ./.github/actions/cache-setup
+
+        - name: Install cargo helpers and test all targets on the nigthly channel
+          run: |
+            cat << EOF > "run-gha-workflow.sh"
+            PATH=$PATH:/usr/share/rust/.cargo/bin
+            echo "`nproc` CPU(s) available"
+            rustup install nightly
+            rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+            rustup install 1.58
+            rustup show
+            cargo test --features=nightly -- --test-threads=`nproc`
+            EOF
+            sudo -E bash -c "ulimit -Sl 512 && ulimit -Hl 512 && bash run-gha-workflow.sh"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -61,7 +61,8 @@ bench = []
 debugging = []
 
 # Unstable features based on nightly
-nightly = []
+native-tls = []
+nightly = ["native-tls"]
 
 [[bench]]
 name = "executor"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -59,6 +59,7 @@ cc = "1.0"
 [features]
 bench = []
 debugging = []
+native-tls = []
 
 [[bench]]
 name = "executor"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -59,7 +59,9 @@ cc = "1.0"
 [features]
 bench = []
 debugging = []
-native-tls = []
+
+# Unstable features based on nightly
+nightly = []
 
 [[bench]]
 name = "executor"

--- a/glommio/benches/preempt.rs
+++ b/glommio/benches/preempt.rs
@@ -1,21 +1,51 @@
 use glommio::prelude::*;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-fn main() {
+fn bench_need_preempt() {
     let local_ex = LocalExecutorBuilder::new(Placement::Fixed(0))
+        .preempt_timer(Duration::from_secs(10))
         .spawn(|| async move {
             let mut runs = 0;
             let t = Instant::now();
-            while !crate::executor().need_preempt() {
+            while runs < 1_000_000 {
+                let _ = crate::executor().need_preempt();
                 runs += 1;
             }
 
             println!(
-                "cost of checking for need_preempt: {:#?}",
-                t.elapsed() / runs,
+                "cost of checking for need_preempt:\t {:#?} (ran {} times)",
+                t.elapsed() / 1_000_000,
+                1_000_000
             );
         })
         .unwrap();
 
     local_ex.join().unwrap();
+}
+
+fn bench_yield_if_needed() {
+    let local_ex = LocalExecutorBuilder::new(Placement::Fixed(0))
+        .preempt_timer(Duration::from_secs(10))
+        .spawn(|| async move {
+            let mut runs = 0;
+            let t = Instant::now();
+            while runs < 1_000_000 {
+                crate::yield_if_needed().await;
+                runs += 1;
+            }
+
+            println!(
+                "cost of calling yield_if_needed:\t {:#?} (ran {} times)",
+                t.elapsed() / 1_000_000,
+                1_000_000
+            );
+        })
+        .unwrap();
+
+    local_ex.join().unwrap();
+}
+
+fn main() {
+    bench_need_preempt();
+    bench_yield_if_needed();
 }

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -52,7 +52,6 @@ use futures_lite::pin;
 use latch::{Latch, LatchState};
 use log::warn;
 pub use placement::{CpuSet, Placement, PoolPlacement};
-use scoped_tls::scoped_thread_local;
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, BinaryHeap},
@@ -87,7 +86,12 @@ pub(crate) const DEFAULT_RING_SUBMISSION_DEPTH: usize = 128;
 /// the second type parameter.
 type Result<T> = crate::Result<T, ()>;
 
-scoped_thread_local!(static LOCAL_EX: LocalExecutor);
+#[cfg(feature = "native-tls")]
+#[thread_local]
+static mut LOCAL_EX: *const LocalExecutor = std::ptr::null();
+
+#[cfg(not(feature = "native-tls"))]
+scoped_tls::scoped_thread_local!(static LOCAL_EX: LocalExecutor);
 
 /// Returns a proxy struct to the [`LocalExecutor`]
 pub fn executor() -> ExecutorProxy {
@@ -95,10 +99,18 @@ pub fn executor() -> ExecutorProxy {
 }
 
 pub(crate) fn executor_id() -> Option<usize> {
-    if LOCAL_EX.is_set() {
-        Some(LOCAL_EX.with(|ex| ex.id))
-    } else {
-        None
+    #[cfg(not(feature = "native-tls"))]
+    {
+        if LOCAL_EX.is_set() {
+            Some(LOCAL_EX.with(|ex| ex.id))
+        } else {
+            None
+        }
+    }
+
+    #[cfg(feature = "native-tls")]
+    unsafe {
+        LOCAL_EX.as_ref().map(|ex| ex.id)
     }
 }
 
@@ -1051,10 +1063,21 @@ impl<T> PoolThreadHandles<T> {
 }
 
 pub(crate) fn maybe_activate(tq: Rc<RefCell<TaskQueue>>) {
+    #[cfg(not(feature = "native-tls"))]
     LOCAL_EX.with(|local_ex| {
         let mut queues = local_ex.queues.borrow_mut();
-        queues.maybe_activate(tq)
-    })
+        queues.maybe_activate(tq);
+    });
+
+    #[cfg(feature = "native-tls")]
+    unsafe {
+        let mut queues = LOCAL_EX
+            .as_ref()
+            .expect("this thread doesn't have a LocalExecutor running")
+            .queues
+            .borrow_mut();
+        queues.maybe_activate(tq);
+    };
 }
 
 pub struct LocalExecutorConfig {
@@ -1426,18 +1449,15 @@ impl LocalExecutor {
     /// assert_eq!(res, 6);
     /// ```
     pub fn run<T>(&self, future: impl Future<Output = T>) -> T {
-        // this waker is never exposed in the public interface and is only used to check
-        // whether the task's `JoinHandle` is `Ready`
-        let waker = dummy_waker();
-        let cx = &mut Context::from_waker(&waker);
+        let run = |this: &Self| {
+            // this waker is never exposed in the public interface and is only used to check
+            // whether the task's `JoinHandle` is `Ready`
+            let waker = dummy_waker();
+            let cx = &mut Context::from_waker(&waker);
 
-        let spin_before_park = self.spin_before_park().unwrap_or_default();
-        if LOCAL_EX.is_set() {
-            panic!("There is already an Executor running in this thread");
-        }
+            let spin_before_park = self.spin_before_park().unwrap_or_default();
 
-        LOCAL_EX.set(self, || {
-            let future = self
+            let future = this
                 .spawn_into(async move { future.await }, TaskQueueHandle::default())
                 .unwrap()
                 .detach();
@@ -1449,7 +1469,7 @@ impl LocalExecutor {
                     // can't be canceled, and join handle is None only upon
                     // cancellation or panic. So in case of panic this just propagates
                     let cur_time = Instant::now();
-                    self.queues.borrow_mut().stats.total_runtime += cur_time - pre_time;
+                    this.queues.borrow_mut().stats.total_runtime += cur_time - pre_time;
                     break t.unwrap();
                 }
 
@@ -1458,16 +1478,16 @@ impl LocalExecutor {
                 // requests that are latency sensitive we want them out of the
                 // ring ASAP (before we run the task queues). We will also use
                 // the opportunity to install the timer.
-                self.parker
-                    .poll_io(|| Some(self.preempt_timer_duration()))
+                this.parker
+                    .poll_io(|| Some(this.preempt_timer_duration()))
                     .expect("Failed to poll io! This is actually pretty bad!");
 
                 // run user code
-                let run = self.run_task_queues();
+                let run = this.run_task_queues();
 
                 // account for runtime and poll/sleep if possible
                 let cur_time = Instant::now();
-                self.queues.borrow_mut().stats.total_runtime += cur_time - pre_time;
+                this.queues.borrow_mut().stats.total_runtime += cur_time - pre_time;
                 pre_time = cur_time;
                 if !run {
                     if let Poll::Ready(t) = future.as_mut().poll(cx) {
@@ -1477,9 +1497,9 @@ impl LocalExecutor {
                         // future is probably the one setting up the task queues and etc.
                         break t.unwrap();
                     } else {
-                        while !self.reactor.spin_poll_io().unwrap() {
+                        while !this.reactor.spin_poll_io().unwrap() {
                             if pre_time.elapsed() > spin_before_park {
-                                self.parker
+                                this.parker
                                     .park()
                                     .expect("Failed to park! This is actually pretty bad!");
                                 break;
@@ -1490,7 +1510,28 @@ impl LocalExecutor {
                     }
                 }
             }
-        })
+        };
+
+        #[cfg(not(feature = "native-tls"))]
+        {
+            assert!(
+                !LOCAL_EX.is_set(),
+                "There is already an LocalExecutor running on this thread"
+            );
+            LOCAL_EX.set(self, || run(self))
+        }
+
+        #[cfg(feature = "native-tls")]
+        unsafe {
+            assert!(
+                LOCAL_EX.is_null(),
+                "There is already an LocalExecutor running on this thread"
+            );
+
+            defer!(LOCAL_EX = std::ptr::null());
+            LOCAL_EX = self as *const Self;
+            run(self)
+        }
     }
 }
 
@@ -2046,22 +2087,44 @@ impl ExecutorProxy {
     where
         F: FnOnce(&LocalExecutor) -> bool,
     {
-        let need_yield = if LOCAL_EX.is_set() {
-            LOCAL_EX.with(|local_ex| {
+        #[cfg(not(feature = "native-tls"))]
+        {
+            let need_yield = if LOCAL_EX.is_set() {
+                LOCAL_EX.with(|local_ex| {
+                    if cond(local_ex) {
+                        local_ex.mark_me_for_yield();
+                        true
+                    } else {
+                        false
+                    }
+                })
+            } else {
+                // We are not in a glommio context
+                false
+            };
+
+            if need_yield {
+                futures_lite::future::yield_now().await;
+            }
+        }
+
+        #[cfg(feature = "native-tls")]
+        {
+            let need_yield = if let Some(local_ex) = unsafe { LOCAL_EX.as_ref() } {
                 if cond(local_ex) {
                     local_ex.mark_me_for_yield();
                     true
                 } else {
                     false
                 }
-            })
-        } else {
-            // We are not in a glommio context
-            false
-        };
+            } else {
+                // We are not in a glommio context
+                false
+            };
 
-        if need_yield {
-            futures_lite::future::yield_now().await;
+            if need_yield {
+                futures_lite::future::yield_now().await;
+            }
         }
     }
 
@@ -2091,30 +2154,17 @@ impl ExecutorProxy {
     ///
     /// [`RefMut`]: https://doc.rust-lang.org/std/cell/struct.RefMut.html
     #[inline(always)]
-    // FIXME: This is a bit less efficient than it needs, because the scoped thread
-    // local key does lazy initialization. Every time we call into this, we are
-    // paying to test if this is initialized. This is what I got from objdump:
-    //
-    // 0:    50                      push   %rax
-    // 1:    ff 15 00 00 00 00       callq  *0x0(%rip)
-    // 7:    48 85 c0                test   %rax,%rax
-    // a:    74 17                   je     23  <== will call into the
-    // initialization routine c:    48 8b 88 38 03 00 00    mov
-    // 0x338(%rax),%rcx <== address of the head 13:   48 8b 80 40 03 00 00
-    // mov    0x340(%rax),%rax <== address of the tail 1a:   8b 00
-    // mov    (%rax),%eax 1c:   3b 01                   cmp    (%rcx),%eax <==
-    // need preempt 1e:   0f 95 c0                setne  %al
-    // 21:   59                      pop    %rcx
-    // 22:   c3                      retq
-    // 23    <== initialization stuff
-    //
-    // Rust has a thread local feature that is under experimental so we can maybe
-    // switch to that someday.
-    //
-    // We will prefer to use the stable compiler and pay that unfortunate price for
-    // now.
     pub fn need_preempt(&self) -> bool {
-        LOCAL_EX.with(|local_ex| local_ex.need_preempt())
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| local_ex.need_preempt());
+
+        #[cfg(feature = "native-tls")]
+        return unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .need_preempt()
+        };
     }
 
     /// Conditionally yields the current task queue. The scheduler may then
@@ -2159,7 +2209,16 @@ impl ExecutorProxy {
 
     #[inline]
     pub(crate) fn reactor(&self) -> Rc<reactor::Reactor> {
-        LOCAL_EX.with(|local_ex| local_ex.get_reactor())
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| local_ex.get_reactor());
+
+        #[cfg(feature = "native-tls")]
+        return unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .get_reactor()
+        };
     }
 
     /// Returns the id of the current executor
@@ -2180,7 +2239,16 @@ impl ExecutorProxy {
     /// });
     /// ```
     pub fn id(&self) -> usize {
-        LOCAL_EX.with(|local_ex| local_ex.id())
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| local_ex.id());
+
+        #[cfg(feature = "native-tls")]
+        return unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .id()
+        };
     }
 
     /// Creates a new task queue, with a given latency hint and the provided
@@ -2224,7 +2292,16 @@ impl ExecutorProxy {
         latency: Latency,
         name: &str,
     ) -> TaskQueueHandle {
-        LOCAL_EX.with(|local_ex| local_ex.create_task_queue(shares, latency, name))
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| local_ex.create_task_queue(shares, latency, name));
+
+        #[cfg(feature = "native-tls")]
+        return unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .create_task_queue(shares, latency, name)
+        };
     }
 
     /// Returns the [`TaskQueueHandle`] that represents the TaskQueue currently
@@ -2265,7 +2342,16 @@ impl ExecutorProxy {
     /// ex.join().unwrap();
     /// ```
     pub fn current_task_queue(&self) -> TaskQueueHandle {
-        LOCAL_EX.with(|local_ex| local_ex.current_task_queue())
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| local_ex.current_task_queue());
+
+        #[cfg(feature = "native-tls")]
+        return unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .current_task_queue()
+        };
     }
 
     /// Returns a [`Result`] with its `Ok` value wrapping a [`TaskQueueStats`]
@@ -2298,10 +2384,22 @@ impl ExecutorProxy {
     /// [`QueueErrorKind`]: crate::error::QueueErrorKind
     /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
     pub fn task_queue_stats(&self, handle: TaskQueueHandle) -> Result<TaskQueueStats> {
-        LOCAL_EX.with(|local_ex| match local_ex.get_queue(&handle) {
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| match local_ex.get_queue(&handle) {
             Some(x) => Ok(x.borrow_mut().stats.take()),
             None => Err(GlommioError::queue_not_found(handle.index)),
-        })
+        });
+
+        #[cfg(feature = "native-tls")]
+        return match unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .get_queue(&handle)
+        } {
+            Some(x) => Ok(x.borrow_mut().stats.take()),
+            None => Err(GlommioError::queue_not_found(handle.index)),
+        };
     }
 
     /// Returns a collection of [`TaskQueueStats`] with information about all
@@ -2340,15 +2438,31 @@ impl ExecutorProxy {
     where
         V: Extend<TaskQueueStats>,
     {
+        #[cfg(not(feature = "native-tls"))]
         LOCAL_EX.with(|local_ex| {
-            let tq = local_ex.queues.borrow();
             output.extend(
-                tq.available_executors
+                local_ex
+                    .queues
+                    .borrow()
+                    .available_executors
                     .values()
                     .map(|x| x.borrow_mut().stats.take()),
             );
-            output
-        })
+        });
+
+        #[cfg(feature = "native-tls")]
+        output.extend(unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .queues
+                .borrow()
+                .available_executors
+                .values()
+                .map(|x| x.borrow_mut().stats.take())
+        });
+
+        output
     }
 
     /// Returns a [`ExecutorStats`] struct with information about this Executor
@@ -2372,7 +2486,18 @@ impl ExecutorProxy {
     ///
     /// [`ExecutorStats`]: struct.ExecutorStats.html
     pub fn executor_stats(&self) -> ExecutorStats {
-        LOCAL_EX.with(|local_ex| std::mem::take(&mut local_ex.queues.borrow_mut().stats))
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| std::mem::take(&mut local_ex.queues.borrow_mut().stats));
+
+        #[cfg(feature = "native-tls")]
+        return std::mem::take(unsafe {
+            &mut LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .queues
+                .borrow_mut()
+                .stats
+        });
     }
 
     /// Returns an [`IoStats`] struct with information about IO performed by
@@ -2394,7 +2519,17 @@ impl ExecutorProxy {
     ///
     /// [`IoStats`]: crate::IoStats
     pub fn io_stats(&self) -> IoStats {
-        LOCAL_EX.with(|local_ex| local_ex.get_reactor().io_stats())
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| local_ex.get_reactor().io_stats());
+
+        #[cfg(feature = "native-tls")]
+        return unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .get_reactor()
+                .io_stats()
+        };
     }
 
     /// Returns an [`IoStats`] struct with information about IO performed from
@@ -2424,12 +2559,25 @@ impl ExecutorProxy {
     ///
     /// [`IoStats`]: crate::IoStats
     pub fn task_queue_io_stats(&self, handle: TaskQueueHandle) -> Result<IoStats> {
-        LOCAL_EX.with(
-            |local_ex| match local_ex.get_reactor().task_queue_io_stats(&handle) {
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| {
+            match local_ex.get_reactor().task_queue_io_stats(&handle) {
                 Some(x) => Ok(x),
                 None => Err(GlommioError::queue_not_found(handle.index)),
-            },
-        )
+            }
+        });
+
+        #[cfg(feature = "native-tls")]
+        return match unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .get_reactor()
+                .task_queue_io_stats(&handle)
+        } {
+            Some(x) => Ok(x),
+            None => Err(GlommioError::queue_not_found(handle.index)),
+        };
     }
 
     /// Spawns a task onto the current single-threaded executor.
@@ -2458,7 +2606,16 @@ impl ExecutorProxy {
     where
         T: 'static,
     {
-        LOCAL_EX.with(|local_ex| Task::<T>(local_ex.spawn(future)))
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| Task::<T>(local_ex.spawn(future)));
+
+        #[cfg(feature = "native-tls")]
+        return Task::<T>(unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .spawn(future)
+        });
     }
 
     /// Spawns a task onto the current single-threaded executor, in a particular
@@ -2498,7 +2655,17 @@ impl ExecutorProxy {
     where
         T: 'static,
     {
-        LOCAL_EX.with(|local_ex| local_ex.spawn_into(future, handle).map(Task::<T>))
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| local_ex.spawn_into(future, handle).map(Task::<T>));
+
+        #[cfg(feature = "native-tls")]
+        return unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .spawn_into(future, handle)
+        }
+        .map(Task::<T>);
     }
 
     /// Spawns a task onto the current single-threaded executor.
@@ -2529,7 +2696,17 @@ impl ExecutorProxy {
         &self,
         future: impl Future<Output = T> + 'a,
     ) -> ScopedTask<'a, T> {
-        LOCAL_EX.with(|local_ex| ScopedTask::<'a, T>(local_ex.spawn(future), PhantomData))
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| ScopedTask::<'a, T>(local_ex.spawn(future), PhantomData));
+
+        #[cfg(feature = "native-tls")]
+        return ScopedTask::<'a, T>(
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .spawn(future),
+            PhantomData,
+        );
     }
 
     /// Spawns a task onto the current single-threaded executor, in a particular
@@ -2570,11 +2747,19 @@ impl ExecutorProxy {
         future: impl Future<Output = T> + 'a,
         handle: TaskQueueHandle,
     ) -> Result<ScopedTask<'a, T>> {
-        LOCAL_EX.with(|local_ex| {
+        #[cfg(not(feature = "native-tls"))]
+        return LOCAL_EX.with(|local_ex| {
             local_ex
                 .spawn_into(future, handle)
                 .map(|x| ScopedTask::<'a, T>(x, PhantomData))
-        })
+        });
+
+        #[cfg(feature = "native-tls")]
+        return LOCAL_EX
+            .as_ref()
+            .expect("this thread doesn't have a LocalExecutor running")
+            .spawn_into(future, handle)
+            .map(|x| ScopedTask::<'a, T>(x, PhantomData));
     }
 
     /// Spawns a blocking task into a background thread where blocking is
@@ -2619,8 +2804,19 @@ impl ExecutorProxy {
     {
         let result = Arc::new(Mutex::new(MaybeUninit::<R>::uninit()));
         let f_inner = enclose::enclose!((result) move || {result.lock().unwrap().write(func());});
+
+        #[cfg(not(feature = "native-tls"))]
         let waiter =
             LOCAL_EX.with(move |local_ex| local_ex.reactor.run_blocking(Box::new(f_inner)));
+
+        #[cfg(feature = "native-tls")]
+        let waiter = unsafe {
+            LOCAL_EX
+                .as_ref()
+                .expect("this thread doesn't have a LocalExecutor running")
+                .reactor
+                .run_blocking(Box::new(f_inner))
+        };
 
         async move {
             let source = waiter.await;
@@ -3969,5 +4165,32 @@ mod test {
             .unwrap()
             .join();
         assert!(ret.is_err());
+    }
+
+    #[test]
+    fn local_executor_unset() {
+        LocalExecutor::default().run(async {});
+
+        #[cfg(not(feature = "native-tls"))]
+        assert!(!LOCAL_EX.is_set());
+
+        #[cfg(feature = "native-tls")]
+        assert!(unsafe { LOCAL_EX.is_null() });
+    }
+
+    #[test]
+    fn local_executor_unset_when_panic() {
+        let res = std::panic::catch_unwind(|| {
+            LocalExecutor::default().run(async {
+                panic!("uh oh!");
+            });
+        });
+        assert!(res.is_err());
+
+        #[cfg(not(feature = "native-tls"))]
+        assert!(!LOCAL_EX.is_set());
+
+        #[cfg(feature = "native-tls")]
+        assert!(unsafe { LOCAL_EX.is_null() });
     }
 }

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -86,11 +86,11 @@ pub(crate) const DEFAULT_RING_SUBMISSION_DEPTH: usize = 128;
 /// the second type parameter.
 type Result<T> = crate::Result<T, ()>;
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "native-tls")]
 #[thread_local]
 static mut LOCAL_EX: *const LocalExecutor = std::ptr::null();
 
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "native-tls"))]
 scoped_tls::scoped_thread_local!(static LOCAL_EX: LocalExecutor);
 
 /// Returns a proxy struct to the [`LocalExecutor`]
@@ -100,7 +100,7 @@ pub fn executor() -> ExecutorProxy {
 }
 
 pub(crate) fn executor_id() -> Option<usize> {
-    #[cfg(not(feature = "nightly"))]
+    #[cfg(not(feature = "native-tls"))]
     {
         if LOCAL_EX.is_set() {
             Some(LOCAL_EX.with(|ex| ex.id))
@@ -109,7 +109,7 @@ pub(crate) fn executor_id() -> Option<usize> {
         }
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "native-tls")]
     unsafe {
         LOCAL_EX.as_ref().map(|ex| ex.id)
     }
@@ -1064,13 +1064,13 @@ impl<T> PoolThreadHandles<T> {
 }
 
 pub(crate) fn maybe_activate(tq: Rc<RefCell<TaskQueue>>) {
-    #[cfg(not(feature = "nightly"))]
+    #[cfg(not(feature = "native-tls"))]
     LOCAL_EX.with(|local_ex| {
         let mut queues = local_ex.queues.borrow_mut();
         queues.maybe_activate(tq);
     });
 
-    #[cfg(feature = "nightly")]
+    #[cfg(feature = "native-tls")]
     unsafe {
         let mut queues = LOCAL_EX
             .as_ref()
@@ -1513,7 +1513,7 @@ impl LocalExecutor {
             }
         };
 
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         {
             assert!(
                 !LOCAL_EX.is_set(),
@@ -1522,7 +1522,7 @@ impl LocalExecutor {
             LOCAL_EX.set(self, || run(self))
         }
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         unsafe {
             assert!(
                 LOCAL_EX.is_null(),
@@ -2111,10 +2111,10 @@ impl ExecutorProxy {
     /// [`RefMut`]: https://doc.rust-lang.org/std/cell/struct.RefMut.html
     #[inline(always)]
     pub fn need_preempt(&self) -> bool {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| local_ex.need_preempt());
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2140,7 +2140,7 @@ impl ExecutorProxy {
     /// [`ExecutorProxy::yield_task_queue_now`].
     #[inline(always)]
     pub async fn yield_if_needed(&self) {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         {
             let need_yield = if LOCAL_EX.is_set() {
                 LOCAL_EX.with(|local_ex| {
@@ -2161,7 +2161,7 @@ impl ExecutorProxy {
             }
         }
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         unsafe {
             if self.need_preempt() {
                 (*LOCAL_EX).mark_me_for_yield();
@@ -2189,7 +2189,7 @@ impl ExecutorProxy {
     /// [`ExecutorProxy::yield_if_needed`] instead is the better choice.
     #[inline(always)]
     pub async fn yield_task_queue_now(&self) {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         {
             if LOCAL_EX.is_set() {
                 LOCAL_EX.with(|local_ex| {
@@ -2199,7 +2199,7 @@ impl ExecutorProxy {
             futures_lite::future::yield_now().await;
         }
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         {
             if let Some(local_ex) = unsafe { LOCAL_EX.as_ref() } {
                 local_ex.mark_me_for_yield();
@@ -2210,10 +2210,10 @@ impl ExecutorProxy {
 
     #[inline(always)]
     pub(crate) fn reactor(&self) -> Rc<reactor::Reactor> {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| local_ex.get_reactor());
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2240,10 +2240,10 @@ impl ExecutorProxy {
     /// });
     /// ```
     pub fn id(&self) -> usize {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| local_ex.id());
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2293,10 +2293,10 @@ impl ExecutorProxy {
         latency: Latency,
         name: &str,
     ) -> TaskQueueHandle {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| local_ex.create_task_queue(shares, latency, name));
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2343,10 +2343,10 @@ impl ExecutorProxy {
     /// ex.join().unwrap();
     /// ```
     pub fn current_task_queue(&self) -> TaskQueueHandle {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| local_ex.current_task_queue());
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2385,13 +2385,13 @@ impl ExecutorProxy {
     /// [`QueueErrorKind`]: crate::error::QueueErrorKind
     /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
     pub fn task_queue_stats(&self, handle: TaskQueueHandle) -> Result<TaskQueueStats> {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| match local_ex.get_queue(&handle) {
             Some(x) => Ok(x.borrow_mut().stats.take()),
             None => Err(GlommioError::queue_not_found(handle.index)),
         });
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return match unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2439,7 +2439,7 @@ impl ExecutorProxy {
     where
         V: Extend<TaskQueueStats>,
     {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         LOCAL_EX.with(|local_ex| {
             output.extend(
                 local_ex
@@ -2451,7 +2451,7 @@ impl ExecutorProxy {
             );
         });
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         output.extend(unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2487,10 +2487,10 @@ impl ExecutorProxy {
     ///
     /// [`ExecutorStats`]: struct.ExecutorStats.html
     pub fn executor_stats(&self) -> ExecutorStats {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| std::mem::take(&mut local_ex.queues.borrow_mut().stats));
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return std::mem::take(unsafe {
             &mut LOCAL_EX
                 .as_ref()
@@ -2520,10 +2520,10 @@ impl ExecutorProxy {
     ///
     /// [`IoStats`]: crate::IoStats
     pub fn io_stats(&self) -> IoStats {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| local_ex.get_reactor().io_stats());
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2560,7 +2560,7 @@ impl ExecutorProxy {
     ///
     /// [`IoStats`]: crate::IoStats
     pub fn task_queue_io_stats(&self, handle: TaskQueueHandle) -> Result<IoStats> {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| {
             match local_ex.get_reactor().task_queue_io_stats(&handle) {
                 Some(x) => Ok(x),
@@ -2568,7 +2568,7 @@ impl ExecutorProxy {
             }
         });
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return match unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2607,10 +2607,10 @@ impl ExecutorProxy {
     where
         T: 'static,
     {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| Task::<T>(local_ex.spawn(future)));
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return Task::<T>(unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2656,10 +2656,10 @@ impl ExecutorProxy {
     where
         T: 'static,
     {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| local_ex.spawn_into(future, handle).map(Task::<T>));
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return unsafe {
             LOCAL_EX
                 .as_ref()
@@ -2697,10 +2697,10 @@ impl ExecutorProxy {
         &self,
         future: impl Future<Output = T> + 'a,
     ) -> ScopedTask<'a, T> {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| ScopedTask::<'a, T>(local_ex.spawn(future), PhantomData));
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return ScopedTask::<'a, T>(
             LOCAL_EX
                 .as_ref()
@@ -2748,14 +2748,14 @@ impl ExecutorProxy {
         future: impl Future<Output = T> + 'a,
         handle: TaskQueueHandle,
     ) -> Result<ScopedTask<'a, T>> {
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         return LOCAL_EX.with(|local_ex| {
             local_ex
                 .spawn_into(future, handle)
                 .map(|x| ScopedTask::<'a, T>(x, PhantomData))
         });
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         return LOCAL_EX
             .as_ref()
             .expect("this thread doesn't have a LocalExecutor running")
@@ -2806,11 +2806,11 @@ impl ExecutorProxy {
         let result = Arc::new(Mutex::new(MaybeUninit::<R>::uninit()));
         let f_inner = enclose::enclose!((result) move || {result.lock().unwrap().write(func());});
 
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         let waiter =
             LOCAL_EX.with(move |local_ex| local_ex.reactor.run_blocking(Box::new(f_inner)));
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         let waiter = unsafe {
             LOCAL_EX
                 .as_ref()
@@ -4172,10 +4172,10 @@ mod test {
     fn local_executor_unset() {
         LocalExecutor::default().run(async {});
 
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         assert!(!LOCAL_EX.is_set());
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         assert!(unsafe { LOCAL_EX.is_null() });
     }
 
@@ -4188,10 +4188,10 @@ mod test {
         });
         assert!(res.is_err());
 
-        #[cfg(not(feature = "nightly"))]
+        #[cfg(not(feature = "native-tls"))]
         assert!(!LOCAL_EX.is_set());
 
-        #[cfg(feature = "nightly")]
+        #[cfg(feature = "native-tls")]
         assert!(unsafe { LOCAL_EX.is_null() });
     }
 }

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -287,7 +287,7 @@
 //! ```
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(doc, deny(rustdoc::broken_intra_doc_links))]
-#![cfg_attr(feature = "nightly", feature(thread_local))]
+#![cfg_attr(feature = "native-tls", feature(thread_local))]
 
 #[macro_use]
 extern crate nix;

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -287,6 +287,8 @@
 //! ```
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(doc, deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(feature = "native-tls", feature(thread_local))]
+
 #[macro_use]
 extern crate nix;
 extern crate alloc;

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -287,7 +287,7 @@
 //! ```
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![cfg_attr(doc, deny(rustdoc::broken_intra_doc_links))]
-#![cfg_attr(feature = "native-tls", feature(thread_local))]
+#![cfg_attr(feature = "nightly", feature(thread_local))]
 
 #[macro_use]
 extern crate nix;

--- a/glommio/tests/linters.rs
+++ b/glommio/tests/linters.rs
@@ -22,14 +22,7 @@ mod tests {
     #[test]
     fn check_clippy() {
         let status = Command::new("cargo")
-            .args([
-                "clippy",
-                "--all-targets",
-                "--all-features",
-                "--",
-                "-D",
-                "warnings",
-            ])
+            .args(["+stable", "clippy", "--all-targets", "--", "-D", "warnings"])
             .status()
             .unwrap();
         assert!(status.success());


### PR DESCRIPTION
I have been waiting for this to land in stable forever, and my patience
is running out. So we'll start supporting this behind a feature gate
that's disabled by default (native TLS requires a nightly compiler).

Additionally, this PR gets rid of `cond_yield` in favor of manually
inlining the preemption code. I tried to get the closure passed to
`cond_yield` to be inlined, but the compiler won't cooperate. This is
such a hot code path that it makes sense to inline it by hand.

And the results are great:

### With std-tls (default):
Before (no inlining):
```
cost of checking for need_preempt:   2ns (ran 1000000 times)
cost of calling yield_if_needed:     5ns (ran 1000000 times)
```
After (inlined):
```
cost of checking for need_preempt:   1ns (ran 1000000 times)
cost of calling yield_if_needed:     3ns (ran 1000000 times)
```

### With native-tls (behind the feature gate):
Before (no inlining):
```
cost of checking for need_preempt:   1ns (ran 1000000 times)
cost of calling yield_if_needed:     3ns (ran 1000000 times)
```
After  (inlined):
```
cost of checking for need_preempt:   0ns (ran 1000000 times)
cost of calling yield_if_needed:     2ns (ran 1000000 times)
```
