### PR TITLE
feat: Update to socket2@0.4

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -40,7 +40,7 @@ scopeguard = "1.1"
 signal-hook = { version = "0.3" }
 sketches-ddsketch = "0.1"
 smallvec = { version = "1.7", features = ["union"] }
-socket2 = { version = "0.3", features = ["unix", "reuseport"] }
+socket2 = { version = "0.4", features = ["all"] }
 tracing = "0.1"
 typenum = "1.15"
 

--- a/glommio/src/net/udp_socket.rs
+++ b/glommio/src/net/udp_socket.rs
@@ -70,11 +70,11 @@ impl UdpSocket {
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "empty address"))?;
 
         let domain = if addr.is_ipv6() {
-            Domain::ipv6()
+            Domain::IPV6
         } else {
-            Domain::ipv4()
+            Domain::IPV4
         };
-        let sk = Socket::new(domain, Type::dgram(), Some(Protocol::udp()))?;
+        let sk = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
         let addr = socket2::SockAddr::from(addr);
         sk.set_reuse_port(true)?;
         sk.bind(&addr)?;

--- a/glommio/src/net/unix.rs
+++ b/glommio/src/net/unix.rs
@@ -91,12 +91,12 @@ impl UnixListener {
     /// });
     /// ```
     pub fn bind<A: AsRef<Path>>(addr: A) -> Result<UnixListener> {
-        let sk = Socket::new(Domain::unix(), Type::stream(), None)?;
+        let sk = Socket::new(Domain::UNIX, Type::STREAM, None)?;
         let addr = socket2::SockAddr::unix(addr.as_ref())?;
 
         sk.bind(&addr)?;
         sk.listen(128)?;
-        let listener = sk.into_unix_listener();
+        let listener = sk.into();
 
         Ok(UnixListener {
             reactor: Rc::downgrade(&crate::executor().reactor()),
@@ -328,7 +328,7 @@ impl UnixStream {
     pub async fn connect<A: AsRef<Path>>(addr: A) -> Result<UnixStream> {
         let reactor = crate::executor().reactor();
 
-        let socket = Socket::new(Domain::unix(), Type::stream(), None)?;
+        let socket = Socket::new(Domain::UNIX, Type::STREAM, None)?;
         let addr = SockAddr::new_unix(addr.as_ref())
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         let source = reactor.connect(socket.as_raw_fd(), addr);
@@ -492,7 +492,7 @@ impl UnixDatagram {
     /// });
     /// ```
     pub fn bind<A: AsRef<Path>>(addr: A) -> Result<UnixDatagram> {
-        let sk = Socket::new(Domain::unix(), Type::dgram(), None)?;
+        let sk = Socket::new(Domain::UNIX, Type::DGRAM, None)?;
         let addr = socket2::SockAddr::unix(addr.as_ref())?;
         sk.bind(&addr)?;
         Ok(Self {
@@ -502,7 +502,7 @@ impl UnixDatagram {
 
     /// Creates a Unix Datagram socket which is not bound to any address.
     pub fn unbound() -> Result<UnixDatagram> {
-        let sk = Socket::new(Domain::unix(), Type::dgram(), None)?;
+        let sk = Socket::new(Domain::UNIX, Type::DGRAM, None)?;
         Ok(Self {
             socket: GlommioDatagram::from(sk),
         })


### PR DESCRIPTION
### What does this PR do?

Updates from `socket@0.3` to `socket@0.4`

### Motivation

I need this to be able to use the `From<Socket>` implementation from `TcpStream`.