### PR TITLE
pass proper max TimeSpec64 to throughput preemption timer source

### DIFF
--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -62,6 +62,7 @@ use nix::sys::{
 };
 use smallvec::SmallVec;
 
+const MAX_I64_DURATION: Duration = Duration::new(i64::MAX as u64, 999_999_999);
 const MSG_ZEROCOPY: i32 = 0x4000000;
 
 #[allow(dead_code)]
@@ -987,7 +988,7 @@ impl SleepableRing {
         let timer_source = Source::new(
             IoRequirements::default(),
             -1,
-            SourceType::Timeout(TimeSpec64::from(Duration::MAX), min_events),
+            SourceType::Timeout(TimeSpec64::from(MAX_I64_DURATION), min_events),
             None,
             None,
         );


### PR DESCRIPTION
### What does this PR do?

I suppose the idea was to pass max (positive) value timespec can represent, but due to the cast from u64 to i64 Duration::MAX becomes timespec with negative tv_sec field.

### Motivation

I've noticed EINVALs (-22) being returned from kernel and that should probably not happen

### Additional Notes

Maybe seconds and nanoseconds constraints should be encoded in TimeSpec64 type?
I'm not sure about that so I left it as it is right now.
