### PR TITLE
fix the conversion from `Duration` to `TimeSpec64`

### DIFF
--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -190,7 +190,9 @@ impl Source {
         let mut inner = self.inner.borrow_mut();
         let t = &mut inner.timeout;
         let old = *t;
-        *t = Some(TimeSpec64::from(d));
+        match TimeSpec64::try_from(d) {
+            Ok(dur) | Err(dur) => *t = Some(dur),
+        }
         old.map(Duration::from)
     }
 

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -13,6 +13,7 @@ use rlimit::Resource;
 use std::{
     cell::{Cell, Ref, RefCell, RefMut},
     collections::VecDeque,
+    convert::TryFrom,
     ffi::CStr,
     fmt,
     future::Future,
@@ -951,7 +952,7 @@ impl SleepableRing {
         let source = Source::new(
             IoRequirements::default(),
             -1,
-            SourceType::Timeout(TimeSpec64::from(d), 0),
+            SourceType::Timeout(TimeSpec64::try_from(d).unwrap(), 0),
             None,
             None,
         );
@@ -987,7 +988,7 @@ impl SleepableRing {
         let timer_source = Source::new(
             IoRequirements::default(),
             -1,
-            SourceType::Timeout(TimeSpec64::from(Duration::MAX), min_events),
+            SourceType::Timeout(TimeSpec64::MAX, min_events),
             None,
             None,
         );
@@ -2052,7 +2053,10 @@ mod tests {
             let source = Source::new(
                 IoRequirements::default(),
                 -1,
-                SourceType::Timeout(TimeSpec64::from(Duration::from_millis(millis)), 0),
+                SourceType::Timeout(
+                    TimeSpec64::try_from(Duration::from_millis(millis)).unwrap(),
+                    0,
+                ),
                 None,
                 None,
             );


### PR DESCRIPTION
`std::time::Duration` uses `u64` to represent seconds while the kernel
uses signed integers. Our implementation of `From` would cast directly,
resulting in two's complement wrapping.

This commit removes `From` in favor of `TryFrom`. This new
implementation allows the user to know whether the returned `TimeSpec64`
maps the original duration or if it was capped to the maximum
value a `TimeSpec64` can represent.

It also makes it easy for a user to ignore the saturation (presumably
this will only ever trigger when trying to convert `Duration::MAX`
values and the likes).

This was originally reported by @khodzha in #535 time and the fix is
co-authored by them. Credit where credit is due! :bow: 

