### PR TITLE
disable CI from commenting on PRs

### DIFF
--- a/.github/templates/license_check_failed.md
+++ b/.github/templates/license_check_failed.md
@@ -1,6 +1,0 @@
-Greetings @{{ .user }}!
-
-It looks like your PR added a new or changed an existing dependency, and CI has failed to validate your changes.
-This is likely an indication that one of the dependencies you added uses a restricted license. See `deny.toml` for a list of licenses we allow.
-
-Thank you!

--- a/.github/workflows/third-party_exported.yml
+++ b/.github/workflows/third-party_exported.yml
@@ -3,8 +3,11 @@ name: Third-party licences
 permissions: write-all
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
+    branches: [ master ]
+    types: [ "opened", "synchronize" ]
+  push:
+    branches: [ master ]
 
 jobs:
   allowed:
@@ -24,30 +27,3 @@ jobs:
           log-level: warn
           command: check licenses
           arguments: --all-features
-
-  comment:
-    runs-on: ubuntu-latest
-
-    needs: [ allowed ]
-    if: failure()
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          # pull the fork's HEAD instead of the main repo's
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Render Template
-        id: template
-        uses: chuhlomin/render-template@v1.2
-        with:
-          template: .github/templates/license_check_failed.md
-          vars: |
-            user: ${{ github.event.pull_request.user.login }}
-
-      - name: Comment PR
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: ${{ steps.template.outputs.result }}


### PR DESCRIPTION
This PR disables the feature whereby CI comments on pull requests if
some CI checks fail.