### PR TITLE
sleep by `poll`ing an eventfd

### DIFF
--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -60,7 +60,6 @@ pub(crate) enum SourceType {
     Fallocate,
     Truncate,
     Close,
-    LinkRings,
     ForeignNotifier(u64, bool),
     Statx(CString, Box<RefCell<libc::statx>>),
     Timeout(TimeSpec64, u32),


### PR DESCRIPTION
We no longer link the rings at all. Instead, we register an eventfd on
the rings (that is written to by the kernel each time a CQE is posted)
and we poll on that instead.

It simplifies the sleeping procedure quite a bit at the expense of
adding one (nonblocking) `read` syscall per reactor trip.