### PR TITLE
Configure cargo to fetch submodules with the git cli

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with cargo and DNS resolution when trying to update the submodule
from upstream crates.

Error:
```
Updating crates.io index
    Updating git submodule `git://git.kernel.dk/liburing`
warning: spurious network error (2 tries remaining): failed to resolve address for git.kernel.dk: Temporary failure in name resolution; class=Net (12)
warning: spurious network error (1 tries remaining): failed to resolve address for git.kernel.dk: Temporary failure in name resolution; class=Net (12)
error: failed to get `glommio` as a dependency of package `glommio-runtime v0.1.0 (/home/dependabot/dependabot-updater/dependabot_tmp_dir/crates/cobalt/runtimes/glommio-runtime)`

Caused by:
  failed to load source for dependency `glommio`

Caused by:
  Unable to update ssh://git@github.com/DataDog/dd-glommio.git?tag=v0.7.0-dd.1#6229cc22

Caused by:
  failed to update submodule `glommio/liburing`

Caused by:
  failed to fetch submodule `glommio/liburing` from git://git.kernel.dk/liburing

Caused by:
  network failure seems to have happened
  if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  failed to resolve address for git.kernel.dk: Temporary failure in name resolution; class=Net (12)
```

### Motivation

### Related issues

### Additional Notes

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
