### PR TITLE
Remove redundant mut in Sharded::send_to

### DIFF
--- a/glommio/src/channels/sharding.rs
+++ b/glommio/src/channels/sharding.rs
@@ -115,7 +115,7 @@ impl<T: Send + 'static, H: Handler<T> + 'static> Sharded<T, H> {
     ///
     /// [`GlommioError::Closed`]: crate::GlommioError::Closed
     /// [`InvalidInput`]: std::io::ErrorKind::InvalidInput
-    pub async fn send_to(&mut self, dst_shard: usize, message: T) -> Result<(), T> {
+    pub async fn send_to(&self, dst_shard: usize, message: T) -> Result<(), T> {
         self.shard.send_to(dst_shard, message).await
     }
 


### PR DESCRIPTION
### What does this PR do?

Removes redundant mut in receiver of Sharded::send_to

### Motivation

Resolve https://github.com/DataDog/glommio/issues/546

### Related issues

Resolves https://github.com/DataDog/glommio/issues/546

### Additional Notes

It is a change in public API but I believe it is not a major one. Such a change is not listed on [this](https://doc.rust-lang.org/cargo/reference/semver.html) cargo book page 

I tried to check it with cargo-semver but hit [this](https://github.com/rust-lang/rust-semverver/issues/296) bug and failed to get a report. 

Mutable references are turned into immutable ones with autoderef, so there is no need to change code. Existing test code shows that

### Checklist

- [ ] I have added unit tests to the code I am submitting
- [ ] My unit tests cover both failure and success scenarios
- [ ] If applicable, I have discussed my architecture
