### PR TITLE
Reset current IoVec upon `IOVecMerger::flush` call

### DIFF
--- a/glommio/src/executor/latch.rs
+++ b/glommio/src/executor/latch.rs
@@ -70,7 +70,8 @@ impl Latch {
     /// `count_down(0)`) is indicative that the state is either `Ready` or
     /// `Canceled`, other data may not yet be synchronized with other threads.
     pub fn count_down(&self, n: usize) -> Result<usize, usize> {
-        self.update(LatchState::Ready, |v| (v >= n).then_some(v - n))
+        #[allow(clippy::unnecessary_lazy_evaluations)]
+        self.update(LatchState::Ready, |v| (v >= n).then(|| v - n))
     }
 
     /// Cancels the latch.  Other threads will no longer wait.  If this call

--- a/glommio/src/executor/latch.rs
+++ b/glommio/src/executor/latch.rs
@@ -70,7 +70,7 @@ impl Latch {
     /// `count_down(0)`) is indicative that the state is either `Ready` or
     /// `Canceled`, other data may not yet be synchronized with other threads.
     pub fn count_down(&self, n: usize) -> Result<usize, usize> {
-        self.update(LatchState::Ready, |v| (v >= n).then(|| v - n))
+        self.update(LatchState::Ready, |v| (v >= n).then_some(v - n))
     }
 
     /// Cancels the latch.  Other threads will no longer wait.  If this call
@@ -79,7 +79,7 @@ impl Latch {
     ///
     /// The method does not synchronize with other threads.
     pub fn cancel(&self) -> Result<usize, LatchState> {
-        self.update(LatchState::Canceled, |v| (v != 0).then(|| 0))
+        self.update(LatchState::Canceled, |v| (v != 0).then_some(0))
             .map_err(|_| self.wait())
     }
 

--- a/glommio/src/sync/rwlock.rs
+++ b/glommio/src/sync/rwlock.rs
@@ -925,7 +925,7 @@ mod test {
             let lock = RwLock::new(());
             drop(lock.read().await.unwrap());
             drop(lock.write().await.unwrap());
-            #[allow(clippy::eval_order_dependence)]
+            #[allow(clippy::clippy::mixed_read_write_in_expression)]
             drop((lock.read().await.unwrap(), lock.read().await.unwrap()));
             drop(lock.read().await.unwrap());
         });

--- a/glommio/src/sync/rwlock.rs
+++ b/glommio/src/sync/rwlock.rs
@@ -925,7 +925,7 @@ mod test {
             let lock = RwLock::new(());
             drop(lock.read().await.unwrap());
             drop(lock.write().await.unwrap());
-            #[allow(clippy::clippy::mixed_read_write_in_expression)]
+            #[allow(clippy::mixed_read_write_in_expression)]
             drop((lock.read().await.unwrap(), lock.read().await.unwrap()));
             drop(lock.read().await.unwrap());
         });

--- a/glommio/src/sys/sysfs.rs
+++ b/glommio/src/sys/sysfs.rs
@@ -465,7 +465,7 @@ impl RangeIter<Checked> {
 
     fn ret(&mut self, v: usize) -> Option<usize> {
         self.last_item = Some(v);
-        (v <= self.end).then(|| v)
+        (v <= self.end).then_some(v)
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix a bug in `IOVecMerger::flush()`.

### Checklist

[X] I have added unit tests to the code I am submitting
[X] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
