### PR TITLE
Fix `pre_allocate` implementation

### DIFF
--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -192,9 +192,16 @@ impl BufferedFile {
     }
 
     /// pre-allocates space in the filesystem to hold a file at least as big as
-    /// the size argument.
-    pub async fn pre_allocate(&self, size: u64) -> Result<()> {
-        self.file.pre_allocate(size).await.map_err(Into::into)
+    /// the size argument. No existing data in the range [0, size) is modified.
+    /// If `keep_size` is false, then anything in [current file length, size)
+    /// will report zeroed blocks until overwritten and the file size reported
+    /// will be `size`. If `keep_size` is true then the existing file size
+    /// is unchanged.
+    pub async fn pre_allocate(&self, size: u64, keep_size: bool) -> Result<()> {
+        self.file
+            .pre_allocate(size, keep_size)
+            .await
+            .map_err(Into::into)
     }
 
     /// Truncates a file to the specified size.

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -369,9 +369,13 @@ impl DmaFile {
     }
 
     /// pre-allocates space in the filesystem to hold a file at least as big as
-    /// the size argument.
-    pub async fn pre_allocate(&self, size: u64) -> Result<()> {
-        self.file.pre_allocate(size).await
+    /// the size argument. No existing data in the range [0, size) is modified.
+    /// If `keep_size` is false, then anything in [current file length, size)
+    /// will report zeroed blocks until overwritten and the file size reported
+    /// will be `size`. If `keep_size` is true then the existing file size
+    /// is unchanged.
+    pub async fn pre_allocate(&self, size: u64, keep_size: bool) -> Result<()> {
+        self.file.pre_allocate(size, keep_size).await
     }
 
     /// Hint to the OS the size of increase of this file, to allow more
@@ -450,13 +454,7 @@ impl DmaFile {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use crate::{
-        enclose,
-        test_utils::{make_test_directories, TestDirectoryKind},
-        ByteSliceMutExt,
-        Latency,
-        Shares,
-    };
+    use crate::{enclose, test_utils::make_test_directories, ByteSliceMutExt, Latency, Shares};
     use futures::join;
     use futures_lite::{stream, StreamExt};
     use rand::{seq::SliceRandom, thread_rng};
@@ -534,17 +532,15 @@ pub(crate) mod test {
         new_file.close().await.expect("failed to close file");
     });
 
-    dma_file_test!(file_fallocate_alocatee, path, kind, {
+    dma_file_test!(file_fallocate_alocatee, path, _kind, {
         let new_file = DmaFile::create(path.join("testfile"))
             .await
             .expect("failed to create file");
 
-        let res = new_file.pre_allocate(4096).await;
-        if let TestDirectoryKind::TempFs = kind {
-            res.expect_err("fallocate should error on tmpfs");
-            return;
-        }
-        res.expect("fallocate failed");
+        new_file
+            .pre_allocate(4096, false)
+            .await
+            .expect("fallocate failed");
 
         std::assert_eq!(
             new_file.file_size().await.unwrap(),
@@ -555,7 +551,10 @@ pub(crate) mod test {
         std::assert_eq!(metadata.len(), 4096);
 
         // should be noop
-        new_file.pre_allocate(2048).await.expect("fallocate failed");
+        new_file
+            .pre_allocate(2048, false)
+            .await
+            .expect("fallocate failed");
 
         std::assert_eq!(
             new_file.file_size().await.unwrap(),
@@ -565,7 +564,36 @@ pub(crate) mod test {
         let metadata = std::fs::metadata(path.join("testfile")).unwrap();
         std::assert_eq!(metadata.len(), 4096);
 
+        let mut buf = new_file.alloc_dma_buffer(4096);
+        buf.as_bytes_mut()[0] = 1;
+        buf.as_bytes_mut()[4095] = 2;
+        new_file.write_at(buf, 0).await.expect("failed to write");
+
+        new_file
+            .pre_allocate(8192, true)
+            .await
+            .expect("fallocate failed");
+        let metadata = std::fs::metadata(path.join("testfile")).unwrap();
+        std::assert_eq!(metadata.len(), 4096);
+
+        new_file
+            .pre_allocate(8192, false)
+            .await
+            .expect("fallocate failed");
+        let metadata = std::fs::metadata(path.join("testfile")).unwrap();
+        std::assert_eq!(metadata.len(), 8192);
+
         new_file.close().await.expect("failed to close file");
+
+        let new_file = DmaFile::open(path.join("testfile"))
+            .await
+            .expect("failed to open file");
+        let read = new_file.read_at(0, 8192).await.expect("failed to read");
+        assert_eq!(read.len(), 8192);
+        assert_eq!(read[0], 1);
+        assert_eq!(read[4095], 2);
+        assert_eq!(read[4096], 0);
+        assert_eq!(read[8191], 0);
     });
 
     dma_file_test!(file_fallocate_zero, path, _k, {
@@ -573,7 +601,7 @@ pub(crate) mod test {
             .await
             .expect("failed to create file");
         new_file
-            .pre_allocate(0)
+            .pre_allocate(0, false)
             .await
             .expect_err("fallocate should fail with len == 0");
 
@@ -649,7 +677,7 @@ pub(crate) mod test {
             .await
             .expect_err("writes to read-only files should fail");
         new_file
-            .pre_allocate(4096)
+            .pre_allocate(4096, false)
             .await
             .expect_err("pre allocating read-only files should fail");
         new_file.close().await.expect("failed to close file");

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -185,8 +185,12 @@ impl GlommioFile {
             .map(|_| Ref::map(self.path.borrow(), |p| p.as_ref().unwrap().as_path()))
     }
 
-    pub(crate) async fn pre_allocate(&self, size: u64) -> Result<()> {
-        let flags = libc::FALLOC_FL_ZERO_RANGE;
+    pub(crate) async fn pre_allocate(&self, size: u64, keep_size: bool) -> Result<()> {
+        let flags = if keep_size {
+            libc::FALLOC_FL_KEEP_SIZE
+        } else {
+            0
+        };
         let source = self
             .reactor
             .upgrade()

--- a/glommio/src/io/immutable_file.rs
+++ b/glommio/src/io/immutable_file.rs
@@ -206,7 +206,7 @@ where
 
         // these two syscall are hints and are allowed to fail.
         if let Some(size) = self.pre_allocate {
-            let _ = file.pre_allocate(size).await;
+            let _ = file.pre_allocate(size, true).await;
         }
         if let Some(size) = self.hint_extent_size {
             let _ = file.hint_extent_size(size).await;


### PR DESCRIPTION
### What does this PR do?

`pre_allocate` will no longer zero out existing content and will only zero-fill past EOF if requested with the new parameter.

### Motivation

I invoked `pre_allocate` thinking it worked similarly to `posix_fallocate` or how `fallocate` documents preallocating space. Had a surprising source of memory corruption using this.

Making this change also makes `pre_allocate` work on `tmpfs`.

### Related issues

#576 

### Additional Notes

None.

### Checklist

[x] I have added unit tests to the code I am submitting
[x] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
