### PR TITLE
Add a warning note for O_APPEND corner case

### DIFF
--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -222,6 +222,12 @@ impl DmaFile {
     /// is the situation, for example, when the device runs out of space
     /// (See the man page for write(2) for details)
     ///
+    /// <p style="background:rgba(255,181,77,0.16);padding:0.75em;">
+    /// <strong>Warning:</strong> If the file has been opened with `append`,
+    /// then the position will get ignored and the buffer will be written at
+    /// the current end of file. See the [man page] for `O_APPEND`
+    /// </p>
+    ///
     /// # Examples
     /// ```no_run
     /// use glommio::{io::DmaFile, LocalExecutor};
@@ -238,6 +244,7 @@ impl DmaFile {
     /// ```
     ///
     /// [`alloc_dma_buffer`]: struct.DmaFile.html#method.alloc_dma_buffer
+    /// [man page]: https://man7.org/linux/man-pages/man2/open.2.html
     pub async fn write_at(&self, buf: DmaBuffer, pos: u64) -> Result<usize> {
         let source = self.file.reactor.upgrade().unwrap().write_dma(
             self.as_raw_fd(),

--- a/glommio/src/io/open_options.rs
+++ b/glommio/src/io/open_options.rs
@@ -80,6 +80,15 @@ impl OpenOptions {
     /// data at the end of it.
     ///
     /// The file must be opened with write access for append to work.
+    ///
+    /// NOTE: Caution is required if using this with [`dma_open`] as
+    /// [`write_at`] will cause the position to be reset to the end of file
+    /// before each write as documented for `O_APPEND` in the
+    /// [man page].
+    ///
+    /// [`dma_open`]: struct.OpenOptions.html#method.dma_open
+    /// [`write_at`]: ../struct.DmaFile.html#method.write_at
+    /// [man page]: https://man7.org/linux/man-pages/man2/open.2.html
     pub fn append(&mut self, append: bool) -> &mut Self {
         self.append = append;
         self

--- a/glommio/tests/linters.rs
+++ b/glommio/tests/linters.rs
@@ -7,7 +7,7 @@
 mod tests {
     use std::process::Command;
     #[test]
-    fn check_formating() {
+    fn check_formatting() {
         let status = Command::new("cargo")
             .args(["+nightly", "fmt", "--all", "--", "--check"])
             .status()


### PR DESCRIPTION
### What does this PR do?

O_APPEND causes a bit surprising behavior in that the position passed to `write_at` is ignored. Document this footgun.

### Motivation

I had accidentally opened the file with `O_APPEND` and my writes were not ending up where I was setting the position
to.

### Related issues

#574 

### Additional Notes

One alternate consideration might be to prevent opening/creating a `DmaFile` with `append` set in the first place.

### Checklist

[] I have added unit tests to the code I am submitting (N/A)
[] My unit tests cover both failure and success scenarios (N/A)
[X] If applicable, I have discussed my architecture
