### PR TITLE
`SealedDmaBuffer` that provides a read-only view that can survive being submitted for writing.

### DIFF
--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -19,7 +19,7 @@ use crate::{
         read_result::ReadResult,
         ScheduledSource,
     },
-    sys::{self, sysfs, DirectIo, DmaBuffer, PollableStatus},
+    sys::{self, sysfs, DirectIo, DmaBuffer, PollableStatus, DmaSource},
 };
 use futures_lite::{Stream, StreamExt};
 use nix::sys::statfs::*;
@@ -250,7 +250,7 @@ impl DmaFile {
     pub async fn write_at(&self, buf: DmaBuffer, pos: u64) -> Result<usize> {
         let source = self.file.reactor.upgrade().unwrap().write_dma(
             self.as_raw_fd(),
-            buf,
+            DmaSource::Owned(buf),
             pos,
             self.pollable,
         );

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -354,7 +354,7 @@ impl Reactor {
 
         let source = self.new_source(
             raw,
-            SourceType::Write(pollable, IoBuffer::Dma(buf)),
+            SourceType::Write(pollable, IoBuffer::DmaSource(buf)),
             Some(stats),
         );
         self.sys.write_dma(&source, pos);

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -39,6 +39,7 @@ use crate::{
         sysfs,
         DirectIo,
         DmaBuffer,
+        DmaSource,
         IoBuffer,
         PollableStatus,
         SleepNotifier,
@@ -337,7 +338,7 @@ impl Reactor {
     pub(crate) fn write_dma(
         &self,
         raw: RawFd,
-        buf: DmaBuffer,
+        buf: DmaSource,
         pos: u64,
         pollable: PollableStatus,
     ) -> Source {

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -372,7 +372,8 @@ impl Drop for SleepNotifier {
 
 #[derive(Debug)]
 pub(crate) enum IoBuffer {
-    Dma(DmaBuffer),
+    DmaSink(DmaBuffer),
+    DmaSource(DmaBuffer),
     Buffered(Vec<u8>),
 }
 
@@ -381,7 +382,8 @@ impl Deref for IoBuffer {
 
     fn deref(&self) -> &Self::Target {
         match &self {
-            IoBuffer::Dma(buffer) => buffer.as_bytes(),
+            IoBuffer::DmaSink(buffer) => buffer.as_bytes(),
+            IoBuffer::DmaSource(buffer) => buffer.as_bytes(),
             IoBuffer::Buffered(buffer) => buffer.as_slice(),
         }
     }


### PR DESCRIPTION
### What does this PR do?

Introduces a `SealedDmaBuffer` which is a read-only view that's submitted to file writes. This new struct is clonable and maintains
a Rc to the underlying owned buffer.

### Motivation

Today submitting a `DmaBuffer` causes you to lose the ability to do anything else with that buffer. However, it's desirable to be
able to post-process that buffer in the background without losing it (e.g. perhaps you want to maintain that buffer in-memory
as a cache of what you wrote or you want to post-process the data in some way).

### Related issues

#575 

### Additional Notes

I wasn't sure if I should add `write_sealed_at` or break compat by changing `write_at` (callers would need to call `.into` or `.seal` on the buffer they were previously supplying). I went with the option of not breaking back compat but technically since this is
a `0.x` library it probably would be OK?

I also wasn't really sure what kind of tests would constitute test coverage here. Putting up the code as a starting discussion point of what I was thinking of.

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
