### PR TITLE
Add fsync interface to DmaFile.

### DIFF
--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -188,7 +188,14 @@ impl BufferedFile {
     /// all writes to the device, providing durability even if the system
     /// crashes or is rebooted.
     pub async fn fdatasync(&self) -> Result<()> {
-        self.file.fdatasync().await.map_err(Into::into)
+        self.file.fsync(true).await.map_err(Into::into)
+    }
+
+    /// Issues `fsync` for the underlying file, instructing the OS to flush
+    /// all writes to the device including file metadata like size and published
+    /// extents, providing durability even if the system crashes or is rebooted.
+    pub async fn fsync(&self) -> Result<()> {
+        self.file.fsync(false).await.map_err(Into::into)
     }
 
     /// pre-allocates space in the filesystem to hold a file at least as big as

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -240,8 +240,12 @@ impl GlommioFile {
         Ok(())
     }
 
-    pub(crate) async fn fdatasync(&self) -> Result<()> {
-        let source = self.reactor.upgrade().unwrap().fdatasync(self.as_raw_fd());
+    pub(crate) async fn fsync(&self, data_sync_only: bool) -> Result<()> {
+        let source = self
+            .reactor
+            .upgrade()
+            .unwrap()
+            .fsync(self.as_raw_fd(), data_sync_only);
         source.collect_rw().await.map_err(|source| {
             GlommioError::create_enhanced(
                 source,

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -629,9 +629,9 @@ impl Reactor {
         }
     }
 
-    pub(crate) fn fdatasync(&self, raw: RawFd) -> Source {
+    pub(crate) fn fsync(&self, raw: RawFd, data_sync_only: bool) -> Source {
         let source = self.new_source(raw, SourceType::FdataSync, None);
-        self.sys.fdatasync(&source);
+        self.sys.fsync(&source, data_sync_only);
         source
     }
 


### PR DESCRIPTION
### What does this PR do?

Exposes the full fsync API via io_uring.

### Motivation

Sometimes you need a full fsync for database correctness. For example, making sure any newly written data is actually published and will be guaranteed visible before deleting other data to avoid losing information in the face of unexpected termination. My understanding is fdatasync guarantees that the blocks are written to the disk but does not guarantee that subsequent reads will see those blocks. I believe the set of extents backing the file are tracked in the metadata portion of the file.

### Related issues

N/A

### Additional Notes

Wasn't sure about bool vs enum for fsync. Went with bool because vscode makes the variable name visible but may not be very good in other dev environments.

### Checklist

[X] I have added unit tests to the code I am submitting
[X] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture

It doesn't look like fdatasync really has any meaningful test coverage. Not sure what test would best add coverage here but I just randomly picked between fdatasync vs fsync for existing tests.
