### PR TITLE
Expose a `.stat` method for files

### DIFF
--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -14,6 +14,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use super::Stat;
+
 type Result<T> = crate::Result<T, ()>;
 
 /// An asynchronously accessed file backed by the OS page cache.
@@ -237,6 +239,12 @@ impl BufferedFile {
         self.file.file_size().await.map_err(Into::into)
     }
 
+    /// Performs a stat operation on a file to retrieve multiple properties at
+    /// once.
+    pub async fn stat(&self) -> Result<Stat> {
+        self.file.statx().await.map(Into::into)
+    }
+
     /// Closes this file.
     pub async fn close(self) -> Result<()> {
         self.file.close().await.map_err(Into::into)
@@ -255,6 +263,8 @@ impl BufferedFile {
 
 #[cfg(test)]
 mod test {
+    use std::convert::TryInto;
+
     use super::*;
     use crate::test_utils::make_test_directories;
 
@@ -351,22 +361,85 @@ mod test {
 
         let reader = BufferedFile::open(path.join("testfile")).await.unwrap();
 
+        let cluster_size = reader.stat().await.unwrap().fs_cluster_size;
+        assert!(cluster_size >= 512, "{}", cluster_size);
+
         let rb = reader.read_at(0, 6).await.unwrap();
         assert_eq!(rb.len(), 0);
 
-        let wb = vec![0, 1, 2, 3, 4, 5];
-        let r = writer.write_at(wb, 10).await.unwrap();
-        assert_eq!(r, 6);
+        let r = writer
+            .write_at(
+                vec![7, 8, 9, 10, 11, 12, 13],
+                (cluster_size * 2).try_into().unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(r, 7.try_into().unwrap());
 
-        let rb = reader.read_at(0, 6).await.unwrap();
-        assert_eq!(rb.len(), 6);
+        let stat = reader.stat().await.unwrap();
+        assert_eq!(stat.file_size, (cluster_size * 2 + 7).try_into().unwrap());
+        assert_eq!(stat.allocated_file_size, cluster_size.try_into().unwrap());
+        assert_eq!(stat.fs_cluster_size, cluster_size);
+
+        let rb = reader
+            .read_at(0, cluster_size.try_into().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(rb.len(), cluster_size.try_into().unwrap());
         for i in rb.iter() {
             assert_eq!(*i, 0);
         }
 
-        let rb = reader.read_at(10, 6).await.unwrap();
-        assert_eq!(rb.len(), 6);
-        check_contents!(*rb, 0);
+        let rb = reader
+            .read_at((cluster_size * 2).try_into().unwrap(), 40)
+            .await
+            .unwrap();
+        assert_eq!(rb.len(), 7);
+        check_contents!(*rb, 7);
+
+        let r = writer
+            .write_at((513..900).map(|i| i as u8).collect(), 513)
+            .await
+            .unwrap();
+        assert_eq!(r, 387);
+        let stat = reader.stat().await.unwrap();
+        // File size is unchanged.
+        assert_eq!(stat.file_size, (cluster_size * 2 + 7).try_into().unwrap());
+        // Allocated size should double because the sparse region should be
+        // dirtied sufficiently to need another full filesystem cluster.
+        assert_eq!(
+            stat.allocated_file_size,
+            (cluster_size * 2).try_into().unwrap()
+        );
+
+        // Make sure the sparse contents are still 0'ed.
+        let rb = reader.read_at(0, 513).await.unwrap();
+        assert_eq!(rb.len(), 513);
+        for i in rb.iter() {
+            assert_eq!(*i, 0);
+        }
+
+        // Make sure the non-zeroed contents at the beginning of the file
+        // are correct.
+        let rb = reader.read_at(513, 387).await.unwrap();
+        assert_eq!(rb.len(), 387);
+        check_contents!(*rb, 513);
+
+        // Make sure the other unallocated extent returns 0s.
+        let rb = reader
+            .read_at(
+                900,
+                ((cluster_size - 900) + cluster_size).try_into().unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            rb.len(),
+            ((cluster_size - 900) + cluster_size).try_into().unwrap()
+        );
+        for i in rb.iter() {
+            assert_eq!(*i, 0);
+        }
 
         writer.close().await.unwrap();
         reader.close().await.unwrap();

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -31,6 +31,8 @@ use std::{
     rc::Rc,
 };
 
+use super::Stat;
+
 pub(super) type Result<T> = crate::Result<T, ()>;
 
 /// Close result of [`DmaFile::close_rc()`]. Indicates which operation is
@@ -436,6 +438,11 @@ impl DmaFile {
         self.file.file_size().await
     }
 
+    /// Returns the size of the filesystem cluster, in bytes
+    pub async fn stat(&self) -> Result<Stat> {
+        self.file.statx().await.map(Into::into)
+    }
+
     /// Closes this DMA file.
     pub async fn close(self) -> Result<()> {
         self.file.close().await
@@ -465,7 +472,7 @@ pub(crate) mod test {
     use futures::join;
     use futures_lite::{stream, StreamExt};
     use rand::{seq::SliceRandom, thread_rng};
-    use std::{cell::RefCell, path::PathBuf, time::Duration};
+    use std::{cell::RefCell, convert::TryInto, path::PathBuf, time::Duration};
 
     macro_rules! dma_file_test {
         ( $name:ident, $dir:ident, $kind:ident, $code:block) => {
@@ -973,5 +980,86 @@ pub(crate) mod test {
             4096 / new_file.o_direct_alignment
         );
         new_file.close_rc().await.expect("failed to close file");
+    });
+
+    dma_file_test!(write_past_end, path, _k, {
+        let writer = DmaFile::create(path.join("testfile")).await.unwrap();
+        let reader = DmaFile::open(path.join("testfile")).await.unwrap();
+
+        let stat = reader.stat().await.unwrap();
+        assert_eq!(stat.file_size, 0);
+        assert_eq!(stat.allocated_file_size, 0);
+
+        let cluster_size = stat.fs_cluster_size;
+        assert!(cluster_size >= 512, "{}", stat.fs_cluster_size);
+
+        let mut buffer = writer.alloc_dma_buffer(512);
+        for (elem, val) in buffer.as_bytes_mut().iter_mut().zip(1..513) {
+            *elem = val as u8;
+        }
+        let r = writer
+            .write_at(buffer, (cluster_size * 2).try_into().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(r, 512);
+
+        let stat = reader.stat().await.unwrap();
+        assert_eq!(stat.file_size, (cluster_size * 2 + 512).try_into().unwrap());
+        assert_eq!(stat.allocated_file_size, (cluster_size).try_into().unwrap());
+        assert_eq!(stat.fs_cluster_size, cluster_size);
+
+        let rb = reader
+            .read_at_aligned(0, (cluster_size * 2).try_into().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(rb.len(), (cluster_size * 2).try_into().unwrap());
+        for i in rb.iter() {
+            assert_eq!(*i, 0);
+        }
+
+        let rb = reader
+            .read_at_aligned((cluster_size * 2).try_into().unwrap(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(rb.len(), 512);
+        for (idx, i) in rb.iter().enumerate() {
+            assert_eq!(*i, (idx + 1) as u8);
+        }
+
+        let mut buffer = writer.alloc_dma_buffer(512);
+        for (elem, val) in buffer.as_bytes_mut().iter_mut().zip(3..515) {
+            *elem = val as u8;
+        }
+        let r = writer.write_at(buffer, 512).await.unwrap();
+        assert_eq!(r, 512);
+
+        let stat = reader.stat().await.unwrap();
+        assert_eq!(stat.file_size, (cluster_size * 2 + 512).try_into().unwrap());
+        assert_eq!(
+            stat.allocated_file_size,
+            (cluster_size * 2).try_into().unwrap()
+        );
+        assert_eq!(stat.fs_cluster_size, cluster_size);
+
+        let rb = reader.read_at_aligned(0, 512).await.unwrap();
+        assert_eq!(rb.len(), 512);
+        for i in rb.iter() {
+            assert_eq!(*i, 0);
+        }
+
+        let rb = reader.read_at_aligned(512, 512).await.unwrap();
+        assert_eq!(rb.len(), 512);
+        for (idx, i) in rb.iter().enumerate() {
+            assert_eq!(*i, (idx + 3) as u8);
+        }
+
+        let rb = reader
+            .read_at_aligned(1024, (cluster_size * 2 - 1024).try_into().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(rb.len(), (cluster_size * 2 - 1024).try_into().unwrap());
+        for i in rb.iter() {
+            assert_eq!(*i, 0);
+        }
     });
 }

--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -130,6 +130,7 @@ mod immutable_file;
 mod open_options;
 mod read_result;
 mod sched;
+mod stat;
 
 use std::path::Path;
 
@@ -173,6 +174,7 @@ pub use self::{
     immutable_file::{ImmutableFile, ImmutableFileBuilder, ImmutableFilePreSealSink},
     open_options::OpenOptions,
     read_result::ReadResult,
+    stat::Stat,
 };
 pub use crate::sys::DmaBuffer;
 

--- a/glommio/src/io/stat.rs
+++ b/glommio/src/io/stat.rs
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the MIT/Apache-2.0 License, at your convenience
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+//
+
+/// Represents the status information about a file.
+#[derive(Debug)]
+pub struct Stat {
+    /// The reported file size, in bytes. This will likely differ from
+    /// allocated_file_size which returns how many bytes were allocated on
+    /// the filesystem.
+    pub file_size: u64,
+
+    /// This returns how many bytes were allocated on the filesystem, ignoring
+    /// sparse regions. The typical minimum granularity for filesystem
+    /// allocation is 512 bytes although some filesystems may allocate more
+    /// than this for the minimum.
+    pub allocated_file_size: u64,
+
+    /// The cluster size on the filesystem that this file descriptor is open on,
+    /// in bytes.
+    pub fs_cluster_size: u32,
+}
+
+impl From<libc::statx> for Stat {
+    fn from(s: libc::statx) -> Self {
+        Self {
+            file_size: s.stx_size,
+            allocated_file_size: s.stx_blocks * 512,
+            fs_cluster_size: s.stx_blksize,
+        }
+    }
+}


### PR DESCRIPTION
Obtaining the file_size is convenient but sometimes you need the cluster size and/or the size allocated on-disk.
Add an exposed `.stat` call that provides this. Rather than exporting `libc::statx`, I figured I would write a friendlier
`Stat` function (I also tried to make them friendlier to use than st_blksize / st_blocks). Hope that's OK.

### What does this PR do?

Expose a call to `stat` an open file.

### Motivation

My program needs a way to get the filesystem cluster size to make sure it's doing I/O optimally on the filesystem it's running on + the actually allocated size for various reporting / statistics.

### Related issues

N/A

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[X] I have added unit tests to the code I am submitting
[/] My unit tests cover both failure and success scenarios
Partially. I've tested success scenarios but not sure how to test a failure scenario for stat.
[X] If applicable, I have discussed my architecture