### PR TITLE
Fix Unbound background thread pool affinity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           cat << EOF > "run-gha-workflow.sh"
           PATH=$PATH:/usr/share/rust/.cargo/bin
           echo "`nproc` CPU(s) available"
-          rustup install 1.58
+          rustup install 1.65
           rustup show
           rustup default stable
           cargo install cargo-sort

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,4 @@ members = [
   "examples",
   "glommio",
 ]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ an [introductory article.](https://www.datadoghq.com/blog/engineering/introducin
 
 ## Supported Rust Versions
 
-Glommio is built against the latest stable release. The minimum supported version is 1.58. The current Glommio version
+Glommio is built against the latest stable release. The minimum supported version is 1.65. The current Glommio version
 is not guaranteed to build on Rust versions earlier than the minimum supported version.
 
 ## Supported Linux kernels

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -30,19 +30,16 @@ fn main() {
         .detach();
 
         // What would you write if there were no enclose! macro.
-        let second =
-            glommio::spawn_local(|_left: Rc<RefCell<bool>>, right: Rc<RefCell<bool>>| -> _ {
-                async move {
-                    loop {
-                        if !(*(right.borrow())) {
-                            println!("right");
-                            *(right.borrow_mut()) = true
-                        }
-                        glommio::yield_if_needed().await;
-                    }
+        let second = glommio::spawn_local(async move {
+            loop {
+                if !(*(right.borrow())) {
+                    println!("right");
+                    *(right.borrow_mut()) = true
                 }
-            }(left.clone(), right.clone()))
-            .detach();
+                glommio::yield_if_needed().await;
+            }
+        })
+        .detach();
 
         futures::join!(first, second);
     });

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["linux", "rust", "async", "iouring", "thread-per-core"]
 categories = ["asynchronous", "concurrency", "os", "filesystem", "network-programming"]
 readme = "../README.md"
 # This is also documented in the README.md under "Supported Rust Versions"
-rust-version = "1.58"
+rust-version = "1.65"
 
 [dependencies]
 ahash = "0.7"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.65"
 [dependencies]
 ahash = "0.7"
 backtrace = { version = "0.3" }
-bitflags = "1.3"
+bitflags = "2.4"
 bitmaps = "3.1"
 buddy-alloc = "0.4"
 concurrent-queue = "1.2"

--- a/glommio/src/channels/channel_mesh.rs
+++ b/glommio/src/channels/channel_mesh.rs
@@ -7,6 +7,7 @@ use std::{
     cell::Cell,
     fmt::{self, Debug, Formatter},
     io::{Error, ErrorKind},
+    rc::Rc,
 };
 
 use std::sync::{Arc, RwLock};
@@ -251,7 +252,7 @@ pub type PartialMesh<T> = MeshBuilder<T, Partial>;
 pub struct MeshBuilder<T: Send, A: MeshAdapter> {
     nr_peers: usize,
     channel_size: usize,
-    peers: Arc<RwLock<Vec<Peer>>>,
+    peers: Rc<RwLock<Vec<Peer>>>,
     channels: Arc<SharedChannels<T>>,
     adapter: A,
 }
@@ -308,7 +309,7 @@ impl<T: 'static + Send, A: MeshAdapter> MeshBuilder<T, A> {
         MeshBuilder {
             nr_peers,
             channel_size,
-            peers: Arc::new(RwLock::new(Vec::new())),
+            peers: Rc::new(RwLock::new(Vec::new())),
             channels: Arc::new(Self::placeholder(nr_peers)),
             adapter,
         }

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -295,7 +295,7 @@ impl<T: Send + Sized> ConnectedSender<T> {
         res
     }
 
-    fn wait_for_room(&self, cx: &mut Context<'_>) -> Poll<()> {
+    fn wait_for_room(&self, cx: &Context<'_>) -> Poll<()> {
         match self.state.buffer.free_space() > 0 || self.state.buffer.producer_disconnected() {
             true => Poll::Ready(()),
             false => {

--- a/glommio/src/error.rs
+++ b/glommio/src/error.rs
@@ -532,6 +532,7 @@ impl<T> From<GlommioError<T>> for io::Error {
 }
 
 #[cfg(test)]
+#[allow(clippy::unnecessary_literal_unwrap)]
 mod test {
     use std::{io, panic::panic_any};
 

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -36,7 +36,8 @@ use crate::{
     error::BuilderErrorKind,
     executor::stall::StallDetector,
     io::DmaBuffer,
-    parking, reactor, sys,
+    parking, reactor,
+    sys::{self, blocking::BlockingThreadPool},
     task::{self, waker_fn::dummy_waker},
     GlommioError, IoRequirements, IoStats, Latency, Reactor, Shares,
 };
@@ -1140,6 +1141,9 @@ impl LocalExecutor {
         cpu_binding: Option<impl IntoIterator<Item = usize>>,
         mut config: LocalExecutorConfig,
     ) -> Result<LocalExecutor> {
+        let blocking_thread =
+            BlockingThreadPool::new(config.thread_pool_placement, notifier.clone())?;
+
         // Linux's default memory policy is "local allocation" which allocates memory
         // on the NUMA node containing the CPU where the allocation takes place.
         // Hence, we bind to a CPU in the provided CPU set before allocating any
@@ -1165,7 +1169,7 @@ impl LocalExecutor {
                 config.io_memory,
                 config.ring_depth,
                 config.record_io_latencies,
-                config.thread_pool_placement,
+                blocking_thread,
             )?),
             stall_detector: RefCell::new(
                 config
@@ -4132,7 +4136,7 @@ mod test {
                 }
 
                 // we created 5 blocking jobs each taking 100ms but our thread pool only has 4
-                // threads. SWe expect one of those jobs to take twice as long as the others.
+                // threads. We expect one of those jobs to take twice as long as the others.
 
                 let mut ts = join_all(blocking.into_iter()).await;
                 assert_eq!(ts.len(), 5);

--- a/glommio/src/executor/placement/mod.rs
+++ b/glommio/src/executor/placement/mod.rs
@@ -308,7 +308,7 @@ impl PartialEq for CpuSet {
 
 impl FromIterator<CpuLocation> for CpuSet {
     fn from_iter<I: IntoIterator<Item = CpuLocation>>(cpus: I) -> Self {
-        Self(HashSet::<CpuLocation>::from_iter(cpus.into_iter()))
+        Self(HashSet::<CpuLocation>::from_iter(cpus))
     }
 }
 

--- a/glommio/src/executor/stall.rs
+++ b/glommio/src/executor/stall.rs
@@ -443,7 +443,7 @@ mod test {
 
     #[test]
     fn stall_detector_multiple_signals() {
-        let signals = vec![
+        let signals = [
             nix::libc::SIGALRM as u8,
             nix::libc::SIGUSR1 as u8,
             nix::libc::SIGUSR2 as u8,

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -403,7 +403,7 @@ impl StreamWriter {
         }
     }
 
-    fn poll_sync(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_sync(&mut self, cx: &Context<'_>) -> Poll<io::Result<()>> {
         if !self.sync_on_close {
             Poll::Ready(Ok(()))
         } else {
@@ -426,7 +426,7 @@ impl StreamWriter {
         }
     }
 
-    fn poll_inner_close(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_inner_close(&mut self, cx: &Context<'_>) -> Poll<io::Result<()>> {
         match self.source.take() {
             None => {
                 let source = self
@@ -446,7 +446,7 @@ impl StreamWriter {
         }
     }
 
-    fn do_poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    fn do_poll_flush(&mut self, cx: &Context<'_>) -> Poll<io::Result<()>> {
         match self.source.take() {
             None => match self.flush_write_buffer(cx.waker()) {
                 true => Poll::Pending,
@@ -456,7 +456,7 @@ impl StreamWriter {
         }
     }
 
-    fn do_poll_close(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    fn do_poll_close(&mut self, cx: &Context<'_>) -> Poll<io::Result<()>> {
         while self.file.is_some() {
             match self.file_status {
                 FileStatus::Open => {

--- a/glommio/src/io/dma_file_stream.rs
+++ b/glommio/src/io/dma_file_stream.rs
@@ -541,7 +541,7 @@ impl DmaStreamReader {
     /// [`get_buffer_aligned`]: Self::get_buffer_aligned
     pub fn poll_get_buffer_aligned(
         &mut self,
-        cx: &mut Context<'_>,
+        cx: &Context<'_>,
         mut len: u64,
     ) -> Poll<Result<ReadResult>> {
         let (start_id, buffer_len) = {
@@ -568,7 +568,7 @@ impl DmaStreamReader {
 
     fn poll_get_buffer(
         &mut self,
-        cx: &mut Context<'_>,
+        cx: &Context<'_>,
         len: u64,
         buffer_id: u64,
     ) -> Poll<Result<ReadResult>> {
@@ -1269,7 +1269,7 @@ impl DmaStreamWriter {
     // but leaves the file open. Useful for the immutable file abstraction.
     pub(super) fn poll_seal(
         &mut self,
-        cx: &mut Context<'_>,
+        cx: &Context<'_>,
     ) -> Poll<io::Result<DmaStreamReaderBuilder>> {
         let mut state = self.state.borrow_mut();
         match state.file_status {

--- a/glommio/src/iou/cqe.rs
+++ b/glommio/src/iou/cqe.rs
@@ -206,6 +206,7 @@ impl Iterator for CQEsBlocking<'_> {
 
 bitflags::bitflags! {
     /// Flags that can be returned from the kernel on [`CQE`]s.
+    #[derive(Debug, Clone, Copy)]
     pub struct CompletionFlags: u32 {
         const BUFFER_SHIFT    = 1 << 0;
     }

--- a/glommio/src/iou/sqe.rs
+++ b/glommio/src/iou/sqe.rs
@@ -68,7 +68,7 @@ impl<'a> SQE<'a> {
     /// Get this event's flags.
     #[inline]
     pub fn flags(&self) -> SubmissionFlags {
-        unsafe { SubmissionFlags::from_bits_unchecked(self.sqe.flags as _) }
+        SubmissionFlags::from_bits_retain(self.sqe.flags as _)
     }
 
     /// Overwrite this event's flags.
@@ -535,6 +535,7 @@ pub struct BufferGroupId {
 
 bitflags::bitflags! {
     /// [`SQE`](SQE) configuration flags.
+    #[derive(Debug, Clone, Copy)]
     pub struct SubmissionFlags: u8 {
         /// This event's file descriptor is an index into the preregistered set of files.
         const FIXED_FILE    = 1 << 0;   /* use fixed fileset */

--- a/glommio/src/net/datagram.rs
+++ b/glommio/src/net/datagram.rs
@@ -203,9 +203,9 @@ impl<S: AsRawFd + FromRawFd + From<socket2::Socket>> GlommioDatagram<S> {
     pub(crate) async fn send_to(
         &self,
         buf: &[u8],
-        mut addr: nix::sys::socket::SockAddr,
+        addr: nix::sys::socket::SockAddr,
     ) -> io::Result<usize> {
-        match self.yolo_sendmsg(buf, &mut addr) {
+        match self.yolo_sendmsg(buf, &addr) {
             Some(res) => res,
             None => self.send_to_blocking(buf, addr).await,
         }
@@ -276,7 +276,7 @@ impl<S: AsRawFd + FromRawFd + From<socket2::Socket>> GlommioDatagram<S> {
     fn yolo_sendmsg(
         &self,
         buf: &[u8],
-        addr: &mut nix::sys::socket::SockAddr,
+        addr: &nix::sys::socket::SockAddr,
     ) -> Option<io::Result<usize>> {
         if self.tx_yolo.get() {
             super::yolo_sendmsg(self.socket.as_raw_fd(), buf, addr)

--- a/glommio/src/net/mod.rs
+++ b/glommio/src/net/mod.rs
@@ -89,7 +89,7 @@ fn yolo_recvmsg(
 fn yolo_sendmsg(
     fd: RawFd,
     buf: &[u8],
-    addr: &mut nix::sys::socket::SockAddr,
+    addr: &nix::sys::socket::SockAddr,
 ) -> Option<io::Result<usize>> {
     match sys::sendmsg_syscall(
         fd,

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -32,10 +32,11 @@ use crate::{
     io::{FileScheduler, IoScheduler, ScheduledSource},
     iou::sqe::SockAddrStorage,
     sys::{
-        self, common_flags, read_flags, sysfs, DirectIo, DmaBuffer, DmaSource, IoBuffer,
-        PollableStatus, SleepNotifier, Source, SourceType, StatsCollection, Statx,
+        self, blocking::BlockingThreadPool, common_flags, read_flags, sysfs, DirectIo, DmaBuffer,
+        DmaSource, IoBuffer, PollableStatus, SleepNotifier, Source, SourceType, StatsCollection,
+        Statx,
     },
-    IoRequirements, IoStats, PoolPlacement, TaskQueueHandle,
+    IoRequirements, IoStats, TaskQueueHandle,
 };
 use nix::poll::PollFlags;
 
@@ -180,9 +181,9 @@ impl Reactor {
         io_memory: usize,
         ring_depth: usize,
         record_io_latencies: bool,
-        thread_pool_placement: PoolPlacement,
+        blocking_thread: BlockingThreadPool,
     ) -> io::Result<Reactor> {
-        let sys = sys::Reactor::new(notifier, io_memory, ring_depth, thread_pool_placement)?;
+        let sys = sys::Reactor::new(notifier, io_memory, ring_depth, blocking_thread)?;
         let (preempt_ptr_head, preempt_ptr_tail) = sys.preempt_pointers();
         Ok(Reactor {
             sys,

--- a/glommio/src/sys/dma_buffer.rs
+++ b/glommio/src/sys/dma_buffer.rs
@@ -25,7 +25,7 @@ impl SysAlloc {
             None
         } else {
             let layout = Layout::from_size_align(size, 4096).unwrap();
-            let data = unsafe { alloc::alloc::alloc(layout) as *mut u8 };
+            let data = unsafe { alloc::alloc::alloc(layout) };
             let data = ptr::NonNull::new(data)?;
             Some(SysAlloc { data, layout })
         }

--- a/glommio/src/sys/hardware_topology.rs
+++ b/glommio/src/sys/hardware_topology.rs
@@ -106,9 +106,9 @@ pub fn get_machine_topology_unsorted() -> io::Result<Vec<CpuLocation>> {
     for l in &cpu_locations {
         node_to_core_to_cpus
             .entry(l.numa_node)
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .entry(l.core)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(l.cpu)
     }
 

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -151,7 +151,7 @@ pub(crate) fn sendmsg_syscall(
     fd: RawFd,
     buf: *const u8,
     len: usize,
-    addr: &mut nix::sys::socket::SockAddr,
+    addr: &nix::sys::socket::SockAddr,
     flags: i32,
 ) -> io::Result<usize> {
     let mut iov = libc::iovec {


### PR DESCRIPTION
### What does this PR do?

Creating a local executor with a non-Unbound placement but with a background thread of  `Unbound` placement now correctly has those background threads free-floating across any CPU instead of pinned to the CPU affinity assigned to the executor.

This is accomplished by creating the background thread pool before we bind the executor's CPU affinity.

### Motivation

Seems like buggy behavior for the executor having an affinity breaking `Unbound` placement for background threads. Violated principle of least surprise when my pinned executor was doing blocking dispatch to 16 threads but all that work was still getting scheduled on just 1 thread.

### Additional Notes

If a non-unbound placement for background threads is provided, this PR has no effect.

### Checklist

[X] I have added unit tests to the code I am submitting
[X] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
