### PR TITLE
bump minimum version to 1.72

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           cat << EOF > "run-gha-workflow.sh"
           PATH=$PATH:/usr/share/rust/.cargo/bin
           echo "`nproc` CPU(s) available"
-          rustup install 1.58
+          rustup install 1.65
           rustup show
           rustup default stable
           cargo install cargo-sort

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["linux", "rust", "async", "iouring", "thread-per-core"]
 categories = ["asynchronous", "concurrency", "os", "filesystem", "network-programming"]
 readme = "../README.md"
 # This is also documented in the README.md under "Supported Rust Versions"
-rust-version = "1.58"
+rust-version = "1.65"
 
 [dependencies]
 ahash = "0.7"


### PR DESCRIPTION
Increasingly difficult to run 1.58, many dependency issues when compiling.
