### PR TITLE
Expose file alignment

### DIFF
--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -432,6 +432,13 @@ impl DmaFile {
         self.file.fdatasync().await.map_err(Into::into)
     }
 
+    /// Returns the alignment required for I/O operations. Typical values will
+    /// be 512 (NVME drive is configured in slower compat mode) or 4096
+    /// (typical TLC native alignment).
+    pub fn alignment(&self) -> u64 {
+        self.o_direct_alignment
+    }
+
     /// Erases a range from the file without changing the size. Check the man
     /// page for [`fallocate`] for a list of the supported filesystems.
     /// Partial blocks are zeroed while whole blocks are simply unmapped


### PR DESCRIPTION
### What does this PR do?

Expose the file alignment directly.

### Motivation

As a user of the library, various parts of my code need the file alignment. This provides a more direct retrieval than `file.align_up(1)`.

### Related issues

### Additional Notes

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
