### PR TITLE
Make sendable files capable of being duped

### DIFF
--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -700,6 +700,25 @@ pub struct OwnedDmaFile {
 
 unsafe impl Send for OwnedDmaFile {}
 
+impl OwnedDmaFile {
+    /// Creates a duplicate instance pointing to the same file descriptor as self.
+    /// See [`DmaFile::dup`](struct.DmaFile.html#method.dup) for more info.
+    pub fn dup(&self) -> Result<Self> {
+        Ok(Self {
+            file: enhanced_try!(
+                self.file.dup(),
+                "Duplicating",
+                self.file.path.as_ref(),
+                self.file.fd
+            )?,
+            o_direct_alignment: self.o_direct_alignment,
+            max_sectors_size: self.max_sectors_size,
+            max_segment_size: self.max_segment_size,
+            pollable: self.pollable,
+        })
+    }
+}
+
 impl From<DmaFile> for OwnedDmaFile {
     fn from(value: DmaFile) -> Self {
         Self {
@@ -721,6 +740,12 @@ impl From<OwnedDmaFile> for DmaFile {
             max_segment_size: value.max_segment_size,
             pollable: value.pollable,
         }
+    }
+}
+
+impl AsRawFd for OwnedDmaFile {
+    fn as_raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds the `dup` method to `OwnedDmaFile`.

### Motivation

I have a benchmark where I want to test how long it takes to process a file and for accuracy of the benchmark I want to avoid the `open` path as it's more expensive than just duping the fd.

### Related issues

### Additional Notes

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture

Didn't bother writing tests for this as it seemed like a trivial change.