### PR TITLE
don't test for file size on resize_dma_buffer

### DIFF
--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -1627,9 +1627,6 @@ pub(crate) mod test {
         let read = file.read_at_aligned(0, 2 * alignment).await.unwrap();
         assert_eq!(read.len(), alignment);
         assert!(read.iter().all(|&b| b == 1));
-
-        let stat = file.stat().await.unwrap();
-        assert_eq!(stat.file_size, alignment as u64, "{:?}", stat);
     });
 
     dma_file_test!(copy_file_range, path, _k, {


### PR DESCRIPTION
We already test that the write is successful, and we already test that we read what we write.

In my local machine on an ext4 filesystem, the file size never changes after we write this. This is a metadata operation and the filesystem is free to do this optimization AFAIR, which it likely does, especially since this is a tmpfile that was not closed. We'd have to have a named file and fsync() the directory to make sure the metadata always gets updated, but I don't see the value in testing that.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
