### PR TITLE
fix test for file send

### DIFF
--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -780,7 +780,6 @@ pub(crate) mod test {
     };
     use futures::join;
     use futures_lite::{stream, StreamExt};
-    use nix::fcntl::{fcntl, FcntlArg::F_GETFD};
     use rand::{seq::SliceRandom, thread_rng};
     use std::{cell::RefCell, convert::TryInto, path::PathBuf, time::Duration};
 
@@ -1546,8 +1545,6 @@ pub(crate) mod test {
         })
         .join()
         .unwrap();
-
-        assert_eq!(fcntl(original_fd, F_GETFD), Err(nix::errno::Errno::EBADF));
 
         let file: DmaFile = result.into();
         assert_ne!(file.as_raw_fd(), original_fd);


### PR DESCRIPTION
The test is broken because we can't really guarantee that the old fd will fail to open. It is entirely possible that by now, some other test (remember tests are threaded) have opened a new file for itself that ended up with the same fd as original_fd.

This test was always failing for me when I ran "cargo test" but always succeeding if I ran the test in isolation, which confirms that this is the likely cause.
