### PR TITLE
Fix stall detector to be correct threshold

### DIFF
--- a/glommio/src/executor/stall.rs
+++ b/glommio/src/executor/stall.rs
@@ -60,9 +60,9 @@ pub trait StallDetectionHandler: std::fmt::Debug + Send + Sync {
     fn threshold(
         &self,
         _queue_handle: TaskQueueHandle,
-        max_expected_runtime: Duration,
+        _max_expected_runtime: Duration,
     ) -> Option<Duration> {
-        Some(max_expected_runtime + Duration::from_millis(10))
+        Some(Duration::from_millis(10))
     }
 
     /// What signal number to use; see values in libc::SIG*.


### PR DESCRIPTION
The final expected runtime, is supposed to be whatever we get from the `threshold` call.

If we add the `max_expected_time` again, it will be wrong.

Whoever CRs this, I have a question: Do we want the `threshold` method to return the time to add to `max_expected_time` or do we want the user to completely control the amount, like I did in this PR?

I think it is better to let the user always control, he can decide whether to use `max_expected_time` or not.