### PR TITLE
refactor: comply with clippy linters

### DIFF
--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -971,6 +971,7 @@ mod test {
                         *cv_mtx_1.1.lock().unwrap() = 1;
                         cv_mtx_1.0.notify_all();
                     });
+                    #[allow(clippy::await_holding_lock)]
                     let t2 = crate::executor().spawn_local(async move {
                         let mut lck = cv_mtx_2
                             .0

--- a/glommio/src/io/buffered_file.rs
+++ b/glommio/src/io/buffered_file.rs
@@ -381,17 +381,14 @@ mod test {
         assert_eq!(rb.len(), 0);
 
         let r = writer
-            .write_at(
-                vec![7, 8, 9, 10, 11, 12, 13],
-                (cluster_size * 2).try_into().unwrap(),
-            )
+            .write_at(vec![7, 8, 9, 10, 11, 12, 13], (cluster_size * 2).into())
             .await
             .unwrap();
         assert_eq!(r, 7.try_into().unwrap());
 
         let stat = reader.stat().await.unwrap();
-        assert_eq!(stat.file_size, (cluster_size * 2 + 7).try_into().unwrap());
-        assert_eq!(stat.allocated_file_size, cluster_size.try_into().unwrap());
+        assert_eq!(stat.file_size, (cluster_size * 2 + 7).into());
+        assert_eq!(stat.allocated_file_size, cluster_size.into());
         assert_eq!(stat.fs_cluster_size, cluster_size);
 
         let rb = reader
@@ -403,10 +400,7 @@ mod test {
             assert_eq!(*i, 0);
         }
 
-        let rb = reader
-            .read_at((cluster_size * 2).try_into().unwrap(), 40)
-            .await
-            .unwrap();
+        let rb = reader.read_at((cluster_size * 2).into(), 40).await.unwrap();
         assert_eq!(rb.len(), 7);
         check_contents!(*rb, 7);
 
@@ -417,13 +411,10 @@ mod test {
         assert_eq!(r, 387);
         let stat = reader.stat().await.unwrap();
         // File size is unchanged.
-        assert_eq!(stat.file_size, (cluster_size * 2 + 7).try_into().unwrap());
+        assert_eq!(stat.file_size, (cluster_size * 2 + 7).into());
         // Allocated size should double because the sparse region should be
         // dirtied sufficiently to need another full filesystem cluster.
-        assert_eq!(
-            stat.allocated_file_size,
-            (cluster_size * 2).try_into().unwrap()
-        );
+        assert_eq!(stat.allocated_file_size, (cluster_size * 2).into());
 
         // Make sure the sparse contents are still 0'ed.
         let rb = reader.read_at(0, 513).await.unwrap();
@@ -454,16 +445,13 @@ mod test {
             assert_eq!(*i, 0);
         }
 
-        writer
-            .deallocate(0, cluster_size.try_into().unwrap())
-            .await
-            .unwrap();
+        writer.deallocate(0, cluster_size.into()).await.unwrap();
         let stat = writer.stat().await.unwrap();
         // File size is unchanged.
-        assert_eq!(stat.file_size, (cluster_size * 2 + 7).try_into().unwrap());
+        assert_eq!(stat.file_size, (cluster_size * 2 + 7).into());
         // Allocated size should go back to 0 because there's still one allocated
         // cluster.
-        assert_eq!(stat.allocated_file_size, cluster_size.try_into().unwrap());
+        assert_eq!(stat.allocated_file_size, cluster_size.into());
 
         // Deallocated range now returns 0s.
         let rb = reader

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -1307,14 +1307,14 @@ pub(crate) mod test {
             *elem = val as u8;
         }
         let r = writer
-            .write_at(buffer, (cluster_size * 2).try_into().unwrap())
+            .write_at(buffer, (cluster_size * 2).into())
             .await
             .unwrap();
         assert_eq!(r, 512);
 
         let stat = reader.stat().await.unwrap();
-        assert_eq!(stat.file_size, (cluster_size * 2 + 512).try_into().unwrap());
-        assert_eq!(stat.allocated_file_size, (cluster_size).try_into().unwrap());
+        assert_eq!(stat.file_size, (cluster_size * 2 + 512).into());
+        assert_eq!(stat.allocated_file_size, (cluster_size).into());
         assert_eq!(stat.fs_cluster_size, cluster_size);
 
         let rb = reader
@@ -1327,7 +1327,7 @@ pub(crate) mod test {
         }
 
         let rb = reader
-            .read_at_aligned((cluster_size * 2).try_into().unwrap(), 1024)
+            .read_at_aligned((cluster_size * 2).into(), 1024)
             .await
             .unwrap();
         assert_eq!(rb.len(), 512);
@@ -1343,11 +1343,8 @@ pub(crate) mod test {
         assert_eq!(r, 512);
 
         let stat = reader.stat().await.unwrap();
-        assert_eq!(stat.file_size, (cluster_size * 2 + 512).try_into().unwrap());
-        assert_eq!(
-            stat.allocated_file_size,
-            (cluster_size * 2).try_into().unwrap()
-        );
+        assert_eq!(stat.file_size, (cluster_size * 2 + 512).into());
+        assert_eq!(stat.allocated_file_size, (cluster_size * 2).into());
         assert_eq!(stat.fs_cluster_size, cluster_size);
 
         let rb = reader.read_at_aligned(0, 512).await.unwrap();
@@ -1373,21 +1370,18 @@ pub(crate) mod test {
 
         // Deallocating past the end of file doesn't matter. The size doesn't change.
         writer
-            .deallocate(
-                (cluster_size * 2).try_into().unwrap(),
-                (cluster_size * 2).try_into().unwrap(),
-            )
+            .deallocate((cluster_size * 2).into(), (cluster_size * 2).into())
             .await
             .unwrap();
         let stat = reader.stat().await.unwrap();
         // File size remains unchanged.
-        assert_eq!(stat.file_size, (cluster_size * 2 + 512).try_into().unwrap());
+        assert_eq!(stat.file_size, (cluster_size * 2 + 512).into());
         // Only one allocated cluster remains.
-        assert_eq!(stat.allocated_file_size, cluster_size.try_into().unwrap());
+        assert_eq!(stat.allocated_file_size, cluster_size.into());
 
         // Deallocated range now returns 0s.
         let rb = reader
-            .read_at_aligned((cluster_size * 2).try_into().unwrap(), 1024)
+            .read_at_aligned((cluster_size * 2).into(), 1024)
             .await
             .unwrap();
         assert_eq!(rb.len(), 512);


### PR DESCRIPTION
Little pull request, to comply with the new lints from clippy:
- [unnecessary_fallible_conversions](https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_fallible_conversions)
- [await_holding_refcell_ref](https://rust-lang.github.io/rust-clippy/master/index.html#/await_holding_refcell_ref)
- [await_holding_lock](https://rust-lang.github.io/rust-clippy/master/index.html#/await_holding_lock)
