### PR TITLE
Fix third-party vulnerability caused by atty v0.2.14

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 edition = "2021"
 
 [dev-dependencies]
+byte-unit = "5.1.4"
 yansi = "~0.5.1"
 clap = "4.5.3"
 fastrand = "1.4.0"
@@ -16,7 +17,6 @@ glommio = { path = "../glommio" }
 # hyper and tokio for the hyper example. We just need the traits from Tokio
 hyper = { version = "1.2.0", features = ["full"] }
 num_cpus = "1.13.0"
-pretty-bytes = "~0.2.2"
 sys-info = "~0.8.0"
 http-body-util = "0.1.0"
 serde_json = "1.0.114"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dev-dependencies]
 yansi = "~0.5.1"
-clap = "2.33"
+clap = "4.5.3"
 fastrand = "1.4.0"
 futures = "~0.3.5"
 futures-lite = "1.11.1"

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -1,4 +1,4 @@
-use clap::{Command, Arg};
+use clap::{Arg, Command};
 use futures_lite::{
     stream::{self, StreamExt},
     AsyncReadExt, AsyncWriteExt,

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -1,3 +1,4 @@
+use byte_unit::{Byte, UnitType};
 use clap::{Arg, Command};
 use futures_lite::{
     stream::{self, StreamExt},
@@ -11,7 +12,6 @@ use glommio::{
     },
     LocalExecutorBuilder, Placement,
 };
-use pretty_bytes::converter;
 use std::{
     cell::Cell,
     fs,
@@ -51,13 +51,17 @@ async fn stream_write<T: AsyncWriteExt + std::marker::Unpin, S: Into<String>>(
 
     let endw = Instant::now();
     let time = start.elapsed();
-    let bytes = converter::convert(file_size as _);
-    let rate = converter::convert((file_size as f64 / time.as_secs_f64()) as _);
-    println!("{name}: Wrote {bytes} in {time:#?}, {rate}/s");
+    let bytes = Byte::from_u64(file_size).get_appropriate_unit(UnitType::Binary);
+    let rate = Byte::from_f64(file_size as f64 / time.as_secs_f64())
+        .unwrap_or_default()
+        .get_appropriate_unit(UnitType::Binary);
+    println!("{name}: Wrote {bytes:.2} in {time:#?}, {rate:.2}/s");
     stream.close().await.unwrap();
-    let rate = converter::convert((file_size as f64 / start.elapsed().as_secs_f64()) as _);
+    let rate = Byte::from_f64(file_size as f64 / start.elapsed().as_secs_f64())
+        .unwrap_or_default()
+        .get_appropriate_unit(UnitType::Binary);
     let time = endw.elapsed();
-    println!("{name}: Closed in {time:#?}, Amortized total {rate}/s");
+    println!("{name}: Closed in {time:#?}, Amortized total {rate:.2}/s");
 }
 
 async fn stream_scan<T: AsyncReadExt + std::marker::Unpin, S: Into<String>>(
@@ -82,10 +86,12 @@ async fn stream_scan<T: AsyncReadExt + std::marker::Unpin, S: Into<String>>(
     let time = start.elapsed();
     let name = name.into();
 
-    let bytes = converter::convert(bytes_read as _);
-    let rate = converter::convert((bytes_read as f64 / time.as_secs_f64()) as _);
+    let bytes = Byte::from_u64(bytes_read as _).get_appropriate_unit(UnitType::Binary);
+    let rate = Byte::from_f64(bytes_read as f64 / time.as_secs_f64())
+        .unwrap_or_default()
+        .get_appropriate_unit(UnitType::Binary);
     println!(
-        "{name}: Scanned {bytes} in {time:#?}, {rate}/s, {} IOPS",
+        "{name}: Scanned {bytes:.2} in {time:#?}, {rate:.2}/s, {} IOPS",
         (ops as f64 / time.as_secs_f64()) as usize
     );
     stream
@@ -115,10 +121,12 @@ async fn stream_scan_alt_api<S: Into<String>>(
     let time = start.elapsed();
     let name = name.into();
 
-    let bytes = converter::convert(bytes_read as _);
-    let rate = converter::convert((bytes_read as f64 / time.as_secs_f64()) as _);
+    let bytes = Byte::from_u64(bytes_read as _).get_appropriate_unit(UnitType::Binary);
+    let rate = Byte::from_f64(bytes_read as f64 / time.as_secs_f64())
+        .unwrap_or_default()
+        .get_appropriate_unit(UnitType::Binary);
     println!(
-        "{name}: Scanned {bytes} in {time:#?}, {rate}/s, {} IOPS",
+        "{name}: Scanned {bytes:.2} in {time:#?}, {rate:.2}/s, {} IOPS",
         (ops as f64 / time.as_secs_f64()) as usize
     );
     stream.close().await.unwrap();
@@ -212,11 +220,11 @@ async fn random_read<S: Into<String>>(
         Ok(file) => file.close().await,
     };
 
-    assert_eq!(finished, parallelism as _);
-    let bytes = converter::convert(random as _);
+    assert_eq!(finished, parallelism);
+    let bytes = Byte::from_u64(random).get_appropriate_unit(UnitType::Binary);
     let dur = time.elapsed();
     println!(
-        "{name}: Random Read (uniform) size span of {bytes}, for {dur:#?}, {} IOPS",
+        "{name}: Random Read (uniform) size span of {bytes:.2}, for {dur:#?}, {} IOPS",
         (iops.get() as f64 / dur.as_secs_f64()) as usize
     );
 }
@@ -261,13 +269,13 @@ async fn random_many_read<S: Into<String>>(
         Ok(file) => file.close().await,
     };
 
-    assert_eq!(finished, parallelism as _);
-    let bytes = converter::convert(random as _);
-    let max_merged = converter::convert(max_buffer_size as _);
+    assert_eq!(finished, parallelism);
+    let bytes = Byte::from_u64(random).get_appropriate_unit(UnitType::Binary);
+    let max_merged = Byte::from_u64(max_buffer_size as _).get_appropriate_unit(UnitType::Binary);
     let dur = time.elapsed();
     println!(
-        "{name}: Random Bulk Read (uniform) size span of {bytes}, for {dur:#?} (max merged size \
-         of {max_merged}), {} IOPS",
+        "{name}: Random Bulk Read (uniform) size span of {bytes:.2}, for {dur:#?} (max merged size \
+         of {max_merged:.2}), {} IOPS",
         (iops.get() as f64 / dur.as_secs_f64()) as usize
     );
 }

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -1,4 +1,4 @@
-use clap::{App, Arg};
+use clap::{Command, Arg};
 use futures_lite::{
     stream::{self, StreamExt},
     AsyncReadExt, AsyncWriteExt,
@@ -273,27 +273,27 @@ async fn random_many_read<S: Into<String>>(
 }
 
 fn main() {
-    let matches = App::new("storage example")
+    let matches = Command::new("storage example")
         .version("0.1.0")
         .author("Glauber Costa <glauber@datadoghq.com>")
         .about("demonstrate glommio's storage APIs")
         .arg(
-            Arg::with_name("storage_dir")
+            Arg::new("storage_dir")
                 .long("dir")
-                .takes_value(true)
+                .action(clap::ArgAction::Set)
                 .required(true)
                 .help("The directory where to write and read file for this test"),
         )
         .arg(
-            Arg::with_name("file_size")
+            Arg::new("file_size")
                 .long("size-gb")
-                .takes_value(true)
+                .action(clap::ArgAction::Set)
                 .required(false)
                 .help("size of the file in GB (default: 2 * memory_size)"),
         )
         .get_matches();
 
-    let path = matches.value_of("storage_dir").unwrap();
+    let path = matches.get_one::<String>("storage_dir").unwrap();
     let mut dir = PathBuf::from(path);
     assert!(dir.exists());
     dir.push("benchfiles");
@@ -303,8 +303,8 @@ fn main() {
     let total_memory = sys_info::mem_info().unwrap().total << 10;
 
     let file_size = matches
-        .value_of("file_size")
-        .map(|s| s.parse::<u64>().unwrap() << 30)
+        .get_one::<u64>("file_size")
+        .map(|s| s << 30)
         .unwrap_or(total_memory * 2);
 
     let random = total_memory / 10;


### PR DESCRIPTION
Github detects third-party vulnerabilities seems to originate from the storage example.

### What does this PR do?

atty has security vulnerability and is used by pretty-bytes and an old clap version.

Fix the vulnerability by updating dependency:
1. Update Clap to the latest version and adjust API accordingly
2. Replace pretty-bytes (no longer maintained) with byte-unit

So that we no longer depend on atty.

### Motivation

Fix the vulnerability to make CI happy.

### Additional Notes

Example output after the change:

```
Buffered I/O: Wrote 61.66 GiB in 111.219587957s, 567.68 MiB/s
Buffered I/O: Closed in 10.132848655s, Amortized total 520.28 MiB/s
```

See detailed info about the vulnerability here:
https://github.com/DataDog/glommio/actions/runs/8078793715/job/22071839053
