### PR TITLE
Fix stat to use the fd instead of the path

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -26,7 +26,7 @@ buddy-alloc = "0.4"
 concurrent-queue = "1.2"
 crossbeam = "0.8"
 enclose = "1.1"
-flume = { version = "0.10", features = ["async"] }
+flume = { version = "0.11", features = ["async"] }
 futures-lite = "1.12"
 intrusive-collections = "0.9"
 lazy_static = "1.4"

--- a/glommio/src/io/buffered_file_stream.rs
+++ b/glommio/src/io/buffered_file_stream.rs
@@ -502,11 +502,7 @@ macro_rules! do_seek {
             }
             SeekFrom::End(pos) => match $source.take() {
                 None => {
-                    let source = $self
-                        .reactor
-                        .upgrade()
-                        .unwrap()
-                        .statx($fileobj.as_raw_fd(), &$fileobj.path().unwrap());
+                    let source = $self.reactor.upgrade().unwrap().statx($fileobj.as_raw_fd());
                     source.add_waiter_single($cx.waker());
                     $source = Some(source);
                     Poll::Pending

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -329,13 +329,7 @@ impl GlommioFile {
 
     // Retrieve file metadata, backed by the statx(2) syscall
     pub(crate) async fn statx(&self) -> Result<Statx> {
-        let path = self.path_required("stat")?.to_owned();
-
-        let source = self
-            .reactor
-            .upgrade()
-            .unwrap()
-            .statx(self.as_raw_fd(), path.as_ref());
+        let source = self.reactor.upgrade().unwrap().statx(self.as_raw_fd());
         source.collect_rw().await.map_err(|source| {
             GlommioError::create_enhanced(
                 source,

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -737,9 +737,7 @@ impl Reactor {
         source
     }
 
-    pub(crate) fn statx(&self, raw: RawFd, path: &Path) -> Source {
-        let path = CString::new(path.as_os_str().as_bytes()).expect("path contained null!");
-
+    pub(crate) fn statx(&self, raw: RawFd) -> Source {
         let statx_buf = unsafe {
             let statx_buf = mem::MaybeUninit::<Statx>::zeroed();
             statx_buf.assume_init()
@@ -747,10 +745,10 @@ impl Reactor {
 
         let source = self.new_source(
             raw,
-            SourceType::Statx(path, Box::new(RefCell::new(statx_buf))),
+            SourceType::Statx(Box::new(RefCell::new(statx_buf))),
             None,
         );
-        self.sys.statx(&source);
+        self.sys.statx_fd(&source);
         source
     }
 

--- a/glommio/src/sys/source.rs
+++ b/glommio/src/sys/source.rs
@@ -54,7 +54,7 @@ pub(crate) enum SourceType {
     Close,
     LinkRings,
     ForeignNotifier(u64, bool),
-    Statx(CString, Box<RefCell<Statx>>),
+    Statx(Box<RefCell<Statx>>),
     Timeout(TimeSpec64, u32),
     Connect(nix::sys::socket::SockaddrStorage),
     Accept(SockAddrStorage),
@@ -73,7 +73,7 @@ impl TryFrom<SourceType> for Statx {
 
     fn try_from(value: SourceType) -> Result<Self, Self::Error> {
         match value {
-            SourceType::Statx(_, buf) => Ok(buf.into_inner()),
+            SourceType::Statx(buf) => Ok(buf.into_inner()),
             src => Err(GlommioError::ReactorError(
                 ReactorErrorKind::IncorrectSourceType(format!("{src:?}")),
             )),


### PR DESCRIPTION
### What does this PR do?

Fixes #648. Noticed that the reported inode for two sibling O_TMPFILE was identical because the stat was being invoked on the parent directory (i.e. stat never worked for temporary files). Similarly, you can now remove the path backing a file and stat continues to work.

### Motivation

2 sibling O_TMPFILE files having the same inode & being unable to get the size of a temporary file.

### Related issues

### Additional Notes

### Checklist

[X] I have added unit tests to the code I am submitting
[X] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
