### PR TITLE
Fix first Reactor sleep taking at least 30-50ms

### DIFF
--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -446,8 +446,8 @@ pub use crate::{
         ResourceType, Result,
     },
     executor::{
-        allocate_dma_buffer, allocate_dma_buffer_global, executor, spawn_local, spawn_local_into,
-        spawn_scoped_local, spawn_scoped_local_into,
+        allocate_dma_buffer, allocate_dma_buffer_global, early_init, executor, spawn_local,
+        spawn_local_into, spawn_scoped_local, spawn_scoped_local_into,
         stall::{DefaultStallDetectionHandler, StallDetection, StallDetectionHandler},
         yield_if_needed, CpuSet, ExecutorJoinHandle, ExecutorProxy, ExecutorStats, LocalExecutor,
         LocalExecutorBuilder, LocalExecutorPoolBuilder, Placement, PoolPlacement,

--- a/glommio/src/sys/membarrier.rs
+++ b/glommio/src/sys/membarrier.rs
@@ -226,3 +226,18 @@ pub(crate) fn heavy() {
         Fallback => atomic::fence(atomic::Ordering::SeqCst),
     }
 }
+
+/// The membarrier strategy is expensive to initialize. Expose that initialization so
+/// that [crate::executor::early_init] can call it (it also gets intentionally called
+/// by [crate::executor::LocalExecutor::new] in case the user didn't).
+///
+/// I believe the cost of registration got worse sometime after Linux 6.6 because tests
+/// in my project that do a sleep on a timer as the first thing started taking >30ms
+/// after upgrading to 6.8 whereas before they were mostly succeeding < 30ms (it was
+/// my hacky attempt at dealing with setting a timeout on how long a timer could take
+/// before I dug into the problem once 6.8 made it unbearable & waiting up to 100ms
+/// for a 10ms test seemed silly & was hard to write assertions around).
+#[inline]
+pub(crate) fn initialize_strategy() {
+    let _ = *STRATEGY;
+}

--- a/glommio/src/sys/mod.rs
+++ b/glommio/src/sys/mod.rs
@@ -173,6 +173,7 @@ pub(crate) fn sendmsg_syscall(
 
 mod dma_buffer;
 mod membarrier;
+pub(crate) use membarrier::initialize_strategy as initialize_membarrier_strategy;
 pub(crate) mod source;
 pub(crate) mod sysfs;
 mod uring;

--- a/glommio/src/timer/timer_impl.rs
+++ b/glommio/src/timer/timer_impl.rs
@@ -1195,4 +1195,21 @@ mod test {
 
         handle.join().unwrap();
     }
+
+    #[test]
+    fn first_timer_finishes_with_expected_duration() {
+        test_executor!(async move {
+            let start = Instant::now();
+            Timer::new(Duration::from_millis(3)).await;
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed >= Duration::from_millis(3),
+                "Timer expired too soon: {elapsed:?}"
+            );
+            assert!(
+                elapsed <= Duration::from_millis(5),
+                "Timer took way too long to run: {elapsed:?}"
+            );
+        });
+    }
 }


### PR DESCRIPTION
Noticed this problem in unit tests where the very first timer sleep would take a very long time because the membarrier was being registered and tests have more than 1 thread.

Initializing the membarrier strategy on Reactor::new seems like a good idea because it's highly likely any use of the Reactor will involve going to sleep and I can't imagine a use-case where that's not the case unless you're not interacting with anything within Glommio in the first place.

With this change we see that the very first timer now completes within 11ms (I added a grace window of an extra ms in case of CI).

### What does this PR do?

The first construction of the IO uring reactor now registers the membarrier.

### Motivation

I had tests that were flakily failing because a very short sleep was taking an almost unbounded amount of time (observed up to 60ms even for a 5ms sleep). I think it's cleaner if the membarrier initialization is front-loaded into Reactor construction vs paying that penalty on the very first .await later where it's a bit more non-obvious and surprising. 

### Related issues

Fixes #652 

### Additional Notes

I believe the cost of registration when there's > 1 thread running got worse sometime after Linux 6.6 because tests in my project that do something similar started regularly taking >30ms after upgrading to 6.8 whereas before they were mostly succeeding < 30ms (it was my grace window for how long a 10ms sleep could take).

### Checklist

[X] I have added unit tests to the code I am submitting
[X] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
