### PR TITLE
fix: export publicly 'StallDetection'

### DIFF
--- a/glommio/src/executor/stall.rs
+++ b/glommio/src/executor/stall.rs
@@ -16,13 +16,20 @@ use std::{
     time::{Duration, Instant},
 };
 
+/// Store information about detected stall
 pub struct StallDetection<'a> {
-    executor: usize,
-    queue_handle: TaskQueueHandle,
-    queue_name: &'a str,
-    trace: backtrace::Backtrace,
-    budget: Duration,
-    overage: Duration,
+    /// Executor id in which the detection occurred
+    pub executor: usize,
+    /// The handle of the queue where the stall was detected
+    pub queue_handle: TaskQueueHandle,
+    /// Name of the queue
+    pub queue_name: &'a str,
+    /// Backtrace captured on stall detection
+    pub trace: backtrace::Backtrace,
+    /// Maximum allowed duration for a task execution before being considered stalled
+    pub budget: Duration,
+    /// Additional duration granted for task execution
+    pub overage: Duration,
 }
 
 impl fmt::Debug for StallDetection<'_> {

--- a/glommio/src/lib.rs
+++ b/glommio/src/lib.rs
@@ -448,7 +448,7 @@ pub use crate::{
     executor::{
         allocate_dma_buffer, allocate_dma_buffer_global, executor, spawn_local, spawn_local_into,
         spawn_scoped_local, spawn_scoped_local_into,
-        stall::{DefaultStallDetectionHandler, StallDetectionHandler},
+        stall::{DefaultStallDetectionHandler, StallDetection, StallDetectionHandler},
         yield_if_needed, CpuSet, ExecutorJoinHandle, ExecutorProxy, ExecutorStats, LocalExecutor,
         LocalExecutorBuilder, LocalExecutorPoolBuilder, Placement, PoolPlacement,
         PoolThreadHandles, ScopedTask, Task, TaskQueueHandle, TaskQueueStats,


### PR DESCRIPTION
Hello,

### What does this PR do?

Here a little mr for publicly export the struct 'StallDetection'.
I'm sorry if the struct documentation isn't very thorough, but I'm open to modifying it.

### Motivation

I wanted to implement 'StallDetectionHandler' in my project, but unfortunately the struct 'StallDetection' is not publicly exported.