### PR TITLE
Implement a weak reference to a DmaFile

### DIFF
--- a/examples/hyper_client.rs
+++ b/examples/hyper_client.rs
@@ -170,7 +170,7 @@ mod hyper_compat {
             while let Some(next) = response.frame().await {
                 let frame = next.unwrap();
                 if let Some(chunk) = frame.data_ref() {
-                    res_buff.write_all(&chunk).unwrap();
+                    res_buff.write_all(chunk).unwrap();
                 }
             }
 
@@ -221,7 +221,7 @@ mod hyper_compat {
             while let Some(next) = response.frame().await {
                 let frame = next.unwrap();
                 if let Some(chunk) = frame.data_ref() {
-                    res_buff.write_all(&chunk).unwrap();
+                    res_buff.write_all(chunk).unwrap();
                 }
             }
 


### PR DESCRIPTION
### What does this PR do?

Introduces `WeakDmaFile` to be able to construct a non-owning reference that can be upgraded to an owning one.

### Motivation

When I went to migrate my current usage of wrapping DmaFile with Rc, I realized there's a spot I use weak Rc. So instead of having a weird pattern of Rc over something using Arc internally, it would be nice to use a proper weak reference to the DmaFile.

### Related issues

#646

### Additional Notes

### Checklist

[X] I have added unit tests to the code I am submitting
[X] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
