### PR TITLE
Some WeakDmaFile fixes

### DIFF
--- a/glommio/src/io/mod.rs
+++ b/glommio/src/io/mod.rs
@@ -162,7 +162,7 @@ pub use self::{
     },
     bulk_io::{IoVec, MergedBufferLimit, ReadAmplificationLimit, ReadManyResult},
     directory::Directory,
-    dma_file::{CloseResult, DmaFile, OwnedDmaFile},
+    dma_file::{CloseResult, DmaFile, OwnedDmaFile, WeakDmaFile},
     dma_file_stream::{
         DmaStreamReader, DmaStreamReaderBuilder, DmaStreamWriter, DmaStreamWriterBuilder,
     },


### PR DESCRIPTION
### What does this PR do?

WeakDmaFile is exported as was intended. Additionally expose `strong_count` for debug logging.

### Motivation

Tried to reference WeakDmaFile explicitly but the type can only be used implicitly via `downgrade`.

### Related issues

### Additional Notes

### Checklist

[X] I have added unit tests to the code I am submitting
[X] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
