### PR TITLE
Define CFLAG -D_GNU_SOURCE as per liburing ./configure

### DIFF
--- a/glommio/build.rs
+++ b/glommio/build.rs
@@ -32,6 +32,7 @@ fn main() {
         .file(src.join("queue.c"))
         .file(src.join("syscall.c"))
         .file(src.join("register.c"))
+        .flag("-D_GNU_SOURCE")
         .include(src.join("include"))
         .include(&configured_include)
         .extra_warnings(false)
@@ -40,6 +41,7 @@ fn main() {
     // (our additional, linkable C bindings)
     Build::new()
         .file(project.join("rusturing.c"))
+        .flag("-D_GNU_SOURCE")
         .include(src.join("include"))
         .include(&configured_include)
         .compile("rusturing");


### PR DESCRIPTION
### What does this PR do?

The `./configure` script for liburing sets `CFLAG=-D_GNU_SOURCE`, so we should set it on our `build.rs` as well.

### Motivation

Fixes the following build error with musl libc:
`error: unknown type name 'cpu_set_t'`

On musl, `cpu_set_t` is only defined when _GNU_SOURCE is set.

### Related issues

none

### Additional Notes

none

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
