### PR TITLE
Force `tid` wrapper to move

### DIFF
--- a/glommio/src/executor/stall.rs
+++ b/glommio/src/executor/stall.rs
@@ -172,14 +172,15 @@ impl StallDetector {
         struct SendWrapper(libc::pthread_t);
         unsafe impl Send for SendWrapper {}
         let tid = SendWrapper(unsafe { nix::libc::pthread_self() });
-        std::thread::spawn(enclose::enclose! { (terminated, timer) move || {
+        std::thread::spawn(move || {
+            let tid = tid;
             while timer.wait().is_ok() {
                 if terminated.load(Ordering::Relaxed) {
-                    return
+                    return;
                 }
                 unsafe { nix::libc::pthread_kill(tid.0, signal) };
             }
-        }})
+        })
     }
 
     pub(crate) fn enter_task_queue(


### PR DESCRIPTION
### What does this PR do?

This patch is related to 517326b, which wraps `tid` into a `SendWrapper`, because on musl, tid carries a raw pointer, making the type !Send.

I tried to build the current master on musl using rust 1.78, and what I see is that the wrapper gets destructed into its inner value before the move happens, causing the build to fail. I am not sure if this issue is related to rust version or if the original patch never worked.

I also removed the call to `enclose!`. It was wastefully cloning 2 arcs that can be moved instead.

### Motivation

Fix the compilation on musl.

### Related issues

517326b

### Additional Notes

It would be nice to add musl into ci <3

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
