### PR TITLE
add CI security workflow 

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -1,0 +1,21 @@
+on: [push]
+
+name: Datadog Static Analysis
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    name: Datadog Static Analyzer
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Check code meets quality and security standards
+      id: datadog-static-analysis
+      uses: DataDog/datadog-static-analyzer-github-action@v1
+      with:
+        dd_api_key: ${{ secrets.DD_API_KEY }}
+        dd_app_key: ${{ secrets.DD_APP_KEY }}
+        dd_service: dd-trace-py
+        dd_env: ci
+        dd_site: datadoghq.com
+        cpu_count: 2

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -13,8 +13,8 @@ jobs:
       id: datadog-static-analysis
       uses: DataDog/datadog-static-analyzer-github-action@v1
       with:
-        dd_api_key: ${{ secrets.DD_API_KEY }}
-        dd_app_key: ${{ secrets.DD_APP_KEY }}
+        dd_api_key: ${{ secrets.DD_STATIC_ANALYSIS_API_KEY }}
+        dd_app_key: ${{ secrets.DD_STATIC_ANALYSIS_APP_KEY }}
         dd_service: dd-trace-py
         dd_env: ci
         dd_site: datadoghq.com

--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,0 +1,4 @@
+rulesets:
+  - sit-ci-best-practices:
+    only:
+      - ".github/workflows"


### PR DESCRIPTION
Add supports for Datadog static analysis. It checks rules that validates
the GitHub actions are safe and secure.