### PR TITLE
ci: remove deprecated field in `datadog-static-analyzer-github-action`

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -15,7 +15,5 @@ jobs:
       with:
         dd_api_key: ${{ secrets.DD_STATIC_ANALYSIS_API_KEY }}
         dd_app_key: ${{ secrets.DD_STATIC_ANALYSIS_APP_KEY }}
-        dd_service: dd-trace-py
-        dd_env: ci
         dd_site: datadoghq.com
         cpu_count: 2


### PR DESCRIPTION
### What does this PR do?


This PR removes [deprecated fields](https://github.com/DataDog/datadog-static-analyzer-github-action#deprecated-inputs) in the [datadog-static-analyzer-github-action](https://github.com/DataDog/datadog-static-analyzer-github-action). There should be no functional impact or changes observed, as these fields are effectively no-ops today.

(cc @HippoBaro since you added the config here)

### Motivation

The fields are deprecated

### Related issues


### Additional Notes


### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
