### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    groups: # 1 PR per week and group
+      cargo-major:
+        update-types: ["major"]
+      cargo-minor:
+        update-types: ["minor"]
+      cargo-patch:
+        update-types: ["patch"]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups: # 1 PR per week for all images
+      actions:
+        patterns: ["*"]
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: weekly
+    groups: # 1 PR per week for all submodules
+      submodules:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache setup
         uses: ./.github/actions/cache-setup
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache setup
         uses: ./.github/actions/cache-setup
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache setup
         uses: ./.github/actions/cache-setup

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -8,7 +8,7 @@ jobs:
     name: Datadog Static Analyzer
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Check code meets quality and security standards
       id: datadog-static-analysis
       uses: DataDog/datadog-static-analyzer-github-action@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "glommio/liburing"]
 	path = glommio/liburing
-	url = git://git.kernel.dk/liburing
+	url = https://github.com/axboe/liburing.git

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dev-dependencies]
 byte-unit = "5.1.4"
-yansi = "~0.5.1"
+yansi = "~1.0.1"
 clap = "4.5.3"
 fastrand = "2"
 futures = "~0.3.5"
@@ -17,7 +17,7 @@ glommio = { path = "../glommio" }
 # hyper and tokio for the hyper example. We just need the traits from Tokio
 hyper = { version = "1.2.0", features = ["full"] }
 num_cpus = "1.13.0"
-sys-info = "~0.8.0"
+sys-info = "~0.9.1"
 http-body-util = "0.1.0"
 serde_json = "1.0.114"
 

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -18,12 +18,12 @@ readme = "../README.md"
 rust-version = "1.70"
 
 [dependencies]
-ahash = "0.7"
+ahash = "0.8"
 backtrace = { version = "0.3" }
 bitflags = "2.4"
 bitmaps = "3.1"
-buddy-alloc = "0.4"
-concurrent-queue = "1.2"
+buddy-alloc = "0.6"
+concurrent-queue = "2.5"
 crossbeam = "0.8"
 enclose = "1.1"
 flume = { version = "0.11", features = ["async"] }
@@ -33,15 +33,15 @@ lazy_static = "1.4"
 libc = "0.2"
 lockfree = "0.5"
 log = "0.4"
-nix = { version = "0.27", features = ["event", "fs", "ioctl", "mman", "net", "poll", "sched", "time"] }
+nix = { version = "0.30", features = ["event", "fs", "ioctl", "mman", "net", "poll", "sched", "time"] }
 pin-project-lite = "0.2"
-rlimit = "0.6"
+rlimit = "0.10"
 scoped-tls = "1.0"
 scopeguard = "1.1"
 signal-hook = { version = "0.3" }
-sketches-ddsketch = "0.1"
+sketches-ddsketch = "0.3"
 smallvec = { version = "1.7", features = ["union"] }
-socket2 = { version = "0.4", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 tracing = "0.1"
 typenum = "1.15"
 


### PR DESCRIPTION
### What does this PR do?

- Update cargo dependencies, .gitmodules and GitHub Actions
- Let dependabot update cargo dependencies, .gitmodules and GitHub Actions

### Motivation

The technical debt was too large, liburing was 2.1 for example (latest is 2.11).

### Related issues

### Additional Notes

There is no dev environment being provided for macOS, and building the GitHub workflow in nektos/act didn't work either.

### Checklist

[] I have added unit tests to the code I am submitting
[] My unit tests cover both failure and success scenarios
[] If applicable, I have discussed my architecture
