### PR TITLE
Actually fix compile errors when targeting musl

### DIFF
--- a/glommio/src/executor/stall.rs
+++ b/glommio/src/executor/stall.rs
@@ -173,6 +173,7 @@ impl StallDetector {
         unsafe impl Send for SendWrapper {}
         let tid = SendWrapper(unsafe { nix::libc::pthread_self() });
         std::thread::spawn(enclose::enclose! { (terminated, timer) move || {
+            let tid = tid;
             while timer.wait().is_ok() {
                 if terminated.load(Ordering::Relaxed) {
                     return


### PR DESCRIPTION
Continue fixes of #590, which still causes compile error like the [comment](https://github.com/DataDog/glommio/pull/590#issuecomment-2765321605). The fix is to just move the binding first to the closure & then use the wrapped value