### PR TITLE
Memory corruption in glommio::channels::spsc_queue under concurrent use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
 [workspace]
-members = [
-  "examples",
-  "glommio",
-]
+members = ["examples", "glommio"]
 resolver = "2"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.9.0"
 authors = [
     "Glauber Costa <glommer@gmail.com>",
     "Hippolyte Barraud <hippolyte.barraud@datadoghq.com>",
-    "DataDog <info@datadoghq.com>"
+    "DataDog <info@datadoghq.com>",
 ]
 edition = "2021"
 description = "Glommio is a thread-per-core crate that makes writing highly parallel asynchronous applications in a thread-per-core architecture easier for rustaceans."
@@ -12,10 +12,24 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/DataDog/glommio"
 homepage = "https://github.com/DataDog/glommio"
 keywords = ["linux", "rust", "async", "iouring", "thread-per-core"]
-categories = ["asynchronous", "concurrency", "os", "filesystem", "network-programming"]
+categories = [
+    "asynchronous",
+    "concurrency",
+    "os",
+    "filesystem",
+    "network-programming",
+]
 readme = "../README.md"
 # This is also documented in the README.md under "Supported Rust Versions"
 rust-version = "1.70"
+
+[features]
+bench = []
+debugging = []
+
+# Unstable features based on nightly
+native-tls = []
+nightly = ["native-tls"]
 
 [dependencies]
 ahash = "0.7"
@@ -33,7 +47,16 @@ lazy_static = "1.4"
 libc = "0.2"
 lockfree = "0.5"
 log = "0.4"
-nix = { version = "0.27", features = ["event", "fs", "ioctl", "mman", "net", "poll", "sched", "time"] }
+nix = { version = "0.27", features = [
+    "event",
+    "fs",
+    "ioctl",
+    "mman",
+    "net",
+    "poll",
+    "sched",
+    "time",
+] }
 pin-project-lite = "0.2"
 rlimit = "0.6"
 scoped-tls = "1.0"
@@ -45,25 +68,25 @@ socket2 = { version = "0.4", features = ["all"] }
 tracing = "0.1"
 typenum = "1.15"
 
+[build-dependencies]
+cc = "1.0"
+
 [dev-dependencies]
 fastrand = "2"
 futures = "0"
 hdrhistogram = "7"
 pretty_env_logger = "0"
 rand = "0"
-tokio = { version = "1", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time", "sync"] }
+tokio = { version = "1", default-features = false, features = [
+    "rt",
+    "macros",
+    "rt-multi-thread",
+    "net",
+    "io-util",
+    "time",
+    "sync",
+] }
 tracing-subscriber = { version = "0", features = ["env-filter"] }
-
-[build-dependencies]
-cc = "1.0"
-
-[features]
-bench = []
-debugging = []
-
-# Unstable features based on nightly
-native-tls = []
-nightly = ["native-tls"]
 
 [[bench]]
 name = "executor"

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -36,7 +36,7 @@ type Result<T, V> = crate::Result<T, V>;
 /// [`ConnectedReceiver`]: struct.ConnectedReceiver.html
 /// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
 pub struct SharedReceiver<T: Send + Sized> {
-    state: Option<Rc<ReceiverState<T>>>,
+    state: Option<ReceiverState<T>>,
 }
 
 /// The `SharedSender` is the sending end of the Shared Channel.
@@ -52,7 +52,7 @@ pub struct SharedReceiver<T: Send + Sized> {
 /// [`ConnectedSender`]: struct.ConnectedSender.html
 /// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
 pub struct SharedSender<T: Send + Sized> {
-    state: Option<Rc<SenderState<T>>>,
+    state: Option<SenderState<T>>,
 }
 
 impl<T: Send + Sized> fmt::Debug for SharedSender<T> {
@@ -79,7 +79,7 @@ unsafe impl<T: Send + Sized> Send for SharedSender<T> {}
 /// The `ConnectedReceiver` is the receiving end of the Shared Channel.
 pub struct ConnectedReceiver<T: Send + Sized> {
     id: u64,
-    state: Rc<ReceiverState<T>>,
+    state: ReceiverState<T>,
     reactor: Weak<Reactor>,
     notifier: Arc<SleepNotifier>,
 }
@@ -87,7 +87,7 @@ pub struct ConnectedReceiver<T: Send + Sized> {
 /// The `ConnectedSender` is the sending end of the Shared Channel.
 pub struct ConnectedSender<T: Send + Sized> {
     id: u64,
-    state: Rc<SenderState<T>>,
+    state: SenderState<T>,
     reactor: Weak<Reactor>,
     notifier: Arc<SleepNotifier>,
 }
@@ -106,12 +106,28 @@ impl<T: Send + Sized> fmt::Debug for ConnectedSender<T> {
 
 #[derive(Debug)]
 struct SenderState<V: Send + Sized> {
-    buffer: Producer<V>,
+    buffer: Rc<Producer<V>>,
+}
+
+impl<V: Send + Sized> Clone for SenderState<V> {
+    fn clone(&self) -> Self {
+        Self {
+            buffer: self.buffer.clone(),
+        }
+    }
 }
 
 #[derive(Debug)]
 struct ReceiverState<V: Send + Sized> {
-    buffer: Consumer<V>,
+    buffer: Rc<Consumer<V>>,
+}
+
+impl<V: Send + Sized> Clone for ReceiverState<V> {
+    fn clone(&self) -> Self {
+        Self {
+            buffer: self.buffer.clone(),
+        }
+    }
 }
 
 struct Connector<T: BufferHalf + Clone> {
@@ -150,10 +166,14 @@ pub fn new_bounded<T: Send + Sized>(size: usize) -> (SharedSender<T>, SharedRece
     let (producer, consumer) = make(size);
     (
         SharedSender {
-            state: Some(Rc::new(SenderState { buffer: producer })),
+            state: Some(SenderState {
+                buffer: Rc::new(producer),
+            }),
         },
         SharedReceiver {
-            state: Some(Rc::new(ReceiverState { buffer: consumer })),
+            state: Some(ReceiverState {
+                buffer: Rc::new(consumer),
+            }),
         },
     )
 }

--- a/glommio/src/channels/spsc_queue.rs
+++ b/glommio/src/channels/spsc_queue.rs
@@ -3,6 +3,7 @@ use std::{
     fmt,
     marker::PhantomData,
     mem::{self, MaybeUninit},
+    rc::Rc,
     slice::from_raw_parts_mut,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -87,25 +88,9 @@ pub struct Consumer<T> {
     pub(crate) buffer: Arc<Buffer<T>>,
 }
 
-impl<T> Clone for Consumer<T> {
-    fn clone(&self) -> Self {
-        Consumer {
-            buffer: self.buffer.clone(),
-        }
-    }
-}
-
 /// A handle to the queue which allows adding values onto the buffer
 pub struct Producer<T> {
     pub(crate) buffer: Arc<Buffer<T>>,
-}
-
-impl<T> Clone for Producer<T> {
-    fn clone(&self) -> Self {
-        Producer {
-            buffer: self.buffer.clone(),
-        }
-    }
 }
 
 impl<T> fmt::Debug for Consumer<T> {
@@ -321,6 +306,23 @@ impl<T> BufferHalf for Producer<T> {
     }
 }
 
+impl<T> BufferHalf for Rc<Producer<T>> {
+    type Item = T;
+    fn buffer(&self) -> &Buffer<T> {
+        &self.buffer
+    }
+
+    fn connect(&self, id: usize) {
+        assert_ne!(id, 0);
+        assert_ne!(id, usize::MAX);
+        self.buffer.ccache.producer_id.store(id, Ordering::Release);
+    }
+
+    fn peer_id(&self) -> usize {
+        self.buffer.pcache.consumer_id.load(Ordering::Acquire)
+    }
+}
+
 impl<T> Producer<T> {
     /// Attempt to push a value onto the buffer.
     ///
@@ -360,6 +362,23 @@ impl<T> Producer<T> {
 }
 
 impl<T> BufferHalf for Consumer<T> {
+    type Item = T;
+    fn buffer(&self) -> &Buffer<T> {
+        &self.buffer
+    }
+
+    fn connect(&self, id: usize) {
+        assert_ne!(id, usize::MAX);
+        assert_ne!(id, 0);
+        self.buffer.pcache.consumer_id.store(id, Ordering::Release);
+    }
+
+    fn peer_id(&self) -> usize {
+        self.buffer.ccache.producer_id.load(Ordering::Acquire)
+    }
+}
+
+impl<T> BufferHalf for Rc<Consumer<T>> {
     type Item = T;
     fn buffer(&self) -> &Buffer<T> {
         &self.buffer

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -177,7 +177,7 @@ impl Ord for TaskQueue {
 
 impl PartialOrd for TaskQueue {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(other.vruntime.cmp(&self.vruntime))
+        Some(self.cmp(other))
     }
 }
 

--- a/glommio/src/free_list.rs
+++ b/glommio/src/free_list.rs
@@ -72,7 +72,7 @@ impl<T> FreeList<T> {
     }
     pub(crate) fn dealloc(&mut self, idx: Idx<T>) -> T {
         let slot = Slot::Free {
-            next_free: mem::replace(&mut self.first_free, Some(idx)),
+            next_free: self.first_free.replace(idx),
         };
         match mem::replace(&mut self.slots[idx.to_raw()], slot) {
             Slot::Full { item } => item,

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 /// Set a limit to the size of merged IO requests.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum MergedBufferLimit {
     /// Disables request coalescing
     NoMerging,
@@ -21,6 +21,7 @@ pub enum MergedBufferLimit {
     /// Sets the limit to the maximum the kernel allows for the underlying
     /// device without breaking down the request into smaller ones
     /// (/sys/block/.../queue/max_sectors_kb)
+    #[default]
     DeviceMaxSingleRequest,
 
     /// Sets a custom limit.
@@ -29,15 +30,9 @@ pub enum MergedBufferLimit {
     Custom(usize),
 }
 
-impl Default for MergedBufferLimit {
-    fn default() -> Self {
-        Self::DeviceMaxSingleRequest
-    }
-}
-
 /// Set a limit to the amount of read amplification in-between two mergeable IO
 /// requests.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum ReadAmplificationLimit {
     /// Deny read amplification.
     ///
@@ -46,6 +41,7 @@ pub enum ReadAmplificationLimit {
     /// size. For instance, if the minimum IO size is 4KiB and the user reads
     /// [0..256] and [2048..2560] then the two will be merged into [0..4096] to
     /// accommodate the 4KiB minimum IO size.
+    #[default]
     NoAmplification,
 
     /// Merge two consecutive IO requests if the read amplification is below a
@@ -57,12 +53,6 @@ pub enum ReadAmplificationLimit {
     /// Always merge successive IO requests if possible, no matter the distance
     /// between them. This is likely not what you want.
     NoLimit,
-}
-
-impl Default for ReadAmplificationLimit {
-    fn default() -> Self {
-        Self::NoAmplification
-    }
 }
 
 /// An interface to an IO vector.

--- a/glommio/src/io/directory.rs
+++ b/glommio/src/io/directory.rs
@@ -117,8 +117,11 @@ impl Directory {
     /// Returns an iterator to the contents of this directory
     pub fn sync_read_dir(&self) -> Result<std::fs::ReadDir> {
         let path = self.file.path_required("read directory")?;
-        enhanced_try!(std::fs::read_dir(&*path), "Reading a directory", self.file)
-            .map_err(Into::into)
+        Ok(enhanced_try!(
+            std::fs::read_dir(&*path),
+            "Reading a directory",
+            self.file
+        )?)
     }
 
     /// Issues fdatasync into the underlying file.

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -382,7 +382,11 @@ impl DmaFile {
             pos,
             self.pollable,
         );
-        enhanced_try!(source.collect_rw().await, "Writing", self.file).map_err(Into::into)
+        Ok(enhanced_try!(
+            source.collect_rw().await,
+            "Writing",
+            self.file
+        )?)
     }
 
     /// Equivalent to [`DmaFile::write_at`] except that the caller retains
@@ -442,7 +446,11 @@ impl DmaFile {
             pos,
             self.pollable,
         );
-        enhanced_try!(source.collect_rw().await, "Writing", self.file).map_err(Into::into)
+        Ok(enhanced_try!(
+            source.collect_rw().await,
+            "Writing",
+            self.file
+        )?)
     }
 
     /// Reads from a specific position in the file and returns the buffer.
@@ -771,6 +779,7 @@ impl DmaFile {
     /// NOTE: Clones are allowed to exist on any thread and all share the same underlying
     /// fd safely. try_take_last_clone is also safe to invoke from any thread and will
     /// behave correctly with respect to clones on other threads.
+    #[allow(clippy::result_large_err)]
     pub fn try_take_last_clone(mut self) -> std::result::Result<Self, Self> {
         match self.file.try_take_last_clone() {
             Ok(took) => {

--- a/glommio/src/io/glommio_file.rs
+++ b/glommio/src/io/glommio_file.rs
@@ -750,10 +750,10 @@ pub(crate) mod test {
                 files
             };
 
-            assert!(file_list().iter().any(|x| *x == gf_fd)); // sanity check that file is open
+            assert!(file_list().contains(&gf_fd)); // sanity check that file is open
             let _ = { gf }; // moves scope and drops
             sleep(Duration::from_millis(10)).await; // forces the reactor to run, which will drop the file
-            assert!(!file_list().iter().any(|x| *x == gf_fd)); // file is gone
+            assert!(!file_list().contains(&gf_fd)); // file is gone
         });
     }
 }


### PR DESCRIPTION
### Description

I’m seeing a heap corruption crash when using `glommio::channels::spsc_queue` from multiple producer and consumer threads.

The code only uses safe Rust and the public `glommio::channels::spsc_queue` API, but at runtime it fails with:

```text
Avvio demo Glommio Multi-Thread...
malloc(): chunk size mismatch in fastbin
malloc(): chunk size mismatch in fastbin
Aborted (core dumped) cargo run
```

This looks like memory corruption / unsoundness in safe code.

I realize this is an SPSC queue and that my sample intentionally uses multiple producers and multiple consumers, but since the API is fully safe, it shouldn’t be possible to trigger heap corruption (ideally the type system or runtime checks would prevent this usage, or at worst it should fail cleanly without UB).

---

### Environment

* Glommio version: `0.9.0` (from github)
* Rust version: `rustc 1.xx.x (stable)`
* OS: Linux x86_64 Fedora
* Build: `cargo run --release` and `cargo run` both affected

---

### Minimal reproducible example

```rust
use std::error::Error;
use glommio::channels::spsc_queue;

fn main() -> Result<(), Box<dyn Error>> {
    println!("Avvio demo Glommio Multi-Thread...");
    let (sender, mut receiver) = spsc_queue::make::<String>(4096);

    let mut producers = Vec::new();
    let mut consumers = Vec::new();

    // 2 producers
    for i in 0..2 {
        let sender = sender.clone();
        producers.push(std::thread::spawn(move || {
            for j in 0..500_000 {
                let msg = format!("Messaggio {} dal produttore {}\n", j, i);
                // ignoring the return value for simplicity
                let _ = sender.try_push(msg);
            }
        }));
    }

    // 2 consumers
    for _ in 0..2 {
        let receiver = receiver.clone();
        consumers.push(std::thread::spawn(move || {
            for _ in 0..500_000 {
                let _ = receiver.try_pop();
            }
        }));
    }

    for producer in producers {
        producer.join().unwrap();
    }
    for consumer in consumers {
        consumer.join().unwrap();
    }

    Ok(())
}
```

Running this with `cargo run` produces:

```text
Avvio demo Glommio Multi-Thread...
malloc(): chunk size mismatch in fastbin
malloc(): chunk size mismatch in fastbin
Aborted (core dumped) cargo run
```

---

### Expected behavior

Even if using `spsc_queue` in a way that violates its logical “single producer / single consumer” design, the use of safe APIs should not result in undefined behavior or heap corruption.

Ideally one of the following would happen instead:

* The type system prevents this misuse (e.g. `Producer` / `Consumer` not being `Clone`, or being more constrained), or
* There are documented guarantees that misusing the queue can cause UB, or
* The queue detects this situation and fails in a defined way (panic, error, etc.), rather than corrupting memory.

---

### Actual behavior

* Program prints `Avvio demo Glommio Multi-Thread...`

* Then glibc reports:

  ```text
  malloc(): chunk size mismatch in fastbin
  malloc(): chunk size mismatch in fastbin
  Aborted (core dumped)
  ```

* This suggests memory corruption happening internally, triggered only through safe `Producer::try_push` and `Consumer::try_pop` calls.

---

### Additional notes

* `Producer<T>` and `Consumer<T>` are `Send` but `!Sync`, and they are `Clone`. This allows creating multiple cloned producers/consumers that operate concurrently on the same underlying queue from different threads.
* The module name `spsc_queue` suggests single-producer/single-consumer behavior, but the current API surface (especially `Clone` + `Send`) makes it easy to use it in multi-producer/multi-consumer scenarios without any compiler errors or warnings.
* Even if this usage is considered invalid, the fact that it leads to heap corruption in safe Rust feels like at least a documentation or soundness issue.

If this usage is explicitly unsupported and considered undefined behavior, it might be helpful to:

1. Clarify that in the documentation for `spsc_queue::make`, `Producer`, and `Consumer`, and/or
2. Tighten the API (e.g. remove `Clone` or add runtime checks) so that this pattern doesn’t compile or at least doesn’t lead to memory corruption.
