### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           cat << EOF > "run-gha-workflow.sh"
           PATH=$PATH:/usr/share/rust/.cargo/bin
           echo "`nproc` CPU(s) available"
-          rustup install 1.70
+          rustup install 1.92
           rustup show
           rustup default stable
           cargo install cargo-sort

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
 [workspace]
-members = [
-  "examples",
-  "glommio",
-]
+members = ["examples", "glommio"]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ an [introductory article.](https://www.datadoghq.com/blog/engineering/introducin
 
 ## Supported Rust Versions
 
-Glommio is built against the latest stable release. The minimum supported version is 1.70. The current Glommio version
+Glommio is built against the latest stable release. The minimum supported version is 1.92. The current Glommio version
 is not guaranteed to build on Rust versions earlier than the minimum supported version.
 
 ## Supported Linux kernels

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,19 +7,19 @@ edition = "2021"
 
 [dev-dependencies]
 byte-unit = "5.1.4"
-yansi = "~0.5.1"
 clap = "4.5.3"
 fastrand = "2"
 futures = "~0.3.5"
 futures-lite = "2.6.0"
 glommio = { path = "../glommio" }
+http-body-util = "0.1.0"
 
 # hyper and tokio for the hyper example. We just need the traits from Tokio
 hyper = { version = "1.2.0", features = ["full"] }
 num_cpus = "1.13.0"
-sys-info = "~0.8.0"
-http-body-util = "0.1.0"
 serde_json = "1.0.114"
+sys-info = "~0.9.1"
+yansi = "~1.0.1"
 
 [[example]]
 name = "echo"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,7 +3,7 @@ name = "examples"
 version = "0.0.0"
 license = "Apache-2.0 OR MIT"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [dev-dependencies]
 byte-unit = "5.1.4"

--- a/examples/deadline_writer.rs
+++ b/examples/deadline_writer.rs
@@ -69,11 +69,11 @@ impl IntWriter {
 
                 println!(
                     "{}: Wrote {} ({}%), {:.0} int/s, scheduler shares: {} , {:.2} % CPU",
-                    Paint::blue(format!("{}s", elapsed.as_secs())),
+                    format!("{}s", elapsed.as_secs()).blue(),
                     self.count.get(),
-                    Paint::new(format!("{:.0}", ratio)).bold(),
+                    format!("{:.0}", ratio).bold(),
                     intratio,
-                    Paint::new(tq_stats.current_shares().to_string()).bold(),
+                    tq_stats.current_shares().to_string().bold(),
                     cpuratio
                 );
                 self.next_print
@@ -168,10 +168,7 @@ fn main() {
                 "cpuhog",
             );
 
-            println!(
-                "{}",
-                Paint::new("Welcome to the Deadline Writer example").bold()
-            );
+            println!("{}", "Welcome to the Deadline Writer example".bold());
             println!(
                 "In this example we will write a sequence of integers to a variable, busy looping \
                  for 500us after each write"
@@ -183,7 +180,7 @@ fn main() {
             println!(
                 "For {} results, this test is pinned to your CPU0. Make sure nothing else of \
                  significance is running there. You should be able to see it at 100% at all times!",
-                Paint::new("best").bold()
+                "best".bold()
             );
 
             println!("\n\nPlease tell me how many integers you would like to write");
@@ -191,28 +188,25 @@ fn main() {
             println!(
                 "Ok, now let's write {} integers with both the writer and the CPU hog having the \
                  same priority",
-                Paint::blue(to_write.to_string())
+                to_write.to_string().blue()
             );
             let dur = static_writer(to_write, 1000, cpuhog_tq).await;
-            println!(
-                "Finished writing in {}",
-                Paint::green(format!("{dur:#.0?}"))
-            );
+            println!("Finished writing in {}", format!("{dur:#.0?}").green());
             println!(
                 "This was using {} shares, and short of reducing the priority of the CPU hog. {}",
-                Paint::green("1000"),
-                Paint::new("This is as fast as we can do!").bold()
+                "1000".green(),
+                "This is as fast as we can do!".bold()
             );
             println!(
                 "With {} shares, this would have taken approximately {}",
-                Paint::green("100"),
-                Paint::green(format!("{:#.1?}", dur * 10))
+                "100".green(),
+                format!("{:#.1?}", dur * 10).green()
             );
             println!(
                 "With {} shares, this would have taken approximately {}. {}.",
-                Paint::green("1"),
-                Paint::green(format!("{:#.1?}", dur * 1000)),
-                Paint::new("Can't go any slower than that!").bold()
+                "1".green(),
+                format!("{:#.1?}", dur * 1000).green(),
+                "Can't go any slower than that!".bold()
             );
 
             println!(
@@ -233,10 +227,7 @@ fn main() {
                 let deadline = DeadlineQueue::new("example", Duration::from_millis(250));
                 let test = IntWriter::new(to_write, Duration::from_secs(duration as u64));
                 let dur = deadline.push_work(test).await.unwrap();
-                println!(
-                    "Finished writing in {}",
-                    Paint::green(format!("{dur:#.2?}"))
-                );
+                println!("Finished writing in {}", format!("{dur:#.2?}").green());
                 stop.set(true);
                 hog.await.unwrap();
                 println!(

--- a/examples/defer.rs
+++ b/examples/defer.rs
@@ -3,7 +3,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
-use glommio::{defer, timer::TimerActionOnce, LocalExecutorBuilder};
+use glommio::{LocalExecutorBuilder, defer, timer::TimerActionOnce};
 use std::time::Duration;
 
 fn main() {

--- a/examples/hyper_client.rs
+++ b/examples/hyper_client.rs
@@ -74,38 +74,6 @@ mod hyper_compat {
         }
     }
 
-    struct GlommioSleep(glommio::timer::Timer);
-
-    impl Future for GlommioSleep {
-        type Output = ();
-
-        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-            match Pin::new(&mut self.0).poll(cx) {
-                Poll::Ready(_) => Poll::Ready(()),
-                Poll::Pending => Poll::Pending,
-            }
-        }
-    }
-
-    impl hyper::rt::Sleep for GlommioSleep {}
-    unsafe impl Send for GlommioSleep {}
-    unsafe impl Sync for GlommioSleep {}
-
-    #[derive(Clone, Copy, Debug)]
-    pub struct GlommioTimer;
-
-    impl hyper::rt::Timer for GlommioTimer {
-        fn sleep(&self, duration: std::time::Duration) -> Pin<Box<dyn hyper::rt::Sleep>> {
-            Box::pin(GlommioSleep(glommio::timer::Timer::new(duration)))
-        }
-
-        fn sleep_until(&self, deadline: std::time::Instant) -> Pin<Box<dyn hyper::rt::Sleep>> {
-            Box::pin(GlommioSleep(glommio::timer::Timer::new(
-                deadline - std::time::Instant::now(),
-            )))
-        }
-    }
-
     struct Body {
         // Our Body type is !Send and !Sync:
         _marker: PhantomData<*const ()>,

--- a/examples/hyper_client.rs
+++ b/examples/hyper_client.rs
@@ -13,9 +13,9 @@ mod hyper_compat {
     use glommio::net::TcpStream;
 
     use http_body_util::BodyExt;
-    use hyper::body::{Body as HttpBody, Bytes, Frame};
     use hyper::Error;
     use hyper::Request;
+    use hyper::body::{Body as HttpBody, Bytes, Frame};
     use std::io;
     use std::marker::PhantomData;
 

--- a/examples/hyper_server.rs
+++ b/examples/hyper_server.rs
@@ -8,9 +8,9 @@ mod hyper_compat {
         sync::Semaphore,
     };
     use hyper::{
+        Error, Request, Response,
         body::{Body as HttpBody, Bytes, Frame, Incoming},
         service::service_fn,
-        Error, Request, Response,
     };
 
     use std::{
@@ -173,7 +173,7 @@ mod hyper_compat {
 }
 
 use glommio::{CpuSet, LocalExecutorPoolBuilder, PoolPlacement};
-use hyper::{body::Incoming, Method, Request, Response, StatusCode};
+use hyper::{Method, Request, Response, StatusCode, body::Incoming};
 use hyper_compat::ResponseBody;
 use std::convert::Infallible;
 

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -3,7 +3,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
-use glommio::{enclose, LocalExecutor};
+use glommio::{LocalExecutor, enclose};
 use std::{cell::RefCell, rc::Rc};
 
 fn main() {

--- a/examples/sharding.rs
+++ b/examples/sharding.rs
@@ -1,4 +1,4 @@
-use futures_lite::{future::ready, stream::repeat_with, FutureExt, StreamExt};
+use futures_lite::{FutureExt, StreamExt, future::ready, stream::repeat_with};
 
 use glommio::{
     channels::{

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -1,16 +1,15 @@
 use byte_unit::{Byte, UnitType};
 use clap::{Arg, Command};
 use futures_lite::{
-    stream::{self, StreamExt},
     AsyncReadExt, AsyncWriteExt,
+    stream::{self, StreamExt},
 };
 use glommio::{
-    enclose,
+    LocalExecutorBuilder, Placement, enclose,
     io::{
         BufferedFile, DmaFile, DmaStreamReader, DmaStreamReaderBuilder, DmaStreamWriterBuilder,
         MergedBufferLimit, ReadAmplificationLimit, StreamReaderBuilder, StreamWriterBuilder,
     },
-    LocalExecutorBuilder, Placement,
 };
 use std::{
     cell::Cell,

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -29,42 +29,41 @@ nightly = ["native-tls"]
 ahash = "0.8"
 backtrace = { version = "0.3" }
 bencher = "0.1.5"
-bitflags = "2.4"
-bitmaps = "3.1"
+bitflags = "2.10"
+bitmaps = "3.2"
 buddy-alloc = "0.6"
 concurrent-queue = "2.5"
 crossbeam = "0.8"
-enclose = "1.1"
+enclose = "1.2"
 flume = { version = "0.12", features = ["async"] }
-futures-lite = "2.6.0"
+futures-lite = "2.6"
 intrusive-collections = "0.10"
-lazy_static = "1.4"
+lazy_static = "1.5"
 libc = "0.2"
-lockfree = "0.5"
 log = "0.4"
 nix = { version = "0.30", features = ["event", "fs", "ioctl", "mman", "net", "poll", "sched", "time"] }
 pin-project-lite = "0.2"
 rlimit = "0.10"
 scoped-tls = "1.0"
-scopeguard = "1.1"
+scopeguard = "1.2"
 signal-hook = { version = "0.4" }
 sketches-ddsketch = "0.3"
-smallvec = { version = "1.7", features = ["union"] }
+smallvec = { version = "1.15", features = ["union"] }
 socket2 = { version = "0.6", features = ["all"] }
 tracing = "0.1"
-typenum = "1.15"
+typenum = "1.19"
 
 [build-dependencies]
-cc = "1.0"
+cc = "1.2"
 
 [dev-dependencies]
-fastrand = "2"
-futures = "0"
-hdrhistogram = "7"
-pretty_env_logger = "0"
-rand = "0"
-tokio = { version = "1", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time", "sync"] }
-tracing-subscriber = { version = "0", features = ["env-filter"] }
+fastrand = "2.3"
+futures = "0.3"
+hdrhistogram = "7.5"
+pretty_env_logger = "0.5"
+rand = "0.9"
+tokio = { version = "1.49", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time", "sync"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [[bench]]
 name = "executor"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.9.0"
 authors = [
     "Glauber Costa <glommer@gmail.com>",
     "Hippolyte Barraud <hippolyte.barraud@datadoghq.com>",
-    "DataDog <info@datadoghq.com>"
+    "DataDog <info@datadoghq.com>",
 ]
 edition = "2021"
 description = "Glommio is a thread-per-core crate that makes writing highly parallel asynchronous applications in a thread-per-core architecture easier for rustaceans."
@@ -17,33 +17,45 @@ readme = "../README.md"
 # This is also documented in the README.md under "Supported Rust Versions"
 rust-version = "1.70"
 
+[features]
+bench = []
+debugging = []
+
+# Unstable features based on nightly
+native-tls = []
+nightly = ["native-tls"]
+
 [dependencies]
-ahash = "0.7"
+ahash = "0.8"
 backtrace = { version = "0.3" }
+bencher = "0.1.5"
 bitflags = "2.4"
 bitmaps = "3.1"
-buddy-alloc = "0.4"
-concurrent-queue = "1.2"
+buddy-alloc = "0.6"
+concurrent-queue = "2.5"
 crossbeam = "0.8"
 enclose = "1.1"
-flume = { version = "0.11", features = ["async"] }
+flume = { version = "0.12", features = ["async"] }
 futures-lite = "2.6.0"
-intrusive-collections = "0.9"
+intrusive-collections = "0.10"
 lazy_static = "1.4"
 libc = "0.2"
 lockfree = "0.5"
 log = "0.4"
-nix = { version = "0.27", features = ["event", "fs", "ioctl", "mman", "net", "poll", "sched", "time"] }
+nix = { version = "0.30", features = ["event", "fs", "ioctl", "mman", "net", "poll", "sched", "time"] }
 pin-project-lite = "0.2"
-rlimit = "0.6"
+rlimit = "0.10"
 scoped-tls = "1.0"
 scopeguard = "1.1"
-signal-hook = { version = "0.3" }
-sketches-ddsketch = "0.1"
+signal-hook = { version = "0.4" }
+sketches-ddsketch = "0.3"
 smallvec = { version = "1.7", features = ["union"] }
-socket2 = { version = "0.4", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 tracing = "0.1"
 typenum = "1.15"
+
+[build-dependencies]
+cc = "1.0"
 
 [dev-dependencies]
 fastrand = "2"
@@ -53,17 +65,6 @@ pretty_env_logger = "0"
 rand = "0"
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time", "sync"] }
 tracing-subscriber = { version = "0", features = ["env-filter"] }
-
-[build-dependencies]
-cc = "1.0"
-
-[features]
-bench = []
-debugging = []
-
-# Unstable features based on nightly
-native-tls = []
-nightly = ["native-tls"]
 
 [[bench]]
 name = "executor"

--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["linux", "rust", "async", "iouring", "thread-per-core"]
 categories = ["asynchronous", "concurrency", "os", "filesystem", "network-programming"]
 readme = "../README.md"
 # This is also documented in the README.md under "Supported Rust Versions"
-rust-version = "1.70"
+rust-version = "1.92"
 
 [features]
 bench = []

--- a/glommio/benches/spsc_queue.rs
+++ b/glommio/benches/spsc_queue.rs
@@ -1,32 +1,76 @@
 use glommio::channels::spsc_queue;
+use std::hint::{black_box, spin_loop};
+use std::thread;
 use std::time::Instant;
 
-fn test_spsc(capacity: usize) {
-    const RUNS: u32 = 10 * 1000 * 1000;
-    let (sender, receiver) = spsc_queue::make::<u64>(1024);
-    let consumer = std::thread::spawn(move || {
-        let t = Instant::now();
-        for _ in 0..RUNS {
-            while receiver.try_pop().is_none() {}
-        }
-        println!(
-            "cost of receiving {:#?}, capacity {}",
-            t.elapsed() / RUNS,
-            capacity,
-        );
-    });
-    let t = Instant::now();
-    for i in 0..RUNS {
-        while sender.try_push(i as u64).is_some() {}
+const RUNS: usize = 10_000_000;
+
+fn pin_to_cpu(cpu: usize) {
+    use std::mem::MaybeUninit;
+
+    unsafe {
+        let mut set = MaybeUninit::<libc::cpu_set_t>::zeroed().assume_init();
+        libc::CPU_ZERO(&mut set);
+        libc::CPU_SET(cpu, &mut set);
+
+        let ret = libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &set);
+        assert_eq!(ret, 0, "sched_setaffinity failed");
     }
+}
+
+fn bench_spsc(capacity: usize, cpu_producer: usize, cpu_consumer: usize) {
+    let (sender, receiver) = spsc_queue::make::<u32>(capacity);
+
+    let consumer = thread::spawn(move || {
+        pin_to_cpu(cpu_consumer);
+
+        let start = Instant::now();
+        for _ in 0..RUNS {
+            loop {
+                if black_box(receiver.try_pop()).is_some() {
+                    break;
+                }
+                spin_loop();
+            }
+        }
+        start.elapsed()
+    });
+
+    // Producer timing
+    pin_to_cpu(cpu_producer);
+
+    let start = Instant::now();
+    for i in 0..RUNS {
+        loop {
+            if black_box(sender.try_push(i as u32)).is_none() {
+                break;
+            }
+            spin_loop();
+        }
+    }
+    let prod_elapsed = start.elapsed();
+    let cons_elapsed = consumer.join().unwrap();
+
+    let prod_ns = prod_elapsed.as_nanos() as f64 / RUNS as f64;
+    let cons_ns = cons_elapsed.as_nanos() as f64 / RUNS as f64;
+
+    let prod_kops = (1e9 / prod_ns) / 1e3;
+    let cons_kops = (1e9 / cons_ns) / 1e3;
+
     println!(
-        "cost of sending {:#?}, capacity {}",
-        t.elapsed() / RUNS,
-        capacity
+        "Cap {:>6} | Prod {:>8.2} ns/op ({:>10.2} KOPS) | Cons {:>8.2} ns/op ({:>10.2} KOPS)",
+        capacity, prod_ns, prod_kops, cons_ns, cons_kops
     );
-    consumer.join().unwrap();
 }
 
 fn main() {
-    test_spsc(1024);
+    let pairs = &[(0usize, 1usize), (0usize, 2usize)];
+
+    for &(cpu_p, cpu_c) in pairs {
+        println!("CPU {}->{}", cpu_p, cpu_c);
+        for &capacity in &[1, 16, 1024, 4096, 10_000] {
+            bench_spsc(capacity, cpu_p, cpu_c);
+        }
+        println!("--");
+    }
 }

--- a/glommio/rusturing.c
+++ b/glommio/rusturing.c
@@ -108,7 +108,7 @@ extern inline void rust_io_uring_prep_poll_add(struct io_uring_sqe *sqe, int fd,
     io_uring_prep_poll_add(sqe, fd, poll_mask);
 }
 
-extern inline void rust_io_uring_prep_poll_remove(struct io_uring_sqe *sqe, void *user_data)
+extern inline void rust_io_uring_prep_poll_remove(struct io_uring_sqe *sqe, __u64 user_data)
 {
     io_uring_prep_poll_remove(sqe, user_data);
 }
@@ -311,4 +311,9 @@ extern inline int rust_io_uring_peek_cqe(struct io_uring *ring, struct io_uring_
 extern inline int rust_io_uring_wait_cqe(struct io_uring *ring, struct io_uring_cqe **cqe_ptr)
 {
     return io_uring_wait_cqe(ring, cqe_ptr);
+}
+
+extern inline struct io_uring_sqe *rust_io_uring_get_sqe(struct io_uring *ring)
+{
+    return io_uring_get_sqe(ring);
 }

--- a/glommio/src/channels/channel_mesh.rs
+++ b/glommio/src/channels/channel_mesh.rs
@@ -334,8 +334,7 @@ impl<T: 'static + Send, A: MeshAdapter> MeshBuilder<T, A> {
         let mut peers = self.peers.write().unwrap();
 
         if peers.len() == self.nr_peers {
-            return Err(GlommioError::IoError(Error::new(
-                ErrorKind::Other,
+            return Err(GlommioError::IoError(Error::other(
                 "The channel mesh is full.",
             )));
         }

--- a/glommio/src/channels/channel_mesh.rs
+++ b/glommio/src/channels/channel_mesh.rs
@@ -4,13 +4,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
 //
 use std::{
-    cell::Cell,
     fmt::{self, Debug, Formatter},
     io::{Error, ErrorKind},
-    rc::Rc,
+    sync::{Arc, Mutex},
 };
-
-use std::sync::{Arc, RwLock};
 
 use crate::{
     channels::shared_channel::{self, *},
@@ -161,26 +158,17 @@ impl<T: Send> Receivers<T> {
 
 struct Peer {
     executor_id: usize,
-    notifier: Option<SharedSender<bool>>,
     role: Role,
 }
 
 impl Peer {
-    fn new(sender: Option<SharedSender<bool>>, role: Role) -> Self {
+    fn new(role: Role) -> Self {
         Self {
             executor_id: crate::executor().id(),
-            notifier: sender,
             role,
         }
     }
 }
-
-type SharedChannel<T> = (
-    Cell<Option<SharedSender<T>>>,
-    Cell<Option<SharedReceiver<T>>>,
-);
-
-type SharedChannels<T> = Vec<Vec<SharedChannel<T>>>;
 
 /// The role an executor plays in the mesh
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -200,6 +188,32 @@ impl Role {
 
     fn is_consumer(&self) -> bool {
         Self::Producer.ne(self)
+    }
+}
+
+struct JoinState<T: Send> {
+    peers: Vec<Peer>,
+    ready: bool,
+    senders: Vec<Vec<Option<SharedSender<T>>>>,
+    receivers: Vec<Vec<Option<SharedReceiver<T>>>>,
+}
+
+impl<T: Send> JoinState<T> {
+    fn new(nr_peers: usize) -> Self {
+        let mut senders: Vec<Vec<Option<SharedSender<T>>>> = Vec::with_capacity(nr_peers);
+        let mut receivers: Vec<Vec<Option<SharedReceiver<T>>>> = Vec::with_capacity(nr_peers);
+
+        for _ in 0..nr_peers {
+            senders.push((0..nr_peers).map(|_| None).collect());
+            receivers.push((0..nr_peers).map(|_| None).collect());
+        }
+
+        Self {
+            peers: Vec::new(),
+            ready: false,
+            senders,
+            receivers,
+        }
     }
 }
 
@@ -252,20 +266,16 @@ pub type PartialMesh<T> = MeshBuilder<T, Partial>;
 pub struct MeshBuilder<T: Send, A: MeshAdapter> {
     nr_peers: usize,
     channel_size: usize,
-    peers: Rc<RwLock<Vec<Peer>>>,
-    channels: Arc<SharedChannels<T>>,
+    state: Arc<Mutex<JoinState<T>>>,
     adapter: A,
 }
-
-unsafe impl<T: Send, A: MeshAdapter> Send for MeshBuilder<T, A> {}
 
 impl<T: Send, A: MeshAdapter> Clone for MeshBuilder<T, A> {
     fn clone(&self) -> Self {
         Self {
             nr_peers: self.nr_peers,
             channel_size: self.channel_size,
-            peers: self.peers.clone(),
-            channels: self.channels.clone(),
+            state: self.state.clone(),
             adapter: self.adapter.clone(),
         }
     }
@@ -309,8 +319,7 @@ impl<T: 'static + Send, A: MeshAdapter> MeshBuilder<T, A> {
         MeshBuilder {
             nr_peers,
             channel_size,
-            peers: Rc::new(RwLock::new(Vec::new())),
-            channels: Arc::new(Self::placeholder(nr_peers)),
+            state: Arc::new(Mutex::new(JoinState::new(nr_peers))),
             adapter,
         }
     }
@@ -320,79 +329,99 @@ impl<T: 'static + Send, A: MeshAdapter> MeshBuilder<T, A> {
         self.nr_peers
     }
 
-    fn placeholder(nr_peers: usize) -> SharedChannels<T> {
-        (0..nr_peers)
-            .map(|_| {
-                (0..nr_peers)
-                    .map(|_| (Cell::new(None), Cell::new(None)))
-                    .collect()
-            })
-            .collect()
-    }
+    async fn register(&self, role: Role) -> Result<(usize, usize), ()> {
+        let (is_last, exec_id) = {
+            let mut state = self.state.lock().unwrap();
 
-    fn register(&self, role: Role) -> Result<RegisterResult<bool>, ()> {
-        let mut peers = self.peers.write().unwrap();
-
-        if peers.len() == self.nr_peers {
-            return Err(GlommioError::IoError(Error::other(
-                "The channel mesh is full.",
-            )));
-        }
-
-        let index = peers
-            .binary_search_by(|n| n.executor_id.cmp(&crate::executor().id()))
-            .expect_err("Should not join a mesh more than once.");
-
-        if peers.len() == self.nr_peers - 1 {
-            peers.insert(index, Peer::new(None, role));
-
-            for (idx_from, from) in peers.iter().enumerate() {
-                for (idx_to, to) in peers.iter().enumerate() {
-                    let channel = &self.channels[idx_from][idx_to];
-                    if idx_from != idx_to && self.adapter.connect(&from.role, &to.role) {
-                        let (sender, receiver) = shared_channel::new_bounded(self.channel_size);
-                        channel.0.set(Some(sender));
-                        channel.1.set(Some(receiver));
-                    }
-                }
+            if state.peers.len() == self.nr_peers {
+                return Err(GlommioError::IoError(Error::other(
+                    "The channel mesh is full.",
+                )));
             }
 
-            let peers: Vec<_> = peers
-                .iter_mut()
-                .filter_map(|notifier| notifier.notifier.take())
-                .collect();
+            let exec_id = crate::executor().id();
+            let index = state
+                .peers
+                .binary_search_by(|n| n.executor_id.cmp(&exec_id))
+                .expect_err("Should not join a mesh more than once.");
 
-            Ok(RegisterResult::NotificationSenders(peers))
+            state.peers.insert(index, Peer::new(role));
+
+            (state.peers.len() == self.nr_peers, exec_id)
+        };
+
+        if is_last {
+            // If this was the last joiner, build the channels
+            let mut state = self.state.lock().unwrap();
+            if !state.ready {
+                let n = state.peers.len();
+                for from_idx in 0..n {
+                    for to_idx in 0..n {
+                        if from_idx == to_idx {
+                            continue;
+                        }
+
+                        let from_role = state.peers[from_idx].role;
+                        let to_role = state.peers[to_idx].role;
+
+                        if self.adapter.connect(&from_role, &to_role) {
+                            let (tx, rx) = shared_channel::new_bounded(self.channel_size);
+                            state.senders[from_idx][to_idx] = Some(tx);
+                            state.receivers[from_idx][to_idx] = Some(rx);
+                        }
+                    }
+                }
+
+                state.ready = true;
+            }
         } else {
-            let (sender, receiver) = shared_channel::new_bounded(1);
-            peers.insert(index, Peer::new(Some(sender), role));
-            Ok(RegisterResult::NotificationReceiver(receiver))
+            // Wait until last joiner finishes building
+            loop {
+                let ready = {
+                    let state = self.state.lock().unwrap();
+                    state.ready
+                };
+
+                if ready {
+                    break;
+                }
+
+                futures_lite::future::yield_now().await;
+            }
         }
+
+        let state = self.state.lock().unwrap();
+        // At this point st.ready == true and st.peers is stable.
+
+        let peer_id = state
+            .peers
+            .binary_search_by(|p| p.executor_id.cmp(&exec_id))
+            .unwrap();
+
+        let role_id = state.peers[..peer_id]
+            .iter()
+            .filter(|p| p.role == role)
+            .count();
+
+        Ok((peer_id, role_id))
     }
 
     async fn join_with(self, role: Role) -> Result<(Senders<T>, Receivers<T>), ()> {
-        match Self::register(&self, role)? {
-            RegisterResult::NotificationReceiver(receiver) => {
-                receiver.connect().await.recv().await.unwrap();
-            }
-            RegisterResult::NotificationSenders(peers) => {
-                for peer in peers {
-                    peer.connect().await.send(true).await.unwrap();
-                }
-            }
-        }
+        let (peer_id, role_id) = self.register(role).await?;
 
-        let (peer_id, role_id) = {
-            let peers = self.peers.read().unwrap();
-            let peer_id = peers
-                .binary_search_by(|n| n.executor_id.cmp(&crate::executor().id()))
-                .unwrap();
-            let role_id = peers
-                .iter()
-                .take(peer_id)
-                .filter(|r| r.role.eq(&role))
-                .count();
-            (peer_id, role_id)
+        // Extract Senders and Receivers for this peer
+        let (mut senders, mut receivers) = {
+            let mut st = self.state.lock().unwrap();
+
+            let mut row = Vec::with_capacity(self.nr_peers);
+            let mut col = Vec::with_capacity(self.nr_peers);
+
+            for i in 0..self.nr_peers {
+                row.push(st.senders[peer_id][i].take());
+                col.push(st.receivers[i][peer_id].take());
+            }
+
+            (row, col)
         };
 
         let producer_id = if role.is_producer() {
@@ -407,32 +436,32 @@ impl<T: 'static + Send, A: MeshAdapter> MeshBuilder<T, A> {
             None
         };
 
-        let mut senders = Vec::with_capacity(self.nr_peers);
-        let mut receivers = Vec::with_capacity(self.nr_peers);
+        let mut senders_vec = Vec::with_capacity(self.nr_peers);
+        let mut receivers_vec = Vec::with_capacity(self.nr_peers);
 
         for i in 0..self.nr_peers {
-            let sender = self.channels[peer_id][i].0.take();
-            let receiver = self.channels[i][peer_id].1.take();
+            let sender = senders[i].take();
+            let receiver = receivers[i].take();
 
-            let sender = sender.map(|sender| crate::spawn_local(sender.connect()).detach());
-            let receiver = receiver.map(|receiver| crate::spawn_local(receiver.connect()).detach());
+            let sender = sender.map(|s| crate::spawn_local(s.connect()).detach());
+            let receiver = receiver.map(|r| crate::spawn_local(r.connect()).detach());
 
             match sender {
                 None => {
                     if self.adapter.is_full() {
-                        senders.push(None)
+                        senders_vec.push(None)
                     }
                 }
-                Some(sender) => senders.push(Some(sender.await.unwrap())),
+                Some(h) => senders_vec.push(Some(h.await.unwrap())),
             }
 
             match receiver {
                 None => {
                     if self.adapter.is_full() {
-                        receivers.push(None)
+                        receivers_vec.push(None)
                     }
                 }
-                Some(receiver) => receivers.push(Some(receiver.await.unwrap())),
+                Some(h) => receivers_vec.push(Some(h.await.unwrap())),
             }
         }
 
@@ -440,20 +469,15 @@ impl<T: 'static + Send, A: MeshAdapter> MeshBuilder<T, A> {
             Senders {
                 peer_id,
                 producer_id,
-                senders,
+                senders: senders_vec,
             },
             Receivers {
                 peer_id,
                 consumer_id,
-                receivers,
+                receivers: receivers_vec,
             },
         ))
     }
-}
-
-enum RegisterResult<T: Send> {
-    NotificationReceiver(SharedReceiver<T>),
-    NotificationSenders(Vec<SharedSender<T>>),
 }
 
 #[cfg(test)]

--- a/glommio/src/channels/shared_channel.rs
+++ b/glommio/src/channels/shared_channel.rs
@@ -36,7 +36,7 @@ type Result<T, V> = crate::Result<T, V>;
 /// [`ConnectedReceiver`]: struct.ConnectedReceiver.html
 /// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
 pub struct SharedReceiver<T: Send + Sized> {
-    state: Option<Rc<ReceiverState<T>>>,
+    state: Option<Arc<ReceiverState<T>>>,
 }
 
 /// The `SharedSender` is the sending end of the Shared Channel.
@@ -52,7 +52,7 @@ pub struct SharedReceiver<T: Send + Sized> {
 /// [`ConnectedSender`]: struct.ConnectedSender.html
 /// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
 pub struct SharedSender<T: Send + Sized> {
-    state: Option<Rc<SenderState<T>>>,
+    state: Option<Arc<SenderState<T>>>,
 }
 
 impl<T: Send + Sized> fmt::Debug for SharedSender<T> {
@@ -73,13 +73,10 @@ impl<T: Send + Sized> fmt::Debug for SharedReceiver<T> {
     }
 }
 
-unsafe impl<T: Send + Sized> Send for SharedReceiver<T> {}
-unsafe impl<T: Send + Sized> Send for SharedSender<T> {}
-
 /// The `ConnectedReceiver` is the receiving end of the Shared Channel.
 pub struct ConnectedReceiver<T: Send + Sized> {
     id: u64,
-    state: Rc<ReceiverState<T>>,
+    state: Arc<ReceiverState<T>>,
     reactor: Weak<Reactor>,
     notifier: Arc<SleepNotifier>,
 }
@@ -87,7 +84,7 @@ pub struct ConnectedReceiver<T: Send + Sized> {
 /// The `ConnectedSender` is the sending end of the Shared Channel.
 pub struct ConnectedSender<T: Send + Sized> {
     id: u64,
-    state: Rc<SenderState<T>>,
+    state: Arc<SenderState<T>>,
     reactor: Weak<Reactor>,
     notifier: Arc<SleepNotifier>,
 }
@@ -150,10 +147,10 @@ pub fn new_bounded<T: Send + Sized>(size: usize) -> (SharedSender<T>, SharedRece
     let (producer, consumer) = make(size);
     (
         SharedSender {
-            state: Some(Rc::new(SenderState { buffer: producer })),
+            state: Some(Arc::new(SenderState { buffer: producer })),
         },
         SharedReceiver {
-            state: Some(Rc::new(ReceiverState { buffer: consumer })),
+            state: Some(Arc::new(ReceiverState { buffer: consumer })),
         },
     )
 }

--- a/glommio/src/controllers/deadline_queue.rs
+++ b/glommio/src/controllers/deadline_queue.rs
@@ -496,9 +496,10 @@ impl<T: 'static> DeadlineQueue<T> {
     pub async fn push_work(&self, source: Rc<dyn DeadlineSource<Output = T>>) -> io::Result<T> {
         self.queue.admit(source.clone())?;
         self.sender.send(source.clone()).await?;
-        self.responder.recv().await.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "no response from response channel")
-        })
+        self.responder
+            .recv()
+            .await
+            .ok_or_else(|| io::Error::other("no response from response channel"))
     }
 
     /// Returns the TaskQueueHandle associated with this controller

--- a/glommio/src/error.rs
+++ b/glommio/src/error.rs
@@ -494,7 +494,7 @@ impl<T> From<GlommioError<T>> for io::Error {
             GlommioError::ExecutorError(ExecutorErrorKind::QueueError { index, kind }) => {
                 match kind {
                     QueueErrorKind::StillActive => {
-                        io::Error::new(io::ErrorKind::Other, format!("Queue #{index} still active"))
+                        io::Error::other(format!("Queue #{index} still active"))
                     }
                     QueueErrorKind::NotFound => {
                         io::Error::new(io::ErrorKind::NotFound, format!("Queue #{index} not found"))
@@ -508,10 +508,9 @@ impl<T> From<GlommioError<T>> for io::Error {
             GlommioError::BuilderError(BuilderErrorKind::NonExistentCpus { .. })
             | GlommioError::BuilderError(BuilderErrorKind::InsufficientCpus { .. })
             | GlommioError::BuilderError(BuilderErrorKind::NrShards { .. })
-            | GlommioError::BuilderError(BuilderErrorKind::ThreadPanic(_)) => io::Error::new(
-                io::ErrorKind::Other,
-                format!("Executor builder error: {display_err}"),
-            ),
+            | GlommioError::BuilderError(BuilderErrorKind::ThreadPanic(_)) => {
+                io::Error::other(format!("Executor builder error: {display_err}"))
+            }
             GlommioError::EnhancedIoError { source, .. } => {
                 io::Error::new(source.kind(), display_err)
             }
@@ -521,7 +520,7 @@ impl<T> From<GlommioError<T>> for io::Error {
                     format!("IncorrectSourceType {x:?}"),
                 ),
                 ReactorErrorKind::MemLockLimit(a, b) => {
-                    io::Error::new(io::ErrorKind::Other, format!("MemLockLimit({a:?}/{b:?})"))
+                    io::Error::other(format!("MemLockLimit({a:?}/{b:?})"))
                 }
             },
             GlommioError::TimedOut(dur) => {
@@ -647,8 +646,7 @@ mod test {
 
     #[test]
     fn composite_error_from_into() {
-        let err: GlommioError<()> =
-            io::Error::new(io::ErrorKind::Other, "test other io-error").into();
+        let err: GlommioError<()> = io::Error::other("test other io-error").into();
         let _: io::Error = err.into();
 
         let err: GlommioError<()> =

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -177,7 +177,7 @@ impl Ord for TaskQueue {
 
 impl PartialOrd for TaskQueue {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(other.vruntime.cmp(&self.vruntime))
+        Some(self.cmp(other))
     }
 }
 

--- a/glommio/src/executor/mod.rs
+++ b/glommio/src/executor/mod.rs
@@ -1025,7 +1025,7 @@ impl LocalExecutorPoolBuilder {
                 } else {
                     // this `Err` isn't visible to the user; the pool builder directly returns an
                     // `Err` from the `std::thread::Builder`
-                    Err(io::Error::new(io::ErrorKind::Other, "spawn failed").into())
+                    Err(io::Error::other("spawn failed").into())
                 }
             }
         });

--- a/glommio/src/executor/placement/pq_tree.rs
+++ b/glommio/src/executor/placement/pq_tree.rs
@@ -78,9 +78,9 @@ where
     fn priority_pack(&self, other: &Self) -> Ordering {
         // if a node is partially saturated (i.e. currently being filled by the packing
         // iterator), then it takes priority
-        if self.nr_slots_selected % self.nr_slots != 0 {
+        if !self.nr_slots_selected.is_multiple_of(self.nr_slots) {
             Ordering::Greater
-        } else if other.nr_slots_selected % other.nr_slots != 0 {
+        } else if !other.nr_slots_selected.is_multiple_of(other.nr_slots) {
             Ordering::Less
         } else {
             // if the node is not partially saturated, then it is either equally saturated

--- a/glommio/src/free_list.rs
+++ b/glommio/src/free_list.rs
@@ -72,7 +72,7 @@ impl<T> FreeList<T> {
     }
     pub(crate) fn dealloc(&mut self, idx: Idx<T>) -> T {
         let slot = Slot::Free {
-            next_free: mem::replace(&mut self.first_free, Some(idx)),
+            next_free: Option::replace(&mut self.first_free, idx),
         };
         match mem::replace(&mut self.slots[idx.to_raw()], slot) {
             Slot::Full { item } => item,

--- a/glommio/src/io/bulk_io.rs
+++ b/glommio/src/io/bulk_io.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 /// Set a limit to the size of merged IO requests.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum MergedBufferLimit {
     /// Disables request coalescing
     NoMerging,
@@ -21,6 +21,7 @@ pub enum MergedBufferLimit {
     /// Sets the limit to the maximum the kernel allows for the underlying
     /// device without breaking down the request into smaller ones
     /// (/sys/block/.../queue/max_sectors_kb)
+    #[default]
     DeviceMaxSingleRequest,
 
     /// Sets a custom limit.
@@ -29,15 +30,9 @@ pub enum MergedBufferLimit {
     Custom(usize),
 }
 
-impl Default for MergedBufferLimit {
-    fn default() -> Self {
-        Self::DeviceMaxSingleRequest
-    }
-}
-
 /// Set a limit to the amount of read amplification in-between two mergeable IO
 /// requests.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum ReadAmplificationLimit {
     /// Deny read amplification.
     ///
@@ -46,6 +41,7 @@ pub enum ReadAmplificationLimit {
     /// size. For instance, if the minimum IO size is 4KiB and the user reads
     /// [0..256] and [2048..2560] then the two will be merged into [0..4096] to
     /// accommodate the 4KiB minimum IO size.
+    #[default]
     NoAmplification,
 
     /// Merge two consecutive IO requests if the read amplification is below a
@@ -57,12 +53,6 @@ pub enum ReadAmplificationLimit {
     /// Always merge successive IO requests if possible, no matter the distance
     /// between them. This is likely not what you want.
     NoLimit,
-}
-
-impl Default for ReadAmplificationLimit {
-    fn default() -> Self {
-        Self::NoAmplification
-    }
 }
 
 /// An interface to an IO vector.

--- a/glommio/src/io/directory.rs
+++ b/glommio/src/io/directory.rs
@@ -118,7 +118,6 @@ impl Directory {
     pub fn sync_read_dir(&self) -> Result<std::fs::ReadDir> {
         let path = self.file.path_required("read directory")?;
         enhanced_try!(std::fs::read_dir(&*path), "Reading a directory", self.file)
-            .map_err(Into::into)
     }
 
     /// Issues fdatasync into the underlying file.

--- a/glommio/src/io/dma_file.rs
+++ b/glommio/src/io/dma_file.rs
@@ -21,7 +21,10 @@ use nix::sys::statfs::*;
 use std::{
     cell::Ref,
     io,
-    os::unix::io::{AsRawFd, RawFd},
+    os::{
+        fd::BorrowedFd,
+        unix::io::{AsFd, AsRawFd, RawFd},
+    },
     path::Path,
     rc::Rc,
     sync::{Arc, Weak as AWeak},
@@ -60,8 +63,8 @@ pub struct AdvisoryLockGuard(Option<Arc<OwnedGlommioFile>>);
 
 impl Drop for AdvisoryLockGuard {
     fn drop(&mut self) {
-        if let Some(mut locked) = self.0.take().and_then(Arc::into_inner) {
-            unsafe { locked.funlock_immediately() }
+        if let Some(locked) = self.0.take().and_then(Arc::into_inner) {
+            locked.funlock_immediately().expect("Cannopt unlock fd")
         }
     }
 }
@@ -159,6 +162,12 @@ impl AsRawFd for DmaFile {
     }
 }
 
+impl AsFd for DmaFile {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.file.as_fd()
+    }
+}
+
 impl DmaFile {
     /// Returns true if the DmaFiles represent the same file on the underlying
     /// device.
@@ -247,7 +256,7 @@ impl DmaFile {
             | (opts.custom_flags as libc::c_int & !libc::O_ACCMODE);
 
         let res = DmaFile::open_at(dir, path, flags, opts.mode).await;
-        Ok(enhanced_try!(res, opdesc, Some(path), None)?)
+        Ok(enhanced_try!(res, opdesc, Some(path.to_path_buf()), None)?)
     }
 
     pub(super) fn attach_scheduler(&self) {
@@ -382,7 +391,7 @@ impl DmaFile {
             pos,
             self.pollable,
         );
-        enhanced_try!(source.collect_rw().await, "Writing", self.file).map_err(Into::into)
+        enhanced_try!(source.collect_rw().await, "Writing", self.file)
     }
 
     /// Equivalent to [`DmaFile::write_at`] except that the caller retains
@@ -442,7 +451,7 @@ impl DmaFile {
             pos,
             self.pollable,
         );
-        enhanced_try!(source.collect_rw().await, "Writing", self.file).map_err(Into::into)
+        enhanced_try!(source.collect_rw().await, "Writing", self.file)
     }
 
     /// Reads from a specific position in the file and returns the buffer.
@@ -771,7 +780,7 @@ impl DmaFile {
     /// NOTE: Clones are allowed to exist on any thread and all share the same underlying
     /// fd safely. try_take_last_clone is also safe to invoke from any thread and will
     /// behave correctly with respect to clones on other threads.
-    pub fn try_take_last_clone(mut self) -> std::result::Result<Self, Self> {
+    pub fn try_take_last_clone(mut self) -> std::result::Result<Self, Box<Self>> {
         match self.file.try_take_last_clone() {
             Ok(took) => {
                 self.file = took;
@@ -779,7 +788,7 @@ impl DmaFile {
             }
             Err(still_cloned) => {
                 self.file = still_cloned;
-                Err(self)
+                Err(Box::new(self))
             }
         }
     }
@@ -955,8 +964,6 @@ impl DmaFile {
 ///     .join()
 ///     .unwrap();
 ///
-///     assert_eq!(nix::fcntl::fcntl(original_fd, nix::fcntl::FcntlArg::F_GETFD), Err(nix::errno::Errno::EBADF));
-///
 ///     let file: DmaFile = result.into();
 ///     assert_ne!(file.as_raw_fd(), original_fd);
 ///     assert_eq!(file.inode(), original_inode);
@@ -995,7 +1002,7 @@ impl OwnedDmaFile {
             file: enhanced_try!(
                 self.file.dup(),
                 "Duplicating",
-                self.file.path.as_ref(),
+                self.file.path.clone(),
                 self.file.fd.as_ref().map(|fd| fd.as_raw_fd())
             )?,
             o_direct_alignment: self.o_direct_alignment,

--- a/glommio/src/io/sched.rs
+++ b/glommio/src/io/sched.rs
@@ -71,7 +71,7 @@ struct FileSchedulerInner {
     sources: RefCell<RBTree<ScheduledSourceAdapter>>,
 }
 
-intrusive_adapter!(FileSchedulerAdapter = Rc<FileSchedulerInner>: FileSchedulerInner { link: RBTreeLink });
+intrusive_adapter!(FileSchedulerAdapter = Rc<FileSchedulerInner>: FileSchedulerInner { link => RBTreeLink });
 impl<'a> KeyAdapter<'a> for FileSchedulerAdapter {
     type Key = Identity;
     fn get_key(&self, s: &'a FileSchedulerInner) -> Self::Key {
@@ -177,7 +177,7 @@ struct ScheduledSourceInner {
     data_range: Range<u64>,
 }
 
-intrusive_adapter!(ScheduledSourceAdapter = Rc<ScheduledSourceInner>: ScheduledSourceInner { link: RBTreeLink });
+intrusive_adapter!(ScheduledSourceAdapter = Rc<ScheduledSourceInner>: ScheduledSourceInner { link => RBTreeLink });
 impl<'a> KeyAdapter<'a> for ScheduledSourceAdapter {
     type Key = u64;
     fn get_key(&self, s: &'a ScheduledSourceInner) -> Self::Key {

--- a/glommio/src/iou/probe.rs
+++ b/glommio/src/iou/probe.rs
@@ -34,6 +34,6 @@ impl Probe {
 
 impl Drop for Probe {
     fn drop(&mut self) {
-        unsafe { libc::free(self.probe.as_ptr() as *mut _) }
+        unsafe { uring_sys::io_uring_free_probe(self.probe.as_ptr()) }
     }
 }

--- a/glommio/src/iou/sqe.rs
+++ b/glommio/src/iou/sqe.rs
@@ -349,7 +349,7 @@ impl<'a> SQE<'a> {
 
     #[inline]
     pub unsafe fn prep_poll_remove(&mut self, user_data: u64) {
-        uring_sys::io_uring_prep_poll_remove(self.sqe, user_data as _)
+        uring_sys::io_uring_prep_poll_remove(self.sqe, user_data)
     }
 
     #[inline]

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -26,7 +26,10 @@ use std::{
     cell::RefCell,
     io,
     net::{self, Shutdown, SocketAddr, ToSocketAddrs},
-    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    os::{
+        fd::AsFd,
+        unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    },
     pin::Pin,
     rc::{Rc, Weak},
     task::{Context, Poll},
@@ -189,8 +192,8 @@ impl TcpListener {
             Some(source) => poll_source(source),
             None => {
                 let reactor = self.reactor.upgrade().unwrap();
-                let raw_fd = self.listener.as_raw_fd();
-                match yolo_accept(raw_fd) {
+                let fd = self.listener.as_fd();
+                match yolo_accept(fd) {
                     Some(r) => match r {
                         Ok(fd) => Poll::Ready(Ok(AcceptedTcpStream { fd })),
                         Err(err) => Poll::Ready(Err(GlommioError::IoError(err))),

--- a/glommio/src/net/tcp_socket.rs
+++ b/glommio/src/net/tcp_socket.rs
@@ -123,7 +123,7 @@ impl TcpListener {
             .to_socket_addrs()
             .unwrap()
             .next()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "empty address"))?;
+            .ok_or_else(|| io::Error::other("empty address"))?;
 
         let domain = if addr.is_ipv6() {
             Domain::IPV6

--- a/glommio/src/net/udp_socket.rs
+++ b/glommio/src/net/udp_socket.rs
@@ -84,7 +84,7 @@ impl UdpSocket {
             .to_socket_addrs()
             .unwrap()
             .next()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "empty address"))?;
+            .ok_or_else(|| io::Error::other("empty address"))?;
 
         let domain = if addr.is_ipv6() {
             Domain::IPV6
@@ -136,7 +136,7 @@ impl UdpSocket {
     /// [`recv`]: UdpSocket::recv
     pub async fn connect<A: ToSocketAddrs>(&self, addr: A) -> Result<()> {
         let iter = addr.to_socket_addrs()?;
-        let mut err = io::Error::new(io::ErrorKind::Other, "No Valid addresses");
+        let mut err = io::Error::other("No Valid addresses");
         for addr in iter {
             let reactor = self.socket.reactor.upgrade().unwrap();
             let source = reactor.connect(self.socket.as_raw_fd(), SockaddrStorage::from(addr));
@@ -628,7 +628,7 @@ impl UdpSocket {
             .to_socket_addrs()
             .unwrap()
             .next()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "empty address"))?;
+            .ok_or_else(|| io::Error::other("empty address"))?;
 
         let sockaddr = SockaddrStorage::from(addr);
         self.socket.send_to(buf, sockaddr).await.map_err(Into::into)

--- a/glommio/src/net/udp_socket.rs
+++ b/glommio/src/net/udp_socket.rs
@@ -46,7 +46,7 @@ fn sockaddr_storage_to_std(addr: SockaddrStorage) -> Option<SocketAddr> {
     match addr.family() {
         Some(nix::sys::socket::AddressFamily::Inet) => addr
             .as_sockaddr_in()
-            .map(|x| SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::from(x.ip()), x.port()))),
+            .map(|x| SocketAddr::V4(SocketAddrV4::new(x.ip(), x.port()))),
         Some(nix::sys::socket::AddressFamily::Inet6) => addr.as_sockaddr_in6().map(|x| {
             SocketAddr::V6(SocketAddrV6::new(
                 x.ip(),

--- a/glommio/src/net/unix.rs
+++ b/glommio/src/net/unix.rs
@@ -329,8 +329,7 @@ impl UnixStream {
         let reactor = crate::executor().reactor();
 
         let socket = Socket::new(Domain::UNIX, Type::STREAM, None)?;
-        let addr =
-            UnixAddr::new(addr.as_ref()).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let addr = UnixAddr::new(addr.as_ref()).map_err(io::Error::other)?;
         let source = reactor.connect(socket.as_raw_fd(), addr);
         source.collect_rw().await?;
 
@@ -536,8 +535,7 @@ impl UnixDatagram {
     /// [`send`]: UnixDatagram::send
     /// [`recv`]: UnixDatagram::recv
     pub async fn connect<A: AsRef<Path>>(&self, addr: A) -> Result<()> {
-        let addr =
-            UnixAddr::new(addr.as_ref()).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let addr = UnixAddr::new(addr.as_ref()).map_err(io::Error::other)?;
 
         let reactor = self.socket.reactor.upgrade().unwrap();
         let source = reactor.connect(self.socket.as_raw_fd(), addr);
@@ -684,8 +682,7 @@ impl UnixDatagram {
     /// })
     /// ```
     pub async fn send_to<A: AsRef<Path>>(&self, buf: &[u8], addr: A) -> Result<usize> {
-        let addr = nix::sys::socket::UnixAddr::new(addr.as_ref())
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let addr = nix::sys::socket::UnixAddr::new(addr.as_ref()).map_err(io::Error::other)?;
         self.socket.send_to(buf, addr).await.map_err(Into::into)
     }
 

--- a/glommio/src/reactor.rs
+++ b/glommio/src/reactor.rs
@@ -24,7 +24,6 @@ use std::{
 };
 
 use ahash::AHashMap;
-use log::error;
 use nix::sys::socket::{MsgFlags, SockaddrLike, SockaddrStorage};
 use smallvec::SmallVec;
 
@@ -32,7 +31,7 @@ use crate::{
     io::{FileScheduler, IoScheduler, ScheduledSource},
     iou::sqe::SockAddrStorage,
     sys::{
-        self, blocking::BlockingThreadPool, common_flags, read_flags, sysfs, DirectIo, DmaBuffer,
+        self, blocking::BlockingThreadPool, common_flags, read_flags, DirectIo, DmaBuffer,
         DmaSource, IoBuffer, PollableStatus, SleepNotifier, Source, SourceType, StatsCollection,
         Statx,
     },
@@ -234,52 +233,6 @@ impl Reactor {
 
     pub(crate) fn inform_io_requirements(&self, req: IoRequirements) {
         self.io_scheduler.inform_requirements(req);
-    }
-
-    pub(crate) async fn probe_iopoll_support(
-        &self,
-        raw: RawFd,
-        alignment: u64,
-        major: usize,
-        minor: usize,
-        path: &Path,
-    ) -> bool {
-        match sysfs::BlockDevice::iopoll(major, minor) {
-            None => {
-                // This routine exercises the iopoll code path in the kernel and asserts that we
-                // can successfully read something. If we can't and receive `ENOTSUP` then
-                // the kernel doesn't support iopoll for this device.
-                //
-                // In a perfect world, we would issue a read of size 0 because we are not
-                // interested in any data, just to check whether we _could_. Unfortunately it
-                // seems we are not allowed to have nice things, and the kernel can
-                // short-circuit its internal logic and return an early
-                // "success" for reads of size 0. We are therefore forced to do
-                // an actual read.
-
-                let source =
-                    self.new_source(raw, SourceType::Read(PollableStatus::Pollable, None), None);
-                self.sys.read_dma(&source, 0, alignment as usize);
-                let iopoll = if let Err(err) = source.collect_rw().await {
-                    if let Some(libc::ENOTSUP) = err.raw_os_error() {
-                        false
-                    } else {
-                        // The IO requests failed, but not because the poll ring doesn't work.
-                        error!(
-                            "got unexpected error when probing iopoll support for file {path:?} \
-                             (fd: {raw}) hosted on ({major}, {minor}); the poll ring will be \
-                             disabled for this device: {err}"
-                        );
-                        false
-                    }
-                } else {
-                    true
-                };
-                sysfs::BlockDevice::set_iopoll_support(major, minor, iopoll);
-                iopoll
-            }
-            Some(iopoll) => iopoll,
-        }
     }
 
     pub(crate) fn register_shared_channel<F>(&self, test_function: Box<F>) -> u64

--- a/glommio/src/sys/hardware_topology.rs
+++ b/glommio/src/sys/hardware_topology.rs
@@ -7,7 +7,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    io::{self, ErrorKind},
+    io::{self},
     path::Path,
 };
 
@@ -39,7 +39,7 @@ fn build_cpu_location(
 
     let package_id = ListIterator::from_path(&cpu_path.join("physical_package_id"))?
         .next()
-        .ok_or_else(|| io::Error::new(ErrorKind::Other, "failed to parse physical_package_id"))??;
+        .ok_or_else(|| io::Error::other("failed to parse physical_package_id"))??;
 
     Ok(CpuLocation {
         cpu,
@@ -146,7 +146,7 @@ fn get_core_id(
             let core = ListIterator::from_path(&cpu_path.join("core_id"))?
                 .next()
                 .transpose()?
-                .ok_or_else(|| io::Error::new(ErrorKind::Other, "failed to parse core_id"))?;
+                .ok_or_else(|| io::Error::other("failed to parse core_id"))?;
             for sibling in cpu_siblings {
                 cpu_to_core.insert(sibling?, core);
             }

--- a/glommio/src/sys/membarrier.rs
+++ b/glommio/src/sys/membarrier.rs
@@ -160,7 +160,7 @@ mod mprotect {
                     0 as libc::off_t,
                 );
                 fatal_assert!(page != libc::MAP_FAILED);
-                fatal_assert!(page as libc::size_t % page_size == 0);
+                fatal_assert!((page as libc::size_t).is_multiple_of(page_size));
 
                 // Locking the page ensures that it stays in memory during the two mprotect
                 // calls in `Barrier::barrier()`. If the page was unmapped between those calls,

--- a/glommio/src/sys/uring.rs
+++ b/glommio/src/sys/uring.rs
@@ -886,9 +886,8 @@ impl UringCommon for PollRing {
             },
             source_map,
         )
-        .map(|x| {
+        .inspect(|_| {
             self.in_kernel -= 1;
-            x
         })
     }
 
@@ -1199,9 +1198,8 @@ impl UringCommon for SleepableRing {
             },
             source_map,
         )
-        .map(|x| {
+        .inspect(|_| {
             self.in_kernel -= 1;
-            x
         })
     }
 

--- a/glommio/src/uring_sys/mod.rs
+++ b/glommio/src/uring_sys/mod.rs
@@ -350,8 +350,6 @@ extern "C" {
 
     pub fn io_uring_submit_and_wait(ring: *mut io_uring, wait_nr: libc::c_uint) -> libc::c_int;
 
-    pub fn io_uring_get_sqe(ring: *mut io_uring) -> *mut io_uring_sqe;
-
     pub fn io_uring_register_buffers(
         ring: *mut io_uring,
         iovecs: *const libc::iovec,
@@ -495,7 +493,7 @@ extern "C" {
     );
 
     #[link_name = "rust_io_uring_prep_poll_remove"]
-    pub fn io_uring_prep_poll_remove(sqe: *mut io_uring_sqe, user_data: *mut libc::c_void);
+    pub fn io_uring_prep_poll_remove(sqe: *mut io_uring_sqe, user_data: libc::__u64);
 
     #[link_name = "rust_io_uring_prep_fsync"]
     pub fn io_uring_prep_fsync(sqe: *mut io_uring_sqe, fd: libc::c_int, fsync_flags: libc::c_uint);
@@ -698,4 +696,7 @@ extern "C" {
 
     #[link_name = "rust_io_uring_wait_cqe"]
     pub fn io_uring_wait_cqe(ring: *mut io_uring, cqe_ptr: *mut *mut io_uring_cqe) -> libc::c_int;
+
+    #[link_name = "rust_io_uring_get_sqe"]
+    pub fn io_uring_get_sqe(ring: *mut io_uring) -> *mut io_uring_sqe;
 }


### PR DESCRIPTION
### What does this PR do?

- Bumps MSRV to 1.92
  - Applies compiler-suggested std API updates and style cleanups.
  - Modernises internals for newer dependency versions
    - Moves file descriptor handling to OwnedFd/BorrowedFd where appropriate for clearer ownership and safer close semantics.
- Updates crate dependencies across the workspace, including updating the liburing submodule to 2.13.
- Updates sysfs probing logic:
  - Stops assuming `minor == 0` identifies the parent block device; this is incorrect for partitions and NVMe devices where valid block devices frequently have non-zero minors
  - Adds partition-safe queue discovery (walk-up to find a queue/directory).
  - Makes queue/io_poll optional (if files are missing - assume unsupported) to handle older kernels/drivers and avoid hard failures when sysfs files are absent.
  - Simplifies cached block property access and removes the “probe iopoll by performing an I/O” path from the reactor.
  - Fixes CI failures on partition-backed and virtual block devices where `queue/*` files are missing or located on the parent disk.
- spsc_queue changes:
  - Eliminate manual allocation and raw pointer arithmetic for buffer, replacing it with an owned slice.
  - Cleans up lookahead/limit handling and switches head/tail progression to wrapping arithmetic to ensure correctness across wrap boundaries.
  - The underlying queue algorithm remains unchanged; this is a safety and maintainability improvement rather than a semantic change.
- Cleans up examples and benchmarks:
  - Removes unused hyper timer glue that was generating warnings.
  - Updates the SPSC benchmark to pin producer/consumer threads to CPUs and prints clearer latency/throughput numbers.

### Motivation

This is a maintenance PR to keep Glommio building cleanly on modern toolchains and dependency versions, and to unblock CI failures.

Keeping the crate aligned with recent stable Rust:
- Reduces friction for contributors using current toolchains
- Prevents accumulating breakage from upstream ecosystem changes
- Lowers the long-term maintenance cost for future feature work

### Notes on behaviour changes

- Poll-ring eligibility is now determined by sysfs capability values (e.g. `queue/io_poll`) combined with conservative device gating, rather than probing support via a test DMA read.
  - This avoids partially-working states where a device appears pollable until the first I/O fails.
  - This may relate to #605 (devices appearing “pollable” until the first read routes via the poll ring and fail).
- Sysfs reads are now more defensive:
  - Missing files fall back to safe defaults instead of panicking.
  - This ensures Glommio continues to work on older kernels, non-NVMe devices, and CI environments.

### Related issues

No related issues - standalone MR.

### Additional Notes

- No public API changes.
- Functional behavior is unchanged for NVMe devices with full sysfs support.
- Behaviour on non-NVMe, virtual, or partition-backed devices avoids runtime and CI failures.
- The examples workspace is now edition = "2024" to align with the updated toolchain and formatting expectations.
- The SPSC benchmark output is intended for easier interpretation in CI/local perf runs and is not a functional API change.
  - The new bench also supports comparing different core pairings; on SMT systems, this can highlight differences between sibling vs non-sibling cores.

### Checklist

- [] I have added unit tests to the code I am submitting
- [] My unit tests cover both failure and success scenarios
- [] If applicable, I have discussed my architecture