### PR TITLE
chore: remove unused dependencies from Cargo.toml

### DIFF
--- a/glommio/Cargo.toml
+++ b/glommio/Cargo.toml
@@ -21,9 +21,7 @@ rust-version = "1.70"
 ahash = "0.7"
 backtrace = { version = "0.3" }
 bitflags = "2.4"
-bitmaps = "3.1"
 buddy-alloc = "0.4"
-concurrent-queue = "1.2"
 crossbeam = "0.8"
 enclose = "1.1"
 flume = { version = "0.11", features = ["async"] }
@@ -31,7 +29,6 @@ futures-lite = "2.6.0"
 intrusive-collections = "0.9"
 lazy_static = "1.4"
 libc = "0.2"
-lockfree = "0.5"
 log = "0.4"
 nix = { version = "0.27", features = ["event", "fs", "ioctl", "mman", "net", "poll", "sched", "time"] }
 pin-project-lite = "0.2"
@@ -43,7 +40,6 @@ sketches-ddsketch = "0.1"
 smallvec = { version = "1.7", features = ["union"] }
 socket2 = { version = "0.4", features = ["all"] }
 tracing = "0.1"
-typenum = "1.15"
 
 [dev-dependencies]
 fastrand = "2"


### PR DESCRIPTION
### What does this PR do?

Removed 'bitmaps', 'concurrent-queue', 'lockfree', and 'typenum' dependencies from Cargo.toml.

### Motivation

Found it manually when going through Cargo.toml, confirmed by `cargo shear`

### Related issues

-

### Additional Notes

-

### Checklist

- [ ] I have added unit tests to the code I am submitting
- [ ] My unit tests cover both failure and success scenarios
- [ ] If applicable, I have discussed my architecture
